### PR TITLE
Fix use of delvewheel with a namespace package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ environment = "MACOSX_DEPLOYMENT_TARGET=10.13"
 
 [tool.cibuildwheel.windows]
 archs = "AMD64"
-before-build = "pip install delvewheel"
-repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
+before-build = "pip install delvewheel>=1.4.0"
+repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel} --namespace-pkg dwave"
 
 [tool.coverage.run]
 source = ["dwave/optimization"]


### PR DESCRIPTION
See https://github.com/dwavesystems/dwave-preprocessing/pull/131, https://github.com/adang1345/delvewheel/issues/38.

Should fix the errors in https://github.com/dwavesystems/dwave-system/pull/518 once it's deployed.