### PR TITLE
Add sdk_index file

### DIFF
--- a/docs/sdk_index.rst
+++ b/docs/sdk_index.rst
@@ -1,12 +1,12 @@
 .. _sdk_index_optimization:
 
+==================
+dwave-optimization
+==================
+
 .. include:: README.rst
    :start-after: index-start-marker1
    :end-before: index-end-marker1
-
-.. include:: README.rst
-   :start-after: index-start-marker2
-   :end-before: index-end-marker2
 
 .. include:: index.rst
    :start-after: sdk-start-marker

--- a/docs/sdk_index.rst
+++ b/docs/sdk_index.rst
@@ -1,0 +1,19 @@
+.. _sdk_index_optimization:
+
+.. include:: README.rst
+   :start-after: index-start-marker1
+   :end-before: index-end-marker1
+
+.. include:: README.rst
+   :start-after: index-start-marker2
+   :end-before: index-end-marker2
+
+.. include:: index.rst
+   :start-after: sdk-start-marker
+   :end-before: sdk-end-marker
+
+.. toctree::
+   :caption: Code
+   :maxdepth: 1
+
+   Source <https://github.com/dwavesystems/dwave-optimization>


### PR DESCRIPTION
Using the index directly in the SDK doesn't look so good (`dwave-samplers` does that but it pulls a lot from the README):
![image](https://github.com/dwavesystems/dwave-optimization/assets/34041130/b04aba38-4c36-4787-b4f8-90c7837491c7)
