### PR TITLE
Flatten generator docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,10 @@ import dwave.optimization
 
 """
 
+autodoc_type_aliases = {
+    'numpy.typing.ArrayLike': 'numpy.typing.ArrayLike',
+}
+
 # -- Options for HTML output ----------------------------------------------
 
 html_theme = "pydata_sphinx_theme"
@@ -102,8 +106,9 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
                        'numpy': ('https://numpy.org/doc/stable/', None),
                        'networkx': ('https://networkx.org/documentation/stable/', None),
                        'oceandocs': ('https://docs.ocean.dwavesys.com/en/stable/', None),
-                       'sysdocs_gettingstarted': ('https://docs.dwavesys.com/docs/latest/', None)}
-                       
+                       'sysdocs_gettingstarted': ('https://docs.dwavesys.com/docs/latest/', None),
+                       }
+
 rst_epilog = """
 .. |array-like| replace:: array-like
 .. _array-like: https://numpy.org/devdocs/glossary.html#term-array_like

--- a/docs/reference/generators.rst
+++ b/docs/reference/generators.rst
@@ -4,17 +4,5 @@
 Model Generators
 ================
 
-.. currentmodule:: dwave.optimization.generators
-
 .. automodule:: dwave.optimization.generators
-
-.. autosummary::
-   :toctree: generated/
-
-   capacitated_vehicle_routing
-   job_shop_scheduling
-   flow_shop_scheduling
-   knapsack
-   quadratic_assignment
-   traveling_salesperson
-
+    :members:

--- a/dwave/optimization/generators.py
+++ b/dwave/optimization/generators.py
@@ -12,6 +12,10 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+"""Model generators for optimization problems."""
+
+from __future__ import annotations
+
 import typing
 
 import numpy as np
@@ -25,6 +29,7 @@ __all__ = [
     "flow_shop_scheduling",
     "job_shop_scheduling",
     "knapsack",
+    "quadratic_assignment",
     "traveling_salesperson",
     ]
 


### PR DESCRIPTION
The main benefit here is that new generators are automatically incorporated into the docs. For example, we were already missing `quadratic_assignment`.

The cons are slightly ugly formatting at the top level 
![image](https://github.com/user-attachments/assets/64d8d2c9-4cae-4c56-85e5-390cd1fce44c)

and no navigation within the page on the sidebar 
![image](https://github.com/user-attachments/assets/2cc04435-3a83-408f-8b70-18035d609e9e)

IMO the maintenance benefit is worth it. If we wanted a summary table at the top, there are sphinx plugins, e.g. https://github.com/Chilipp/autodocsumm.

Another change made is that by using `autodoc_type_aliases` we can significantly shrink the size and increase the readability of the signature. IMO we should make that change in the SDK.
