### PR TITLE
Add `compress` kwarg to `Model.to_file()` and `States.to_file()`

### DIFF
--- a/dwave/optimization/model.pyi
+++ b/dwave/optimization/model.pyi
@@ -70,6 +70,7 @@ class Model:
         *,
         max_num_states: int = 0,
         only_decision: bool = False,
+        compress: bool = False,
         ): ...
 
     def is_locked(self) -> bool: ...
@@ -102,6 +103,7 @@ class Model:
         *,
         max_num_states: int = 0,
         only_decision: bool = False,
+        compress: bool = False,
         ) -> typing.BinaryIO: ...
 
     # networkx might not be installed, so we just say we return an object.
@@ -129,12 +131,13 @@ class States:
     def into_file(
         self,
         file: typing.Union[typing.BinaryIO, collections.abc.ByteString, str],
+        compress: bool = False,
         ): ...
 
     def resize(self, n: int): ...
     def resolve(self): ...
     def size(self) -> int: ...
-    def to_file(self) -> typing.BinaryIO: ...
+    def to_file(self, *, compress: bool = False) -> typing.BinaryIO: ...
 
 
 class Symbol:

--- a/releasenotes/notes/serialization-compression-b3c08ab6ae12991a.yaml
+++ b/releasenotes/notes/serialization-compression-b3c08ab6ae12991a.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add ``compress`` keyword argument to ``Model.into_file()``, ``Model.to_file()``,
+    ``States.into_file()``, and ``States.to_file()``.


### PR DESCRIPTION
By default this maintains the existing behavior but allows us to toggle it via a keyword argument.

See also https://github.com/dwavesystems/dimod/pull/1296