### PR TITLE
Update build requirements in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ numpy==2.1.0; python_version >= '3.10'
 
 # Build requirements
 cython~=3.0.0
-meson-python~=0.16.0
-meson~=1.5.0
+meson-python~=0.17.0
+meson~=1.6.0
 ninja~=1.11.0
 
 # Other requirements, see also tests/requirements.txt and docs/requirements.txt


### PR DESCRIPTION
To the latest as of today. A user was experiencing a bug with the previous version(s). If we find ourselves doing this too often we can switch to `~=1.0`.