### PR TITLE
Implement `Logical` and `Not` symbols

### DIFF
--- a/docs/reference/math.rst
+++ b/docs/reference/math.rst
@@ -12,8 +12,10 @@ Mathematical Functions
    :toctree: generated/
 
    ~add
+   ~logical
    ~logical_and
    ~logical_or
+   ~logical_not
    ~maximum
    ~minimum
    ~multiply

--- a/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
@@ -31,6 +31,11 @@ struct abs {
 };
 
 template <class T>
+struct logical {
+    constexpr bool operator()(const T& x) const { return x; }
+};
+
+template <class T>
 struct max {
     constexpr T operator()(const T& x, const T& y) const { return std::max(x, y); }
 };
@@ -167,6 +172,9 @@ class UnaryOpNode : public ArrayOutputMixin<ArrayNode> {
 
     double const* buff(const State& state) const override;
     std::span<const Update> diff(const State& state) const override;
+    bool integral() const override;
+    double max() const override;
+    double min() const override;
 
     void commit(State& state) const override;
     void revert(State& state) const override;
@@ -183,7 +191,9 @@ class UnaryOpNode : public ArrayOutputMixin<ArrayNode> {
 };
 
 using AbsoluteNode = UnaryOpNode<functional::abs<double>>;
+using LogicalNode = UnaryOpNode<functional::logical<double>>;
 using NegativeNode = UnaryOpNode<std::negate<double>>;
+using NotNode = UnaryOpNode<std::logical_not<double>>;
 using SquareNode = UnaryOpNode<functional::square<double>>;
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/libcpp/nodes.pxd
+++ b/dwave/optimization/libcpp/nodes.pxd
@@ -99,6 +99,9 @@ cdef extern from "dwave-optimization/nodes/mathematical.hpp" namespace "dwave::o
     cdef cppclass LessEqualNode(ArrayNode):
         pass
 
+    cdef cppclass LogicalNode(ArrayNode):
+        pass
+
     cdef cppclass MaximumNode(ArrayNode):
         pass
 
@@ -127,6 +130,9 @@ cdef extern from "dwave-optimization/nodes/mathematical.hpp" namespace "dwave::o
         void add_node(ArrayNode*) except+
 
     cdef cppclass NegativeNode(ArrayNode):
+        pass
+
+    cdef cppclass NotNode(ArrayNode):
         pass
 
     cdef cppclass OrNode(ArrayNode):

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -155,6 +155,9 @@ def logical_and(x1: ArraySymbol, x2: ArraySymbol) -> And:
         ...     y.set_state(0, [False, True, False])
         ...     print(z.state(0))
         [0. 1. 0.]
+
+    See Also:
+        :class:`~dwave.optimization.symbols.And`: equivalent symbol.
     """
     return And(x1, x2)
 
@@ -213,6 +216,9 @@ def logical_or(x1: ArraySymbol, x2: ArraySymbol) -> Or:
         ...     y.set_state(0, [False, True, False])
         ...     print(z.state(0))
         [1. 1. 0.]
+
+    See Also:
+        :class:`~dwave.optimization.symbols.Or`: equivalent symbol.
     """
     return Or(x1, x2)
 

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -19,6 +19,7 @@ from dwave.optimization.model import ArraySymbol
 from dwave.optimization.symbols import (
     Add,
     And,
+    Logical,
     Maximum,
     Minimum,
     Multiply,
@@ -26,6 +27,7 @@ from dwave.optimization.symbols import (
     NaryMaximum,
     NaryMinimum,
     NaryMultiply,
+    Not,
     Or,
     Where,
 )
@@ -33,8 +35,10 @@ from dwave.optimization.symbols import (
 
 __all__ = [
     "add",
-    "logical_or",
+    "logical",
     "logical_and",
+    "logical_not",
+    "logical_or",
     "maximum",
     "minimum",
     "multiply",
@@ -97,6 +101,35 @@ def add(x1: ArraySymbol, x2: ArraySymbol, *xi: ArraySymbol) -> typing.Union[Add,
     raise RuntimeError("implementated by the op() decorator")
 
 
+def logical(x: ArraySymbol) -> Logical:
+    r"""Return the element-wise truth value on the given symbol.
+
+    Args:
+        x: Input array symbol.
+
+    Returns:
+        A symbol that propagates the element-wise truth value of the given symbol.
+
+    Examples:
+        This example shows the truth values an array symbol.
+
+        >>> from dwave.optimization import Model
+        >>> from dwave.optimization.mathematical import logical
+        ...
+        >>> model = Model()
+        >>> x = model.constant([0, 1, -2, .5])
+        >>> logical_x = logical(x)
+        >>> model.states.resize(1)
+        >>> with model.lock():
+        ...     print(logical_x.state())
+        [0. 1. 1. 1.]
+
+    See Also:
+        :class:`~dwave.optimization.symbols.Logical`: equivalent symbol.
+    """
+    return Logical(x)
+
+
 def logical_and(x1: ArraySymbol, x2: ArraySymbol) -> And:
     r"""Return an element-wise logical AND on the given symbols.
 
@@ -124,6 +157,35 @@ def logical_and(x1: ArraySymbol, x2: ArraySymbol) -> And:
         [0. 1. 0.]
     """
     return And(x1, x2)
+
+
+def logical_not(x: ArraySymbol) -> Not:
+    r"""Return an element-wise logical NOT on the given symbol.
+
+    Args:
+        x: Input array symbol.
+
+    Returns:
+        A symbol that propagates the element-wise NOT of the given symbol.
+
+    Examples:
+        This example negates an array symbol.
+
+        >>> from dwave.optimization import Model
+        >>> from dwave.optimization.mathematical import logical_not
+        ...
+        >>> model = Model()
+        >>> x = model.constant([0, 1, -2, .5])
+        >>> not_x = logical_not(x)
+        >>> model.states.resize(1)
+        >>> with model.lock():
+        ...     print(not_x.state())
+        [1. 0. 0. 0.]
+
+    See Also:
+        :class:`~dwave.optimization.symbols.Not`: equivalent symbol.
+    """
+    return Not(x)
 
 
 def logical_or(x1: ArraySymbol, x2: ArraySymbol) -> Or:

--- a/dwave/optimization/symbols.pyi
+++ b/dwave/optimization/symbols.pyi
@@ -100,6 +100,10 @@ class ListVariable(ArraySymbol):
     def set_state(self, index: int, state: numpy.typing.ArrayLike): ...
 
 
+class Logical(ArraySymbol):
+    ...
+
+
 class Max(ArraySymbol):
     ...
 
@@ -137,6 +141,10 @@ class NaryMultiply(ArraySymbol):
 
 
 class Negative(ArraySymbol):
+    ...
+
+
+class Not(ArraySymbol):
     ...
 
 

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -309,18 +309,8 @@ _register(All, typeid(cppAllNode))
 cdef class And(ArraySymbol):
     """Boolean AND element-wise between two symbols.
 
-    Examples:
-        This example creates an AND operation between binary arrays.
-
-        >>> from dwave.optimization.model import Model
-        >>> from dwave.optimization.mathematical import logical_and
-        ...
-        >>> model = Model()
-        >>> x = model.binary(200)
-        >>> y = model.binary(200)
-        >>> z = logical_and(x, y)
-        >>> type(z)
-        <class 'dwave.optimization.symbols.And'>
+    See Also:
+        :func:`~dwave.optimization.mathematical.logical_and`: equivalent function.
     """
     def __init__(self, ArraySymbol lhs, ArraySymbol rhs):
         if lhs.model is not rhs.model:
@@ -2198,18 +2188,8 @@ _register(Not, typeid(cppNotNode))
 cdef class Or(ArraySymbol):
     """Boolean OR element-wise between two symbols.
 
-    Examples:
-        This example creates an OR operation between binary arrays.
-
-        >>> from dwave.optimization.model import Model
-        >>> from dwave.optimization.mathematical import logical_or
-        ...
-        >>> model = Model()
-        >>> x = model.binary(200)
-        >>> y = model.binary(200)
-        >>> z = logical_or(x, y)
-        >>> type(z)
-        <class 'dwave.optimization.symbols.Or'>
+    See Also:
+        :func:`~dwave.optimization.mathematical.logical_or`: equivalent function.
     """
     def __init__(self, ArraySymbol lhs, ArraySymbol rhs):
         if lhs.model is not rhs.model:

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -61,6 +61,7 @@ from dwave.optimization.libcpp.nodes cimport (
     IntegerNode as cppIntegerNode,
     LessEqualNode as cppLessEqualNode,
     ListNode as cppListNode,
+    LogicalNode as cppLogicalNode,
     MaxNode as cppMaxNode,
     MaximumNode as cppMaximumNode,
     MinNode as cppMinNode,
@@ -71,6 +72,7 @@ from dwave.optimization.libcpp.nodes cimport (
     NaryMinimumNode as cppNaryMinimumNode,
     NaryMultiplyNode as cppNaryMultiplyNode,
     NegativeNode as cppNegativeNode,
+    NotNode as cppNotNode,
     OrNode as cppOrNode,
     PermutationNode as cppPermutationNode,
     ProdNode as cppProdNode,
@@ -105,6 +107,7 @@ __all__ = [
     "IntegerVariable",
     "LessEqual",
     "ListVariable",
+    "Logical",
     "Max",
     "Maximum",
     "Min",
@@ -115,6 +118,7 @@ __all__ = [
     "NaryMinimum",
     "NaryMultiply",
     "Negative",
+    "Not",
     "Or",
     "Permutation",
     "Prod",
@@ -1697,6 +1701,33 @@ cdef class ListVariable(ArraySymbol):
 _register(ListVariable, typeid(cppListNode))
 
 
+cdef class Logical(ArraySymbol):
+    """Logical truth value element-wise on a symbol.
+
+    See Also:
+        :func:`~dwave.optimization.mathematical.logical`: equivalent function.
+    """
+    def __init__(self, ArraySymbol x):
+        cdef Model model = x.model
+
+        self.ptr = model._graph.emplace_node[cppLogicalNode](x.array_ptr)
+        self.initialize_arraynode(model, self.ptr)
+
+    @staticmethod
+    def _from_symbol(Symbol symbol):
+        cdef cppLogicalNode* ptr = dynamic_cast_ptr[cppLogicalNode](symbol.node_ptr)
+        if not ptr:
+            raise TypeError("given symbol cannot be used to construct a Logical")
+        cdef Logical x = Logical.__new__(Logical)
+        x.ptr = ptr
+        x.initialize_arraynode(symbol.model, ptr)
+        return x
+
+    cdef cppLogicalNode* ptr
+
+_register(Logical, typeid(cppLogicalNode))
+
+
 cdef class Max(ArraySymbol):
     """Maximum value in the elements of a symbol.
 
@@ -2135,6 +2166,33 @@ cdef class Negative(ArraySymbol):
     cdef cppNegativeNode* ptr
 
 _register(Negative, typeid(cppNegativeNode))
+
+
+cdef class Not(ArraySymbol):
+    """Logical negation element-wise on a symbol.
+
+    See Also:
+        :func:`~dwave.optimization.mathematical.logical_not`: equivalent function.
+    """
+    def __init__(self, ArraySymbol x):
+        cdef Model model = x.model
+
+        self.ptr = model._graph.emplace_node[cppNotNode](x.array_ptr)
+        self.initialize_arraynode(model, self.ptr)
+
+    @staticmethod
+    def _from_symbol(Symbol symbol):
+        cdef cppNotNode* ptr = dynamic_cast_ptr[cppNotNode](symbol.node_ptr)
+        if not ptr:
+            raise TypeError("given symbol cannot be used to construct a Not")
+        cdef Not x = Not.__new__(Not)
+        x.ptr = ptr
+        x.initialize_arraynode(symbol.model, ptr)
+        return x
+
+    cdef cppNotNode* ptr
+
+_register(Not, typeid(cppNotNode))
 
 
 cdef class Or(ArraySymbol):

--- a/releasenotes/notes/unary-nodes-refresh-e60c3850212ee7d6.yaml
+++ b/releasenotes/notes/unary-nodes-refresh-e60c3850212ee7d6.yaml
@@ -1,10 +1,10 @@
 ---
 features:
   - |
-    Add C++ ``LogicalNode``. ``LogicalNode`` propagates the truth value(s) of its
+    Add C++ ``LogicalNode`` and Python ``Logical`` symbol. ``Logical`` propagates the truth value(s) of its
     predecessor element-wise.
   - |
-    Add C++ ``NotNode``. ``NotNode`` propagates the inverse of the truth value(s)
+    Add C++ ``NotNode`` and Python ``Not`` symbol. ``Not`` propagates the inverse of the truth value(s)
     of its predecessor element-wise.
 fixes:
   - |

--- a/releasenotes/notes/unary-nodes-refresh-e60c3850212ee7d6.yaml
+++ b/releasenotes/notes/unary-nodes-refresh-e60c3850212ee7d6.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    Add C++ ``LogicalNode``. ``LogicalNode`` propagates the truth value(s) of its
+    predecessor element-wise.
+  - |
+    Add C++ ``NotNode``. ``NotNode`` propagates the inverse of the truth value(s)
+    of its predecessor element-wise.
+fixes:
+  - |
+    Implement C++ ``UnaryOpNode::max()``, ``UnaryOpNode::min()``, and ``UnaryOpNode::logical()``.
+    Therefore ``AbsoluteNode``, ``NegativeNode``, and ``SquareNode`` will now correctly
+    propagate their minimum and maximum value
+    and will now correctly report if they represent integer or boolean values.


### PR DESCRIPTION
There isn't really an analogue to `Logical` in NumPy, it does either `np.asarray(x, dtype=bool)` or `x != 0`. I chose `logical(x)` to follow NumPy's `logical_and(array)`, `logical_not(array)`, etc convention. Open to other names.

I also implemented some missing `UnaryOpNode` methods. Probably there are similar things we need to do for `NaryOpNode` and `BinaryOpNode`.