### PR TITLE
Fix combined indexing

### DIFF
--- a/dwave/optimization/generators.py
+++ b/dwave/optimization/generators.py
@@ -605,23 +605,19 @@ def job_shop_scheduling(times: numpy.typing.ArrayLike, machines: numpy.typing.Ar
 
     # Ensure that for each job, its tasks do not overlap
     for j in range(num_jobs):
-        ends = end_times[j, :][machines[j, :-1]]
-        starts = start_times[j, :][machines[j, :]][1:]
+        ends = end_times[j, machines[j, :-1]]
+        starts = start_times[j, machines[j, 1:]]
+
         model.add_constraint((ends <= starts).all())
 
     # Ensure for each machine, its tasks do not overlap
     for m in range(num_machines):
         order = orders[m]
 
-        ends = end_times[:, m]
-        starts = start_times[:, m]
+        ends = end_times[order[:-1], m]
+        starts = start_times[order[1:], m]
 
-        # todo: with combined indexing we wouldn't need this loop
-        for t in range(num_jobs - 1):
-            end = ends[order[t]]  # end of the t'th job on machine m
-            start = starts[order[t+1]]  # start of the (t+1)th job on machine m
-
-            model.add_constraint(end <= start)
+        model.add_constraint((ends <= starts).all())
 
     model.lock()
     return model

--- a/dwave/optimization/model.pyx
+++ b/dwave/optimization/model.pyx
@@ -1690,8 +1690,8 @@ cdef class ArraySymbol(Symbol):
                 # https://numpy.org/doc/stable/user/basics.indexing.html#basic-indexing
                 return dwave.optimization.symbols.BasicIndexing(self, *index)
 
-            elif all(isinstance(idx, ArraySymbol)
-                     or idx.start is None and idx.stop is None and idx.step is None
+            elif all(isinstance(idx, ArraySymbol) or
+                     (isinstance(idx, slice) and idx.start is None and idx.stop is None and idx.step is None)
                      for idx in index):
                 # Advanced indexing
                 # https://numpy.org/doc/stable/user/basics.indexing.html#advanced-indexing
@@ -1706,8 +1706,8 @@ cdef class ArraySymbol(Symbol):
                 # order may be more efficient in some cases, but for now let's do the simple thing
 
                 basic_indices, advanced_indices = _split_indices(index)
-                basic = dwave.optimization.symbols(self, *basic_indices)
-                return dwave.optimization.symbols(basic, *advanced_indices)
+                basic = dwave.optimization.symbols.BasicIndexing(self, *basic_indices)
+                return dwave.optimization.symbols.AdvancedIndexing(basic, *advanced_indices)
 
             else:
                 # todo: consider supporting NumPy arrays directly

--- a/releasenotes/notes/fix-combined-indexing-with-integers-d6203f3865864769.yaml
+++ b/releasenotes/notes/fix-combined-indexing-with-integers-d6203f3865864769.yaml
@@ -3,3 +3,6 @@ fixes:
   - |
     Fix combined indexing. Previously indexing an array symbol by a mixture of
     arrays, integers, and non-empty slices would always result in an error.
+features:
+  - | 
+    Reduce the number of symbols in the model returned by ``job_shop_scheduling()`` generator.

--- a/releasenotes/notes/fix-combined-indexing-with-integers-d6203f3865864769.yaml
+++ b/releasenotes/notes/fix-combined-indexing-with-integers-d6203f3865864769.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix combined indexing. Previously indexing an array symbol by a mixture of
+    arrays, integers, and non-empty slices would always result in an error.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -42,6 +42,40 @@ class TestArraySymbol(unittest.TestCase):
         with self.assertRaises(ValueError):
             bool(symbol)
 
+    def test_combined_indexing_with_integers(self):
+        model = Model()
+        a = model.constant(np.arange(27).reshape(3, 3, 3))
+        x = model.list(3)
+
+        y = a[x, x, 2]
+
+        model.lock()
+        self.assertEqual(model.num_symbols(), 4)  # an intermediate node was created
+
+        model.states.resize(1)
+
+        xarr = np.asarray(x.state(), dtype=int)
+        aarr = np.asarray(a)
+
+        np.testing.assert_array_equal(y.state(), aarr[xarr, xarr, 2])
+
+    def test_combined_indexing_with_slices(self):
+        model = Model()
+        a = model.constant(np.arange(27).reshape(3, 3, 3))
+        x = model.list(3)
+
+        y = a[x, x, 1:3]
+
+        model.lock()
+        self.assertEqual(model.num_symbols(), 4)  # an intermediate node was created
+
+        model.states.resize(1)
+
+        xarr = np.asarray(x.state(), dtype=int)
+        aarr = np.asarray(a)
+
+        np.testing.assert_array_equal(y.state(), aarr[xarr, xarr, 1:3])
+
     def test_operator_types(self):
         # For each, test that we get the right class from the operator and that
         # incorrect types returns NotImplemented


### PR DESCRIPTION
Previously indexing an array symbol by a mixture of arrays, integers, and non-empty slices would always result in an error.