### PR TITLE
Fix assertion errors seen with `_GLIBCXX_ASSERTIONS`

### DIFF
--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -527,15 +527,19 @@ void AdvancedIndexingNode::initialize_state(State& state) const {
     const ssize_t size = std::get<ArrayNode*>(indices_[first_array_index_])->size(state);
 
     std::vector<ssize_t> offsets(size);
-    for (ssize_t index = 0; index < static_cast<ssize_t>(indices_.size()); ++index) {
-        if (std::holds_alternative<ArrayNode*>(indices_[index])) {
-            assert(array_strides[index] % static_cast<ssize_t>(itemsize()) == 0);
-            ssize_t stride = array_strides[index] / static_cast<ssize_t>(itemsize());
+    if (size) {
+        for (ssize_t index = 0; index < static_cast<ssize_t>(indices_.size()); ++index) {
+            if (std::holds_alternative<ArrayNode*>(indices_[index])) {
+                assert(array_strides[index] % static_cast<ssize_t>(itemsize()) == 0);
 
-            auto it = offsets.begin();
-            for (auto& index : std::get<ArrayNode*>(indices_[index])->view(state)) {
-                *it += index * stride;
-                ++it;
+                assert(index < static_cast<ssize_t>(array_strides.size()));
+                ssize_t stride = array_strides[index] / static_cast<ssize_t>(itemsize());
+
+                auto it = offsets.begin();
+                for (auto& index : std::get<ArrayNode*>(indices_[index])->view(state)) {
+                    *it += index * stride;
+                    ++it;
+                }
             }
         }
     }

--- a/dwave/optimization/src/nodes/numbers.cpp
+++ b/dwave/optimization/src/nodes/numbers.cpp
@@ -104,7 +104,7 @@ bool IntegerNode::is_valid(double value) const {
 }
 
 double IntegerNode::generate_value(RngAdaptor& rng) const {
-    std::uniform_int_distribution<std::size_t> value_dist(lower_bound_, upper_bound_);
+    std::uniform_int_distribution<ssize_t> value_dist(lower_bound_, upper_bound_);
     return value_dist(rng);
 }
 

--- a/dwave/optimization/src/nodes/testing.cpp
+++ b/dwave/optimization/src/nodes/testing.cpp
@@ -267,7 +267,7 @@ void DynamicArrayTestingNode::initialize_state(State& state, std::span<const dou
 }
 
 double const* DynamicArrayTestingNode::buff(const State& state) const noexcept {
-    return &(data_ptr<DynamicArrayTestingNodeData>(state)->current_data[0]);
+    return data_ptr<DynamicArrayTestingNodeData>(state)->current_data.data();
 }
 
 std::span<const Update> DynamicArrayTestingNode::diff(const State& state) const {


### PR DESCRIPTION
Discovered while messing around with building tests with `meson`. Have not activated `_GLIBCXX_ASSERTIONS` in CI yet, will do that in a followup PR (pending decisions on tests-with-`meson`).