### PR TITLE
Feature/feasibility

### DIFF
--- a/dwave/optimization/libcpp/graph.pxd
+++ b/dwave/optimization/libcpp/graph.pxd
@@ -40,7 +40,6 @@ cdef extern from "dwave-optimization/graph.hpp" namespace "dwave::optimization" 
         void add_constraint(ArrayNode*) except+
         void topological_sort()
         bool topologically_sorted() const
-        bool feasible(State&) const
 
     cdef cppclass Node:
         struct SuccessorView:

--- a/dwave/optimization/libcpp/graph.pxd
+++ b/dwave/optimization/libcpp/graph.pxd
@@ -40,6 +40,7 @@ cdef extern from "dwave-optimization/graph.hpp" namespace "dwave::optimization" 
         void add_constraint(ArrayNode*) except+
         void topological_sort()
         bool topologically_sorted() const
+        bool feasible(State&) const
 
     cdef cppclass Node:
         struct SuccessorView:

--- a/dwave/optimization/model.pyi
+++ b/dwave/optimization/model.pyi
@@ -45,7 +45,7 @@ class Model:
         self, primary_set_size: int, num_disjoint_lists: int,
         ) -> typing.Tuple[DisjointLists, typing.Tuple[DisjointList, ...]]: ...
 
-    def feasible(self, state: int = 0) -> bool:
+    def feasible(self, index: int = 0) -> bool:
 
     @classmethod
     def from_file(

--- a/dwave/optimization/model.pyi
+++ b/dwave/optimization/model.pyi
@@ -45,6 +45,8 @@ class Model:
         self, primary_set_size: int, num_disjoint_lists: int,
         ) -> typing.Tuple[DisjointLists, typing.Tuple[DisjointList, ...]]: ...
 
+    def feasible(self, state: int = 0) -> bool:
+
     @classmethod
     def from_file(
         cls,

--- a/dwave/optimization/model.pyi
+++ b/dwave/optimization/model.pyi
@@ -45,7 +45,7 @@ class Model:
         self, primary_set_size: int, num_disjoint_lists: int,
         ) -> typing.Tuple[DisjointLists, typing.Tuple[DisjointList, ...]]: ...
 
-    def feasible(self, index: int = 0) -> bool:
+    def feasible(self, index: int = 0) -> bool: ...
 
     @classmethod
     def from_file(

--- a/dwave/optimization/model.pyx
+++ b/dwave/optimization/model.pyx
@@ -253,7 +253,27 @@ cdef class Model:
 
         Returns:
             Feasibility of the state.
+
+        Examples:
+            This example demonstrates checking the feasibility of a simple model with
+            feasible and infeasible states.
+
+            >>> from dwave.optimization.model import Model
+            >>> model = Model()
+            >>> b = model.binary()
+            >>> model.add_constraint(b) # doctest: +ELLIPSIS
+            <dwave.optimization.BinaryVariable at ...>
+            >>> model.states.resize(2)
+            >>> b.set_state(0, 1) # Feasible
+            >>> b.set_state(1, 0) # Infeasible
+            >>> with model.lock():
+            ...     model.feasible(0)
+            True
+            >>> with model.lock():
+            ...     model.feasible(1)
+            False
         """
+
         cdef Py_ssize_t num_states = self.states.size()
 
         if not -num_states <= index < num_states:

--- a/dwave/optimization/model.pyx
+++ b/dwave/optimization/model.pyx
@@ -254,7 +254,8 @@ cdef class Model:
         Returns:
             Feasibility of the state.
         """
-        cdef int num_states = self.state_size()
+        cdef Py_ssize_t num_states = self.states.size()
+
         if not -num_states <= index < num_states:
             raise ValueError(f"index out of range: {index}")
         elif index < 0:  # allow negative indexing

--- a/dwave/optimization/model.pyx
+++ b/dwave/optimization/model.pyx
@@ -245,6 +245,23 @@ cdef class Model:
         lists = [DisjointList(main, i) for i in range(num_disjoint_lists)]
         return main, lists
 
+    def feasible(self, int index = 0):
+        """Check the feasibility of the state at the input index.
+
+        Args:
+            index: index of the state to check for feasibility.
+
+        Returns:
+            Feasibility of the state.
+        """
+        cdef int num_states = self.state_size()
+        if not -num_states <= index < num_states:
+            raise ValueError(f"index out of range: {index}")
+        elif index < 0:  # allow negative indexing
+            index += num_states
+
+        return self._graph.feasible(self.states._states[index])
+
     @classmethod
     def from_file(cls, file, *,
                   check_header = True,

--- a/dwave/optimization/model.pyx
+++ b/dwave/optimization/model.pyx
@@ -261,7 +261,7 @@ cdef class Model:
         elif index < 0:  # allow negative indexing
             index += num_states
 
-        return self._graph.feasible(self.states._states[index])
+        return all(sym.state(index) for sym in self.iter_constraints())
 
     @classmethod
     def from_file(cls, file, *,

--- a/dwave/optimization/model.pyx
+++ b/dwave/optimization/model.pyx
@@ -273,14 +273,6 @@ cdef class Model:
             ...     model.feasible(1)
             False
         """
-
-        cdef Py_ssize_t num_states = self.states.size()
-
-        if not -num_states <= index < num_states:
-            raise ValueError(f"index out of range: {index}")
-        elif index < 0:  # allow negative indexing
-            index += num_states
-
         return all(sym.state(index) for sym in self.iter_constraints())
 
     @classmethod

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -207,24 +207,25 @@ class TestModel(unittest.TestCase):
         c = model.constant(5)
         model.add_constraint(i <= c)
 
-        # Check expected exception if no states initialize
-        with self.assertRaises(ValueError):
-            model.feasible(0)
+        with model.lock():
+            # Check expected exception if no states initialize
+            with self.assertRaises(ValueError):
+                model.feasible(0)
 
-        model.states.resize(1)
-        i.set_state(0, 1)
+            model.states.resize(1)
+            i.set_state(0, 1)
 
-        # Check that True is returned for feasible state
-        self.assertTrue(model.feasible(0))
+            # Check that True is returned for feasible state
+            self.assertTrue(model.feasible(0))
 
-        # Check expected exception for index out of range with initialized state
-        with self.assertRaises(ValueError):
-            model.feasible(1)
+            # Check expected exception for index out of range with initialized state
+            with self.assertRaises(ValueError):
+                model.feasible(1)
 
-        i.set_state(0, 6)
+            i.set_state(0, 6)
 
-        # Check that False is returned for infeasible state
-        self.assertFalse(model.feasible(0))
+            # Check that False is returned for infeasible state
+            self.assertFalse(model.feasible(0))
 
     def test_lock(self):
         model = Model()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -201,6 +201,31 @@ class TestModel(unittest.TestCase):
         self.assertTrue(c_iter.state(0))
         self.assertTrue(c_direct.state(0))
 
+    def test_feasible(self):
+        model = Model()
+        i = model.integer()
+        c = model.constant(5)
+        model.add_constraint(i <= c)
+
+        # Check expected exception if no states initialize
+        with self.assertRaises(ValueError):
+            model.feasible(0)
+
+        model.states.resize(1)
+        i.set_state(0, 1)
+
+        # Check that True is returned for feasible state
+        self.assertTrue(model.feasible(0))
+
+        # Check expected exception for index out of range with initialized state
+        with self.assertRaises(ValueError):
+            model.feasible(1)
+
+        i.set_state(0, 6)
+
+        # Check that False is returned for infeasible state
+        self.assertFalse(model.feasible(0))
+
     def test_lock(self):
         model = Model()
 


### PR DESCRIPTION
@arcondello adds a `feasible()` method to the `Model` class to make it easier for users to check the feasibility of a model state without manually checking the state of each constraint symbol. Addresses #82 

Current work will build, but throws a segfault when I try to actually call the method in Python.