### PR TITLE
Fix formatting for math formula of DisjointBitSets class method

### DIFF
--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -1024,7 +1024,8 @@ cdef class DisjointBitSets(Symbol):
 
         The given state must be a partition of ``range(primary_set_size)``
         into :meth:`.num_disjoint_sets` partitions, encoded as a 2D
-        :math:`num_disjoint_sets \times primary_set_size` Boolean array.
+        :code:`num_disjoint_sets` :math:`\times` :code:`primary_set_size` 
+        Boolean array.
 
         Args:
             index:


### PR DESCRIPTION
Currently:
![image](https://github.com/user-attachments/assets/ac5d7b5b-e074-4785-a716-26aa748e9c81)

Fix:
![image](https://github.com/user-attachments/assets/e58b9c40-c12d-40be-b860-587c8e9b04bf)

Should be last one from Gaelen in the series