### PR TITLE
Refactor node discovery

### DIFF
--- a/dwave/optimization/__init__.py
+++ b/dwave/optimization/__init__.py
@@ -14,7 +14,7 @@
 
 import dwave.optimization.generators
 
-from dwave.optimization.model import Model, _register_node_subclasses
+from dwave.optimization.model import Model
 from dwave.optimization.mathematical import *
 
 __version__ = "0.1.0"
@@ -41,7 +41,3 @@ def get_library():
     if platform.system() == "Windows":
         raise RuntimeError("dwave-optimization does not distribute a library on Windows")
     return "dwave-optimization"
-
-
-_register_node_subclasses()
-del _register_node_subclasses

--- a/dwave/optimization/model.pxd
+++ b/dwave/optimization/model.pxd
@@ -88,6 +88,9 @@ cdef class Symbol:
     # Exactly deref(self.expired_ptr)
     cpdef bool expired(self) noexcept
 
+    @staticmethod
+    cdef Symbol from_ptr(Model model, cppNode* ptr)
+
     # Hold on to a reference to the Model, both for access but also, importantly,
     # to ensure that the model doesn't get garbage collected unless all of
     # the observers have also been garbage collected.

--- a/dwave/optimization/model.pyx
+++ b/dwave/optimization/model.pyx
@@ -1212,6 +1212,27 @@ cdef class Symbol:
     cpdef bool expired(self) noexcept:
         return deref(self.expired_ptr)
 
+    @staticmethod
+    cdef Symbol from_ptr(Model model, cppNode* ptr):
+        """Construct a Symbol from a C++ Node pointer.
+
+        There are times when a Node* needs to be passed through the Python layer
+        and this method provides a mechanism to do so.
+        """
+        if not ptr:
+            raise ValueError("cannot construct a Symbol from a nullptr")
+        if model is None:
+            raise ValueError("model cannot be None")
+
+        cdef Symbol obj = Symbol.__new__(Symbol)
+        obj.initialize_node(model, ptr)
+        return obj
+
+    @staticmethod
+    def _from_symbol(Symbol symbol):
+        # Symbols must overload this method
+        raise ValueError("Symbols cannot be constructed directly")
+
     @classmethod
     def _from_zipfile(cls, zf, directory, Model model, predecessors):
         """Construct a node from a compressed file.

--- a/releasenotes/notes/refactor-node-discovery-f468e7dc54fcfbdc.yaml
+++ b/releasenotes/notes/refactor-node-discovery-f468e7dc54fcfbdc.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - Speed up ``Model.iter_symbols()`` and other symbol iteration methods.
+upgrade:
+  - Remove ``.from_ptr()`` ``cdef`` method from all of the symbol classes.


### PR DESCRIPTION
Change the way that the library creates nodes from either raw pointers or their names.

The main change is removing the enormous `if`/`else` statement in `symbol_from_ptr()` and replace it with an approach that uses [typeid()](https://en.cppreference.com/w/cpp/language/typeid). This makes `symbol_from_ptr()` take ~66% less time in benchmarks on my system. It's also less of a maintenance nightmare.

The cost however is that now each node must be registered, with a new private `_register()` function. I'd like to automate that with something like [__init_subclass__](https://docs.python.org/3/reference/datamodel.html#object.__init_subclass__), but as far as I can tell, Cython doesn't have any mechanism that gets called when a class is defined. Or any support for metaclasses etc.