### PR TITLE
Raise better error messages from indexing arrays

### DIFF
--- a/dwave/optimization/libcpp/graph.pxd
+++ b/dwave/optimization/libcpp/graph.pxd
@@ -24,7 +24,7 @@ from dwave.optimization.libcpp.state cimport State
 
 cdef extern from "dwave-optimization/graph.hpp" namespace "dwave::optimization" nogil:
     cdef cppclass Graph:
-        T* emplace_node[T](...) except +ValueError
+        T* emplace_node[T](...) except+
         void initialize_state(State&) except+
         span[const unique_ptr[Node]] nodes() const
         span[ArrayNode*] constraints() const

--- a/dwave/optimization/model.pyi
+++ b/dwave/optimization/model.pyi
@@ -161,7 +161,7 @@ class ArraySymbol(Symbol):
 
     def __getitem__(
         self,
-        index: typing.Union[Symbol, int, slice, tuple[int]],
+        index: typing.Union[Symbol, int, slice, tuple],
         ) -> typing.Union[AdvancedIndexing, BasicIndexing, Permutation]: ...
 
     def __iadd__(self, rhs: ArraySymbol) -> NaryAdd: ...

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -392,7 +392,7 @@ cdef class AdvancedIndexing(ArraySymbol):
                 cppindices.emplace_back(cppSlice())
             else:
                 array_index = index
-                if array_index.model != model:
+                if array_index.model is not model:
                     raise ValueError("mismatched parent models")
 
                 cppindices.emplace_back(array_index.array_ptr)

--- a/releasenotes/notes/feature-better-indexing-error-messages-2e2ce0e2bbebb42e.yaml
+++ b/releasenotes/notes/feature-better-indexing-error-messages-2e2ce0e2bbebb42e.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Raise clearer error messages when trying to use out-of-bounds indices.

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -348,6 +348,43 @@ class TestAdd(utils.BinaryOpTests):
 
 
 class TestAdvancedIndexing(unittest.TestCase):
+    def test_out_of_bounds(self):
+        model = Model()
+
+        a = model.constant([0, 1, 2, 3])
+        b = model.constant(1.5)
+        x = model.integer(lower_bound=1, upper_bound=100)
+
+        # Error messages are chosen to be similar to NumPy's
+        with self.assertRaisesRegex(
+                IndexError,
+                "index's smallest possible value -100 is out of bounds for axis 0 with size 4"):
+            a[-x]
+        with self.assertRaisesRegex(
+                IndexError,
+                "index's largest possible value 100 is out of bounds for axis 0 with size 4"):
+            a[x]
+
+        with self.assertRaisesRegex(
+                IndexError,
+                "index may not contain non-integer values for axis 0"):
+            a[b]
+
+        a = model.constant(np.arange(12).reshape(3, 4))
+
+        with self.assertRaisesRegex(
+                IndexError,
+                "index may not contain non-integer values for axis 1"):
+            a[:, b]
+
+        s = model.set(5, min_size=3)
+
+        with self.assertRaisesRegex(
+                IndexError,
+                "index's largest possible value 100 is out of bounds for axis 0 "
+                "with minimum size 3"):
+            s[x]
+
     def test_higher_dimenional_indexers_not_allowed(self):
         model = Model()
         constant = model.constant(np.arange(10))


### PR DESCRIPTION
In the case of combined indexing the reported axis might be a bit confusing. But combined with the traceback I think it's fairly clear what's happening.