### PR TITLE
Use default linux arm machine in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
         type: string
 
     machine:
-      image: ubuntu-2004:202101-01
+      image: default
 
     resource_class: arm.medium
 


### PR DESCRIPTION
See https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177