### PR TITLE
Update `UnaryOpNode` to correctly handle dynamic predecessors

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
@@ -298,6 +298,11 @@ class UnaryOpNode : public ArrayOutputMixin<ArrayNode> {
     bool integral() const override;
     double max() const override;
     double min() const override;
+    using ArrayOutputMixin::shape;
+    std::span<const ssize_t> shape(const State& state) const override;
+    using ArrayOutputMixin::size;
+    ssize_t size(const State& state) const override;
+    ssize_t size_diff(const State& state) const override;
 
     void commit(State& state) const override;
     void revert(State& state) const override;

--- a/dwave/optimization/src/nodes/testing.cpp
+++ b/dwave/optimization/src/nodes/testing.cpp
@@ -45,6 +45,7 @@ void check_shape(const std::span<const ssize_t>& dynamic_shape,
 
 ArrayValidationNode::ArrayValidationNode(ArrayNode* node_ptr) : array_ptr(node_ptr) {
     assert(array_ptr->ndim() == static_cast<ssize_t>(array_ptr->shape().size()));
+    assert(array_ptr->dynamic() == (array_ptr->size() == -1));
     add_predecessor(node_ptr);
 }
 

--- a/releasenotes/notes/UnaryOpNode-dynamic-predecessor-f7cd282afb15270d.yaml
+++ b/releasenotes/notes/UnaryOpNode-dynamic-predecessor-f7cd282afb15270d.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Update C++ ``UnaryOpNode`` to correctly handle dynamic predecessors.


### PR DESCRIPTION
Previously it would accept them but then segfault.