### PR TITLE
Prevent higher dim indexers for advanced indexing

### DIFF
--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -325,6 +325,12 @@ struct AdvancedIndexingNode::IndexParser_ {
             bullet1mode = true;
         }
 
+        if (indexing_arrays_ndim > 1) {
+            throw std::invalid_argument(
+                    "Advanced indexing currently only supports 0- and 1-dimensional indexing "
+                    "arrays");
+        }
+
         simple_array_strides = shape_to_strides(array_ptr->ndim(), array_ptr->shape().data());
         for (ssize_t i = 0; i < array_ptr->ndim(); ++i) {
             simple_array_strides[i] /= array_ptr->itemsize();

--- a/releasenotes/notes/advanced-indexing-disallow-higher-than-1d-indexers-5ffcd3fc9541f079.yaml
+++ b/releasenotes/notes/advanced-indexing-disallow-higher-than-1d-indexers-5ffcd3fc9541f079.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    Using advanced indexing nodes with indexing arrays that have a higher dimension than
+    one (e.g. ``A[:, i, :, j]`` where ``i`` and ``j`` are 2d arrays) has been disabled.
+    Previously, it was possible to construct models that used this functionality, but
+    the behavior of the model during state initialization and propagation may not have
+    been correct.

--- a/tests/cpp/tests/test_nodes_indexing.cpp
+++ b/tests/cpp/tests/test_nodes_indexing.cpp
@@ -1571,6 +1571,18 @@ TEST_CASE("AdvancedIndexingNode") {
             }
         }
     }
+
+    GIVEN("A static-sized 4d 2x3x5x4 matrix with a 2d indexing array") {
+        auto arr_ptr = graph.emplace_node<IntegerNode>(std::initializer_list<ssize_t>{2, 3, 5, 4},
+                                                       -1000, 1000);
+
+        auto i_ptr = graph.emplace_node<IntegerNode>(std::initializer_list<ssize_t>{2, 3}, 0, 1);
+
+        THEN("We are prevented from doing an indexing operation") {
+            CHECK_THROWS(graph.emplace_node<AdvancedIndexingNode>(arr_ptr, Slice(), i_ptr, Slice(),
+                                                                  Slice()));
+        }
+    }
 }
 
 TEST_CASE("BasicIndexingNode") {

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -347,6 +347,22 @@ class TestAdd(utils.BinaryOpTests):
             a + b
 
 
+class TestAdvancedIndexing(unittest.TestCase):
+    def test_higher_dimenional_indexers_not_allowed(self):
+        model = Model()
+        constant = model.constant(np.arange(10))
+
+        i0 = model.integer(lower_bound=0, upper_bound=9)
+        self.assertTrue(constant[i0].shape() == tuple())
+
+        i1 = model.integer(3, lower_bound=0, upper_bound=9)
+        self.assertTrue(constant[i1].shape() == (3,))
+
+        i2 = model.integer((2, 3), lower_bound=0, upper_bound=9)
+        with self.assertRaises(ValueError):
+            constant[i2]
+
+
 class TestAll(utils.SymbolTests):
     def generate_symbols(self):
         model = Model()


### PR DESCRIPTION
Larger than 1d is still not well tested