### PR TITLE
Refactor ArrayIterator for random access and clearer const/non-const

### DIFF
--- a/dwave/optimization/include/dwave-optimization/array.hpp
+++ b/dwave/optimization/include/dwave-optimization/array.hpp
@@ -277,6 +277,11 @@ class ArrayIteratorImpl_ {
             : ptr_(ptr),
               mask_(nullptr),
               shape_((ndim >= 1) ? std::make_unique<ShapeInfo>(ndim, shape, strides) : nullptr) {}
+    ArrayIteratorImpl_(value_type* ptr, std::span<const ssize_t> shape,
+                       std::span<const ssize_t> strides)
+            : ArrayIteratorImpl_(ptr, shape.size(), shape.data(), strides.data()) {
+        assert(shape.size() == strides.size());
+    }
 
     // Both the copy and move operator using the copy-and-swap idiom
     ArrayIteratorImpl_& operator=(ArrayIteratorImpl_ other) noexcept {
@@ -545,11 +550,17 @@ class ArrayIteratorImpl_ {
 using ArrayIterator = ArrayIteratorImpl_<false>;
 using ConstArrayIterator = ArrayIteratorImpl_<true>;
 
+static_assert(std::forward_iterator<ArrayIterator>);
+static_assert(std::bidirectional_iterator<ArrayIterator>);
 static_assert(std::forward_iterator<ConstArrayIterator>);
 static_assert(std::bidirectional_iterator<ConstArrayIterator>);
 // todo: random access iterator?
 
-// unique_ptr is not trivial so the best we can have for ConstArrayIterator is nothrow
+// unique_ptr is not trivial so the best we can have for ArrayIterator is nothrow
+static_assert(std::is_nothrow_copy_constructible<ArrayIterator>::value);
+static_assert(std::is_nothrow_move_constructible<ArrayIterator>::value);
+static_assert(std::is_nothrow_copy_assignable<ArrayIterator>::value);
+static_assert(std::is_nothrow_move_assignable<ArrayIterator>::value);
 static_assert(std::is_nothrow_copy_constructible<ConstArrayIterator>::value);
 static_assert(std::is_nothrow_move_constructible<ConstArrayIterator>::value);
 static_assert(std::is_nothrow_copy_assignable<ConstArrayIterator>::value);

--- a/dwave/optimization/src/nodes/mathematical.cpp
+++ b/dwave/optimization/src/nodes/mathematical.cpp
@@ -392,11 +392,12 @@ struct InverseOp<std::multiplies<double>> {
 };
 
 struct NaryOpNodeData : public ArrayNodeStateData {
-    explicit NaryOpNodeData(std::vector<double> values, std::vector<ConstArrayIterator> iterators)
+    explicit NaryOpNodeData(std::vector<double> values,
+                            std::vector<Array::const_iterator> iterators)
             : ArrayNodeStateData(std::move(values)), iterators(std::move(iterators)) {}
 
     // used to avoid reallocating memory for predecessor iterators every propagation
-    std::vector<ConstArrayIterator> iterators;
+    std::vector<Array::const_iterator> iterators;
 };
 
 template <class BinaryOp>
@@ -591,7 +592,7 @@ void NaryOpNode<BinaryOp>::initialize_state(State& state) const {
 
     values.reserve(size());
 
-    std::vector<ConstArrayIterator> iterators;
+    std::vector<Array::const_iterator> iterators;
     for (const Array* array_ptr : operands_) {
         iterators.push_back(array_ptr->begin(state));
     }
@@ -945,11 +946,11 @@ double PartialReduceNode<BinaryOp>::reduce(const State& state, ssize_t index) co
 
     // 3. We create an iterator that starts from index just found and iterates through the axis we
     // are reducing over
-    ConstArrayIterator begin =
-            ConstArrayIterator(array_ptr_->buff(state) + start_idx, 1, &array_ptr_->shape()[axis],
+    const_iterator begin =
+            const_iterator(array_ptr_->buff(state) + start_idx, 1, &array_ptr_->shape()[axis],
                           &array_ptr_->strides()[axis]);
 
-    ConstArrayIterator end = begin + array_ptr_->shape(state)[axis];
+    const_iterator end = begin + array_ptr_->shape(state)[axis];
 
     // Get the initial value
     double init;

--- a/dwave/optimization/src/nodes/mathematical.cpp
+++ b/dwave/optimization/src/nodes/mathematical.cpp
@@ -392,11 +392,11 @@ struct InverseOp<std::multiplies<double>> {
 };
 
 struct NaryOpNodeData : public ArrayNodeStateData {
-    explicit NaryOpNodeData(std::vector<double> values, std::vector<ArrayIterator> iterators)
+    explicit NaryOpNodeData(std::vector<double> values, std::vector<ConstArrayIterator> iterators)
             : ArrayNodeStateData(std::move(values)), iterators(std::move(iterators)) {}
 
     // used to avoid reallocating memory for predecessor iterators every propagation
-    std::vector<ArrayIterator> iterators;
+    std::vector<ConstArrayIterator> iterators;
 };
 
 template <class BinaryOp>
@@ -591,7 +591,7 @@ void NaryOpNode<BinaryOp>::initialize_state(State& state) const {
 
     values.reserve(size());
 
-    std::vector<ArrayIterator> iterators;
+    std::vector<ConstArrayIterator> iterators;
     for (const Array* array_ptr : operands_) {
         iterators.push_back(array_ptr->begin(state));
     }
@@ -945,11 +945,11 @@ double PartialReduceNode<BinaryOp>::reduce(const State& state, ssize_t index) co
 
     // 3. We create an iterator that starts from index just found and iterates through the axis we
     // are reducing over
-    ArrayIterator begin =
-            ArrayIterator(array_ptr_->buff(state) + start_idx, 1, &array_ptr_->shape()[axis],
+    ConstArrayIterator begin =
+            ConstArrayIterator(array_ptr_->buff(state) + start_idx, 1, &array_ptr_->shape()[axis],
                           &array_ptr_->strides()[axis]);
 
-    ArrayIterator end = begin + array_ptr_->shape(state)[axis];
+    ConstArrayIterator end = begin + array_ptr_->shape(state)[axis];
 
     // Get the initial value
     double init;

--- a/releasenotes/notes/iterator-refactor-7c21470cc6a232c9.yaml
+++ b/releasenotes/notes/iterator-refactor-7c21470cc6a232c9.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - Add ``const`` and non-``const`` versions of C++ array iterators.
+  - Make C++ array iterators random access iterators. Previously they were bidirectional iterators.
+upgrade:
+  - |
+    The ``dwave::optimization::ArrayIterator`` class has been moved. It can now
+    be found as a nested class in the ``Array``,
+    i.e. ``dwave::optimization::Array::const_iterator``.

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -35,7 +35,7 @@ TEST_CASE("ArrayIterator and ConstArrayIterator") {
         WHEN("We use a strided ArrayIterator to mutate every other value") {
             std::vector<ssize_t> shape{5};
             std::vector<ssize_t> strides{2 * sizeof(double)};
-            auto it = ArrayIterator(values.data(), 1, shape.data(), strides.data());
+            auto it = ArrayIterator(values.data(), shape, strides);
 
             for (auto end = it + 5; it != end; ++it) {
                 *it = -5;

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -28,7 +28,25 @@ TEST_CASE("Test SizeInfo") {
     CHECK(SizeInfo(5) == 5);
 }
 
-TEST_CASE("ConstArrayIterator") {
+TEST_CASE("ArrayIterator and ConstArrayIterator") {
+    GIVEN("A std::vector<double>{0, 1, 2, 3, 4, 5, 6, 7, 8}") {
+        auto values = std::vector<double>{0, 1, 2, 3, 4, 5, 6, 7, 8};
+
+        WHEN("We use a strided ArrayIterator to mutate every other value") {
+            std::vector<ssize_t> shape{5};
+            std::vector<ssize_t> strides{2 * sizeof(double)};
+            auto it = ArrayIterator(values.data(), 1, shape.data(), strides.data());
+
+            for (auto end = it + 5; it != end; ++it) {
+                *it = -5;
+            }
+
+            THEN("The vector is edited") {
+                CHECK(std::ranges::equal(values, std::vector{-5, 1, -5, 3, -5, 5, -5, 7, -5}));
+            }
+        }
+    }
+
     GIVEN("A std::vector<double>{0, 1, 2, 3, 4, 5, 6, 7, 8}") {
         auto values = std::vector<double>{0, 1, 2, 3, 4, 5, 6, 7, 8};
 

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -28,12 +28,12 @@ TEST_CASE("Test SizeInfo") {
     CHECK(SizeInfo(5) == 5);
 }
 
-TEST_CASE("ArrayIterator") {
+TEST_CASE("ConstArrayIterator") {
     GIVEN("A std::vector<double>{0, 1, 2, 3, 4, 5, 6, 7, 8}") {
         auto values = std::vector<double>{0, 1, 2, 3, 4, 5, 6, 7, 8};
 
-        WHEN("We make an ArrayIterator from values.data()") {
-            auto it = ArrayIterator(values.data());
+        WHEN("We make an ConstArrayIterator from values.data()") {
+            auto it = ConstArrayIterator(values.data());
 
             THEN("It behaves like a contiguous iterator") {
                 CHECK(*it == 0);
@@ -48,15 +48,15 @@ TEST_CASE("ArrayIterator") {
                 CHECK(*(it + 3) == 3);
                 CHECK(*(it + 4) == 4);
 
-                CHECK(ArrayIterator(values.data() + 4) - it == 4);
-                CHECK(it - ArrayIterator(values.data() + 4) == -4);
+                CHECK(ConstArrayIterator(values.data() + 4) - it == 4);
+                CHECK(it - ConstArrayIterator(values.data() + 4) == -4);
             }
         }
 
         WHEN("We specify a shape and strides defining a subset of the values") {
             std::vector<ssize_t> shape{5};
             std::vector<ssize_t> strides{2 * sizeof(double)};
-            auto it = ArrayIterator(values.data(), 1, shape.data(), strides.data());
+            auto it = ConstArrayIterator(values.data(), 1, shape.data(), strides.data());
 
             THEN("It behaves like a strided iterator") {
                 CHECK(*it == 0);
@@ -72,7 +72,7 @@ TEST_CASE("ArrayIterator") {
                 CHECK(*(it + 4) == 8);
 
                 // this is past-the-end, but a proxy for END
-                CHECK(it + 5 == ArrayIterator(values.data() + 10));
+                CHECK(it + 5 == ConstArrayIterator(values.data() + 10));
             }
 
             THEN("We can decrement an advanced iterator") {
@@ -89,15 +89,16 @@ TEST_CASE("ArrayIterator") {
             std::vector<ssize_t> shape{Array::DYNAMIC_SIZE, 2};
             std::vector<ssize_t> strides{4 * sizeof(double), sizeof(double)};
 
-            auto it = ArrayIterator(values.data(), 2, shape.data(), strides.data());
+            auto it = ConstArrayIterator(values.data(), 2, shape.data(), strides.data());
 
             THEN("We can calculate the distance between two pointers in the strided array") {
-                const auto end = ArrayIterator(values.data() + 4, 2, shape.data(), strides.data());
+                const auto end =
+                        ConstArrayIterator(values.data() + 4, 2, shape.data(), strides.data());
                 CHECK(end - it == 2);
             }
 
             THEN("The distance between two iterators with different strides is asymmetric") {
-                const auto end = ArrayIterator(values.data() + 4);  // contiguous iterator
+                const auto end = ConstArrayIterator(values.data() + 4);  // contiguous iterator
 
                 CHECK(end - it == 2);   // 2 strides steps
                 CHECK(it - end == -4);  // 4 contiguous steps.
@@ -113,10 +114,10 @@ TEST_CASE("ArrayIterator") {
         }
 
         WHEN("We create a mask over the array and create a masked iterator") {
-            auto mask = std::vector<double>{true, false, false, true, false, false, false, true, false};
+            auto mask = std::vector<double>{1, 0, 0, 1, 0, 0, 0, 1, 0};
             const double fill = 6;
 
-            auto it = ArrayIterator(values.data(), mask.data(), &fill);
+            auto it = ConstArrayIterator(values.data(), mask.data(), &fill);
 
             THEN("It behaves like a contiguous iterator") {
                 CHECK(*it == 6);  // masked
@@ -135,8 +136,8 @@ TEST_CASE("ArrayIterator") {
 
         THEN("We can construct another vector using reverse iterators") {
             auto copy = std::vector<double>();
-            copy.assign(std::reverse_iterator(ArrayIterator(values.data()) + 6),
-                        std::reverse_iterator(ArrayIterator(values.data())));
+            copy.assign(std::reverse_iterator(ConstArrayIterator(values.data()) + 6),
+                        std::reverse_iterator(ConstArrayIterator(values.data())));
             CHECK(std::ranges::equal(copy, std::vector<double>{5, 4, 3, 2, 1, 0}));
         }
     }

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -37,6 +37,8 @@ TEST_CASE("ArrayIterator and ConstArrayIterator") {
     using ArrayIterator = typename Array::iterator;
     using ConstArrayIterator = typename Array::const_iterator;
 
+    static_assert(std::is_nothrow_constructible<ArrayIterator>::value);
+    static_assert(std::is_nothrow_constructible<ConstArrayIterator>::value);
     static_assert(std::is_nothrow_copy_constructible<ArrayIterator>::value);
     static_assert(std::is_nothrow_move_constructible<ArrayIterator>::value);
     static_assert(std::is_nothrow_copy_assignable<ArrayIterator>::value);
@@ -48,6 +50,19 @@ TEST_CASE("ArrayIterator and ConstArrayIterator") {
 
     static_assert(std::random_access_iterator<ArrayIterator>);
     static_assert(std::random_access_iterator<ConstArrayIterator>);
+
+    // Both iterators are input iterators
+    static_assert(std::input_iterator<ArrayIterator>);
+    static_assert(std::input_iterator<ConstArrayIterator>);
+
+    // But only ArrayIterator is an output iterator.
+    static_assert(std::output_iterator<ArrayIterator, double>);
+    static_assert(!std::output_iterator<ConstArrayIterator, double>);
+
+    GIVEN("A default-constructed Array iterator") {
+        auto it = ArrayIterator();
+        CHECK(it.get() == nullptr);
+    }
 
     GIVEN("A buffer encoding 2d array [[0, 1, 2], [3, 4, 5]]") {
         auto values = std::array<double, 6>{0, 1, 2, 3, 4, 5};


### PR DESCRIPTION
Almost a complete refactor of `ArrayIterator`. Highlights:
* `const` and non-`const` iterators.
* Moved the implementation to be a nested class inside `Array`.
* Made it a random access iterator.