### PR TITLE
Fix two bugs in advanced indexing propagation for non-const non-dynamic arrays with dynamic indexers

### DIFF
--- a/releasenotes/notes/fix-bugs-in-advanced-indexing-non-const-array-with-dynamic-indexers-1ef4c31adebcc081.yaml
+++ b/releasenotes/notes/fix-bugs-in-advanced-indexing-non-const-array-with-dynamic-indexers-1ef4c31adebcc081.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix two bugs in advanced indexing node propogation in the case of a
+    non-const main array with dynamic indexers, e.g. ``A[x]`` where ``A`` is a
+    1d integer decision variable and ``x`` is a list. The first bug could cause
+    segfaults during propagation, and the second could lead to incorrect output
+    if both arrays were changed during propagation.


### PR DESCRIPTION
First one was just a simple logic error in which method should be called when reverting the reverse offset map. Second one was basically covered by an old TODO: to ensure all updates to the parent array are reflected in the final advanced indexing output, we need to track the offset indices that were modified (not just the offsets themselves) as new offsets may be added that duplicate previous unchanged offsets.