### PR TITLE
Refactor C++ `ArrayIterator` for performance and safety

### DIFF
--- a/dwave/optimization/include/dwave-optimization/array.hpp
+++ b/dwave/optimization/include/dwave-optimization/array.hpp
@@ -261,10 +261,13 @@ class ArrayIterator {
     explicit ArrayIterator(value_type const* ptr) noexcept
             : ptr_(ptr), mask_(nullptr), shape_(nullptr) {}
 
-    // Create a masked iterator with a fill value. Will return fill when *mask_ptr evaluates to true
-    ArrayIterator(value_type const* data_ptr, value_type const* mask_ptr,
-                  value_type fill = 0) noexcept
-            : ptr_(data_ptr), mask_(std::make_unique<MaskInfo>(mask_ptr, fill)), shape_(nullptr) {}
+    // Create a masked iterator with a fill value. Will return the value pointed at by *fill_ptr
+    // when *mask_ptr evaluates to true.
+    ArrayIterator(const value_type* data_ptr, const value_type* mask_ptr,
+                  const value_type* fill_ptr) noexcept
+            : ptr_(data_ptr),
+              mask_(std::make_unique<MaskInfo>(mask_ptr, fill_ptr)),
+              shape_(nullptr) {}
 
     // shape and strides must outlive the iterator!
     ArrayIterator(value_type const* ptr, ssize_t ndim, const ssize_t* shape, const ssize_t* strides)
@@ -282,15 +285,15 @@ class ArrayIterator {
     }
 
     const value_type& operator*() const {
-        if (mask_ && *(mask_->ptr)) {
-            return mask_->fill;
+        if (mask_ && *(mask_->mask_ptr)) {
+            return *(mask_->fill_ptr);
         }
 
         return *ptr_;
     }
     const value_type* operator->() const {
-        if (mask_ && *(mask_->ptr)) {
-            return &(mask_->fill);
+        if (mask_ && *(mask_->mask_ptr)) {
+            return mask_->fill_ptr;
         }
 
         return ptr_;
@@ -305,7 +308,7 @@ class ArrayIterator {
             ptr_ += shape_->advance() / sizeof(value_type);
         } else if (mask_) {
             // advance both the mask ptr and the data ptr
-            ++(mask_->ptr);
+            ++(mask_->mask_ptr);
             ++ptr_;
         } else {
             ++ptr_;
@@ -327,7 +330,7 @@ class ArrayIterator {
             ptr_ += shape_->unadvance() / sizeof(value_type);
         } else if (mask_) {
             // decrement both the mask ptr and the data ptr
-            --(mask_->ptr);
+            --(mask_->mask_ptr);
             --ptr_;
         } else {
             --ptr_;
@@ -349,7 +352,7 @@ class ArrayIterator {
             ptr_ += shape_->advance(rhs) / sizeof(double);
         } else if (mask_) {
             ptr_ += rhs;
-            (mask_->ptr) += rhs;
+            (mask_->mask_ptr) += rhs;
         } else {
             ptr_ += rhs;
         }
@@ -380,10 +383,11 @@ class ArrayIterator {
     struct MaskInfo {
         MaskInfo() = delete;
 
-        MaskInfo(value_type const* ptr, value_type fill) noexcept : ptr(ptr), fill(fill) {}
+        MaskInfo(const value_type* mask_ptr, const value_type* fill_ptr) noexcept
+                : mask_ptr(mask_ptr), fill_ptr(fill_ptr) {}
 
-        value_type const* ptr;  // ptr to the value indicating whether to use the mask value or not
-        const value_type fill;  // the value to provide for masked entries
+        const value_type* mask_ptr;  // ptr to the value indicating whether to use the fill or not
+        const value_type* fill_ptr;  // the value to provide for masked entries, won't be iterated
     };
 
     // if this is a masked iterator, put information about the mask here

--- a/releasenotes/notes/fix-ArrayIterator-9eb71f75a968f570.yaml
+++ b/releasenotes/notes/fix-ArrayIterator-9eb71f75a968f570.yaml
@@ -1,4 +1,6 @@
 ---
+features:
+  - Improve the move/copy behavior of C++ ``ArrayIterator``.
 upgrade:
   - Change C++ ``ArrayIterator`` to no longer have ownership of its fill value when masked.
 fixes:

--- a/releasenotes/notes/fix-ArrayIterator-9eb71f75a968f570.yaml
+++ b/releasenotes/notes/fix-ArrayIterator-9eb71f75a968f570.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - Change C++ ``ArrayIterator`` to no longer have ownership of its fill value when masked.
+fixes:
+  - Fix the possibility of creating a dangling reference when using a masked C++ ``ArrayIterator``.

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -114,8 +114,9 @@ TEST_CASE("ArrayIterator") {
 
         WHEN("We create a mask over the array and create a masked iterator") {
             auto mask = std::vector<double>{true, false, false, true, false, false, false, true, false};
+            const double fill = 6;
 
-            auto it = ArrayIterator(values.data(), mask.data(), 6);
+            auto it = ArrayIterator(values.data(), mask.data(), &fill);
 
             THEN("It behaves like a contiguous iterator") {
                 CHECK(*it == 6);  // masked
@@ -130,6 +131,13 @@ TEST_CASE("ArrayIterator") {
                 CHECK(*(it + 3) == 6);  // masked
                 CHECK(*(it + 4) == 4);
             }
+        }
+
+        THEN("We can construct another vector using reverse iterators") {
+            auto copy = std::vector<double>();
+            copy.assign(std::reverse_iterator(ArrayIterator(values.data()) + 6),
+                        std::reverse_iterator(ArrayIterator(values.data())));
+            CHECK(std::ranges::equal(copy, std::vector<double>{5, 4, 3, 2, 1, 0}));
         }
     }
 }


### PR DESCRIPTION
See also [C.12: Don’t make data members const or references in a copyable or movable type](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c12-dont-make-data-members-const-or-references-in-a-copyable-or-movable-type)