### PR TITLE
Bugfix/cvrptw generator

### DIFF
--- a/dwave/optimization/generators.py
+++ b/dwave/optimization/generators.py
@@ -525,10 +525,16 @@ def capacitated_vehicle_routing_with_time_windows(demand: numpy.typing.ArrayLike
     time_distance_ext = np.zeros((num_customers + 1, num_customers + 1))
     time_distance_ext[:num_customers, :num_customers] = time_distances_array[1:, 1:]
 
-    time_depo_ext = np.zeros(num_customers + 1)
-    time_depo_ext[:num_customers] = time_distances_array[0, 1:]
+    # Time from depot to destination
+    time_from_depo_ext = np.zeros(num_customers + 1)
+    time_from_depo_ext[:num_customers] = time_distances_array[0, 1:]
 
-    t_depo = model.constant(time_depo_ext)
+    # Time from source to depot
+    time_to_depo_ext = np.zeros(num_customers + 1)
+    time_to_depo_ext[:num_customers] = time_distances_array[1:, 0]
+
+    t_from_depo = model.constant(time_from_depo_ext)
+    t_to_depo = model.constant(time_to_depo_ext)
     t_cust = model.constant(time_distance_ext)
 
     time_open_ext = np.zeros(num_customers + 1)
@@ -599,7 +605,7 @@ def capacitated_vehicle_routing_with_time_windows(demand: numpy.typing.ArrayLike
                 # index of the first customer visited, if length of the route is zero,
                 # points to the last (0) element
                 idx = where(condition, routes[vehicle_idx][:1].sum(), range_helper[-1])
-                this_t_serving_time.append(maximum(t_depo[idx], t_open[idx]))
+                this_t_serving_time.append(maximum(t_from_depo[idx], t_open[idx]))
                 this_t_leaving.append(this_t_serving_time[-1] + t_service[idx])
 
             else:
@@ -618,7 +624,7 @@ def capacitated_vehicle_routing_with_time_windows(demand: numpy.typing.ArrayLike
         condition = (num_clients_in_route[f'route{vehicle_idx}'] >= one)
         last_cust_idx = where(condition, routes[vehicle_idx][-1:].sum(), range_helper[-1])
 
-        times_back.append(this_t_leaving[-1] + t_depo[last_cust_idx])
+        times_back.append(this_t_leaving[-1] + t_to_depo[last_cust_idx])
         time_leaving.append(this_t_leaving)
         serving_time.append(this_t_serving_time)
 
@@ -634,8 +640,8 @@ def capacitated_vehicle_routing_with_time_windows(demand: numpy.typing.ArrayLike
     # minimize travelled distance
     route_costs = []
     for r in range(number_of_vehicles):
-        route_costs.append(t_depo[routes[r][:1]].sum())
-        route_costs.append(t_depo[routes[r][-1:]].sum())
+        route_costs.append(t_from_depo[routes[r][:1]].sum())
+        route_costs.append(t_to_depo[routes[r][-1:]].sum())
         route_costs.append(t_cust[routes[r][1:], routes[r][:-1]].sum())
 
     model.minimize(add(*route_costs))

--- a/dwave/optimization/generators.py
+++ b/dwave/optimization/generators.py
@@ -533,8 +533,12 @@ def capacitated_vehicle_routing_with_time_windows(demand: numpy.typing.ArrayLike
     time_to_depo_ext = np.zeros(num_customers + 1)
     time_to_depo_ext[:num_customers] = time_distances_array[1:, 0]
 
-    t_from_depo = model.constant(time_from_depo_ext)
-    t_to_depo = model.constant(time_to_depo_ext)
+    if np.equal(time_from_depo_ext, time_to_depo_ext).all():
+        t_from_depo = t_to_depo = model.constant(time_from_depo_ext)
+    else:
+        t_from_depo = model.constant(time_from_depo_ext)
+        t_to_depo = model.constant(time_to_depo_ext)
+
     t_cust = model.constant(time_distance_ext)
 
     time_open_ext = np.zeros(num_customers + 1)

--- a/releasenotes/notes/fix-cvrptw-generator-044c7d7b5ad1c112.yaml
+++ b/releasenotes/notes/fix-cvrptw-generator-044c7d7b5ad1c112.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Updates the logic in the `capacitated_vehicle_routing_with_time_windows` generator function
+    to correctly account for asymmetric time-distance matrices.
+    

--- a/releasenotes/notes/fix-cvrptw-generator-044c7d7b5ad1c112.yaml
+++ b/releasenotes/notes/fix-cvrptw-generator-044c7d7b5ad1c112.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Updates the logic in the `capacitated_vehicle_routing_with_time_windows` generator function
+    Update the logic in the ``capacitated_vehicle_routing_with_time_windows()`` generator function
     to correctly account for asymmetric time-distance matrices.
     

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -510,7 +510,7 @@ class TestCapacitatedVehicleRoutingTimeWindow(unittest.TestCase):
         route = next(model.iter_decisions())
         self.assertEqual(route.num_disjoint_lists(), 2)
         route.set_state(0, [[0], [1]])
-        self.assertEqual(model.objective.state(0), 18)
+        self.assertEqual(model.objective.state(0), 15)
 
         # Test asymmetric distances
         model = dwave.optimization.generators.capacitated_vehicle_routing_with_time_windows(
@@ -527,7 +527,7 @@ class TestCapacitatedVehicleRoutingTimeWindow(unittest.TestCase):
         route = next(model.iter_decisions())
         self.assertEqual(route.num_disjoint_lists(), 2)
         route.set_state(0, [[0], [1]])
-        self.assertEqual(model.objective.state(0), 8)
+        self.assertEqual(model.objective.state(0), 10)
 
     def test_serialization(self):
         model = dwave.optimization.generators.capacitated_vehicle_routing_with_time_windows(


### PR DESCRIPTION
I was reverse-engineering this generator function while developing a slightly different formulation for this problem type and noticed that the values for some of the intermediate symbols were different than expected using an asymmetric time-distance matrix. Let me know if the modifications make sense or if I'm missing something in the original function and the updates are off-base.