### PR TITLE
Fix behavior for scalar indices in adv indexing

### DIFF
--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -367,8 +367,8 @@ struct AdvancedIndexingNode::IndexParser_ {
             if (indexing_arrays_ndim == 0) {
                 subspace_stride = ndim > 0 ? strides[0] * shape[0] : array_ptr->itemsize();
             } else {
-                subspace_stride =
-                        bullet1mode ? strides[indexing_arrays_ndim - 1] : strides[first_array_index];
+                subspace_stride = bullet1mode ? strides[indexing_arrays_ndim - 1]
+                                              : strides[first_array_index];
             }
         }
     }
@@ -1543,9 +1543,7 @@ std::span<const ssize_t> BasicIndexingNode::shape(const State& state) const {
 // PermutationNode ************************************************************
 
 PermutationNode::PermutationNode(ArrayNode* array_ptr, ArrayNode* order_ptr)
-        : ArrayOutputMixin(array_ptr->shape()),
-          array_ptr_(array_ptr),
-          order_ptr_(order_ptr) {
+        : ArrayOutputMixin(array_ptr->shape()), array_ptr_(array_ptr), order_ptr_(order_ptr) {
     std::span<const ssize_t> array_shape = array_ptr_->shape();
 
     // For now, we are only going to support permutation on constant nodes

--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -212,7 +212,7 @@ struct AdvancedIndexingNodeData : NodeStateData {
 };
 
 struct AdvancedIndexingNode::IndexParser_ {
-    IndexParser_(Array* array_ptr, std::vector<array_or_slice>&& indices, ssize_t item_size)
+    IndexParser_(Array* array_ptr, std::vector<array_or_slice>&& indices)
             : indices_(std::move(indices)) {
         // This may happen if the dynamic_cast to Array from Node fails in the
         // AdvancedIndexingNode constructor
@@ -241,7 +241,7 @@ struct AdvancedIndexingNode::IndexParser_ {
         Array* first_array = nullptr;
 
         this->ndim = 0;
-        this->subspace_stride = item_size;
+        this->subspace_stride = array_ptr->itemsize();
 
         for (size_t idx = 0; idx < indices_.size(); ++idx) {
             const array_or_slice& index = indices_[idx];
@@ -302,7 +302,7 @@ struct AdvancedIndexingNode::IndexParser_ {
 
         simple_array_strides = shape_to_strides(array_ptr->ndim(), array_ptr->shape().data());
         for (ssize_t i = 0; i < array_ptr->ndim(); ++i) {
-            simple_array_strides[i] /= item_size;
+            simple_array_strides[i] /= array_ptr->itemsize();
         }
 
         if (this->ndim > 0) {
@@ -365,7 +365,7 @@ struct AdvancedIndexingNode::IndexParser_ {
 
             strides = shape_to_strides(this->ndim, shape.get());
             if (indexing_arrays_ndim == 0) {
-                subspace_stride = ndim > 0 ? strides[0] * shape[0] : item_size;
+                subspace_stride = ndim > 0 ? strides[0] * shape[0] : array_ptr->itemsize();
             } else {
                 subspace_stride =
                         bullet1mode ? strides[indexing_arrays_ndim - 1] : strides[first_array_index];
@@ -390,7 +390,7 @@ struct AdvancedIndexingNode::IndexParser_ {
 
 AdvancedIndexingNode::AdvancedIndexingNode(ArrayNode* array_ptr,
                                            std::vector<array_or_slice> indices)
-        : AdvancedIndexingNode(array_ptr, IndexParser_(array_ptr, std::move(indices), itemsize())) {}
+        : AdvancedIndexingNode(array_ptr, IndexParser_(array_ptr, std::move(indices))) {}
 
 AdvancedIndexingNode::AdvancedIndexingNode(ArrayNode* array_ptr, IndexParser_&& parser)
         : array_ptr_(array_ptr),

--- a/releasenotes/notes/support-scalar-indices-with-advanced-indexing-027ad8cee2a4d2a5.yaml
+++ b/releasenotes/notes/support-scalar-indices-with-advanced-indexing-027ad8cee2a4d2a5.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Fully support scalar (0-dimensional) indices for advanced indexing
+    operations, e.g. ``A[i, :, j, :]`` where ``i`` and ``j`` are nodes with
+    scalar output. Previously, this would work only if the final output of the
+    indexing operation was also scalar.
+fixes:
+  - |
+    Fix the case of using scalar indices in an advanced indexing operation
+    where the indices were not grouped, e.g. ``A[:, i, :, j]``, which was
+    technically unsupported but no errors were raised. This could also lead
+    to segfaults during state initialization or propagation.

--- a/tests/cpp/tests/test_nodes_indexing.cpp
+++ b/tests/cpp/tests/test_nodes_indexing.cpp
@@ -1382,8 +1382,8 @@ TEST_CASE("AdvancedIndexingNode") {
         auto k_ptr = graph.emplace_node<IntegerNode>(std::initializer_list<ssize_t>{});
 
         WHEN("We access the matrix by (i, j, :, :)") {
-            auto adv =
-                    graph.emplace_node<AdvancedIndexingNode>(arr_ptr, i_ptr, j_ptr, Slice(), Slice());
+            auto adv = graph.emplace_node<AdvancedIndexingNode>(arr_ptr, i_ptr, j_ptr, Slice(),
+                                                                Slice());
 
             THEN("We get the shape we expect") {
                 CHECK(!adv->dynamic());
@@ -1396,13 +1396,9 @@ TEST_CASE("AdvancedIndexingNode") {
                 j_ptr->initialize_state(state, {1});
                 graph.initialize_state(state);
 
-                std::vector<double> expected_initial_state({
-                        80, 81, 82, 83,
-                        84, 85, 86, 87,
-                        88, 89, 90, 91,
-                        92, 93, 94, 95,
-                        96, 97, 98, 99
-                    });
+                std::vector<double> expected_initial_state({80, 81, 82, 83, 84, 85, 86,
+                                                            87, 88, 89, 90, 91, 92, 93,
+                                                            94, 95, 96, 97, 98, 99});
 
                 THEN("The state starts with the expected values") {
                     CHECK(std::ranges::equal(adv->view(state), expected_initial_state));
@@ -1419,13 +1415,8 @@ TEST_CASE("AdvancedIndexingNode") {
                     THEN("The state has the expected values and the diff is correct") {
                         CHECK(adv->size(state) == 20);
 
-                        std::vector<double> new_state({
-                                                 40, 41, 42, 43,
-                                                 44, 45, 46, 47,
-                                                 48, 49, 50, 51,
-                                                 52, 53, 54, 55,
-                                                 56, 57, 58, 59
-                                                 });
+                        std::vector<double> new_state({40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
+                                                       50, 51, 52, 53, 54, 55, 56, 57, 58, 59});
                         CHECK(std::ranges::equal(adv->view(state), new_state));
                         verify_array_diff(expected_initial_state, new_state, adv->diff(state));
                     }
@@ -1434,8 +1425,8 @@ TEST_CASE("AdvancedIndexingNode") {
         }
 
         WHEN("We access the matrix by (:, i, j, :)") {
-            auto adv =
-                    graph.emplace_node<AdvancedIndexingNode>(arr_ptr, Slice(), i_ptr, j_ptr, Slice());
+            auto adv = graph.emplace_node<AdvancedIndexingNode>(arr_ptr, Slice(), i_ptr, j_ptr,
+                                                                Slice());
 
             THEN("We get the shape we expect") {
                 CHECK(!adv->dynamic());
@@ -1448,10 +1439,7 @@ TEST_CASE("AdvancedIndexingNode") {
                 j_ptr->initialize_state(state, {1});
                 graph.initialize_state(state);
 
-                std::vector<double> expected_initial_state({
-                        24, 25, 26, 27,
-                        84, 85, 86, 87
-                    });
+                std::vector<double> expected_initial_state({24, 25, 26, 27, 84, 85, 86, 87});
 
                 THEN("The state starts with the expected values") {
                     CHECK(std::ranges::equal(adv->view(state), expected_initial_state));
@@ -1468,10 +1456,7 @@ TEST_CASE("AdvancedIndexingNode") {
                     THEN("The state has the expected values and the diff is correct") {
                         CHECK(adv->size(state) == 8);
 
-                        std::vector<double> new_state({
-                                                 8, 9, 10, 11,
-                                                 68, 69, 70, 71
-                                                 });
+                        std::vector<double> new_state({8, 9, 10, 11, 68, 69, 70, 71});
                         CHECK(std::ranges::equal(adv->view(state), new_state));
                         verify_array_diff(expected_initial_state, new_state, adv->diff(state));
                     }


### PR DESCRIPTION
This should achieve the expected behavior for scalar (0-dimensional) `ArrayNode` indices for `AdvancedIndexingNode`. Previously there were a few asserts and an exception raised in one case but it was not properly prevented, and also not properly implemented.