### PR TITLE
Use CPPFLAGS rather than CFLAGS in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,13 +89,13 @@ jobs:
           name: build with -Werror
           command: |
             . env/bin/activate
-            CFLAGS="-Werror" python setup.py build_ext --inplace
+            CPPFLAGS="-Werror" python setup.py build_ext --inplace
 
       - run:
           name: build with -Werror and -UNDEBUG
           command: |
             . env/bin/activate
-            CFLAGS="-UNDEBUG -Werror" python setup.py build_ext --inplace --force
+            CPPFLAGS="-UNDEBUG -Werror" python setup.py build_ext --inplace --force
 
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
             rm -r env
             python -m venv env
             . env/bin/activate
-            pip install dist/dwave-optimization*.tar.gz
+            pip install dist/dwave*optimization*.tar.gz
       - run: &run-tests
           name: test with installed package
           command: |

--- a/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
@@ -80,10 +80,9 @@ class NumberNode : public ArrayOutputMixin<ArrayNode>, public DecisionNode {
 
 template <std::ranges::range R>
 void NumberNode::initialize_state(State& state, R&& number_data) const {
-    int index = this->topological_index();
-    assert(index >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > index && "unexpected state length");
-    assert(state[index] == nullptr && "already initialized state");
+    assert(this->topological_index() >= 0 && "must be topologically sorted");
+    assert(static_cast<int>(state.size()) > this->topological_index() && "unexpected state length");
+    assert(state[this->topological_index()] == nullptr && "already initialized state");
 
     if (number_data.size() != static_cast<size_t>(this->size())) {
         throw std::invalid_argument("Size of data provided does not match node size");

--- a/dwave/optimization/src/nodes/testing.cpp
+++ b/dwave/optimization/src/nodes/testing.cpp
@@ -27,13 +27,15 @@ class ArrayValidationNodeData : public dwave::optimization::NodeStateData {
 
 void check_shape(const std::span<const ssize_t>& dynamic_shape,
                  const std::span<const ssize_t> shape, ssize_t expected_size) {
-    ssize_t size = 1;
     assert(shape.size() == dynamic_shape.size());
-    for (ssize_t axis = 0; axis < static_cast<ssize_t>(shape.size()); ++axis) {
-        if (axis >= 1) assert(shape[axis] == dynamic_shape[axis]);
-        size *= dynamic_shape[axis];
-    }
-    assert(size == expected_size);
+    assert(([&dynamic_shape, &shape, &expected_size]() -> bool {
+        ssize_t size = 1;
+        for (ssize_t axis = 0; axis < static_cast<ssize_t>(shape.size()); ++axis) {
+            if (axis >= 1 && shape[axis] != dynamic_shape[axis]) return false;
+            size *= dynamic_shape[axis];
+        }
+        return size == expected_size;
+    })());
 }
 
 ArrayValidationNode::ArrayValidationNode(ArrayNode* node_ptr) : array_ptr(node_ptr) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
     "cython==3.0.8",
-    "setuptools>=46.4.0",
-    "setuptools_dso>=2.10,<3.0;platform_system != 'Windows'",  # On Windows we don't distribute a dynamic library
+    "setuptools==71.1.0",
+    "setuptools_dso==2.10;platform_system != 'Windows'",  # On Windows we don't distribute a dynamic library
     "wheel>=0.30.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 cython==3.0.9
 numpy==1.21.6; python_version < '3.10'  # support numpy.typing
 oldest-supported-numpy; python_version >= '3.10'
-setuptools>=46.4.0  # to support setup.cfg getting __version__
+setuptools==71.1.0  # temporarily fix before switching off setuptools_sdo
 
 # On windows we don't distribute a dynamic library
-setuptools_dso>=2.10,<3.0; platform_system != 'Windows'
+setuptools_dso==2.10; platform_system != 'Windows'
 
 reno==4.1.0  # for changelog


### PR DESCRIPTION
This fixes an issue introduced by a backwards compatibility break in setuptools 72.1.0.

Thanks @randomir for finding the bug.