### PR TITLE
Fix `DisjointBitSetsNode` state copying

### DIFF
--- a/dwave/optimization/src/nodes/collections.cpp
+++ b/dwave/optimization/src/nodes/collections.cpp
@@ -290,6 +290,10 @@ struct DisjointBitSetsNodeData : NodeStateData {
         }
     }
 
+    std::unique_ptr<NodeStateData> copy() const override {
+        return std::make_unique<DisjointBitSetsNodeData>(*this);
+    }
+
     void revert() {
         for (ssize_t set_index = 0; set_index < num_disjoint_sets; ++set_index) {
             for (const auto& update : diffs[set_index] | std::views::reverse) {

--- a/releasenotes/notes/fix-disjointbitset-state-copy-0f1760e77330ba6d.yaml
+++ b/releasenotes/notes/fix-disjointbitset-state-copy-0f1760e77330ba6d.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Add missing ``copy()`` override for C++ ``DisjointBitSetsNode`` states.

--- a/tests/cpp/tests/test_nodes_collections.cpp
+++ b/tests/cpp/tests/test_nodes_collections.cpp
@@ -69,6 +69,24 @@ TEST_CASE("DisjointBitSetsNode") {
                     CHECK(std::ranges::equal(bit_set, std::vector{1, 1, 1, 1, 1}));
                 }
 
+                AND_WHEN("We copy the state") {
+                    state[ptr->topological_index()] = state[ptr->topological_index()]->copy();
+
+                    THEN("The output nodes contain the whole set") {
+                        std::vector<int> bit_set(5, 0);
+
+                        for (auto const& set : sets) {
+                            REQUIRE(set->size(state) == 5);
+                            for (ssize_t i = 0; i < set->size(state); ++i) {
+                                REQUIRE((set->view(state)[i] == 0 || set->view(state)[i] == 1));
+                                bit_set[i] += set->view(state)[i];
+                            }
+                        }
+
+                        CHECK(std::ranges::equal(bit_set, std::vector{1, 1, 1, 1, 1}));
+                    }
+                }
+
                 AND_WHEN("We then mutate the node and propagate") {
                     ptr->swap_between_sets(state, 0, 1, 2);    // {0 1 3 4} {2} {}
                     ptr->swap_between_sets(state, 0, 2, 4);    // {0 1 3} {2} {4}


### PR DESCRIPTION
I'll think about ways to enforce that all decision nodes have copyable states in the future. But for now let's fix the current one.