### PR TITLE
Implement `BinaryOpNode::sizeinfo()`

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
@@ -103,6 +103,8 @@ class BinaryOpNode : public ArrayOutputMixin<ArrayNode> {
 
     ssize_t size_diff(const State& state) const override;
 
+    SizeInfo sizeinfo() const override;
+
     void commit(State& state) const override;
     void revert(State& state) const override;
     void initialize_state(State& state) const override;

--- a/dwave/optimization/src/nodes/mathematical.cpp
+++ b/dwave/optimization/src/nodes/mathematical.cpp
@@ -360,6 +360,30 @@ ssize_t BinaryOpNode<BinaryOp>::size_diff(const State& state) const {
     return data_ptr<ArrayNodeStateData>(state)->size_diff();
 }
 
+template <class BinaryOp>
+SizeInfo BinaryOpNode<BinaryOp>::sizeinfo() const {
+    if (!dynamic()) return SizeInfo(size());
+
+    const Array* lhs_ptr = operands_[0];
+    const Array* rhs_ptr = operands_[1];
+
+    if (lhs_ptr->dynamic() && rhs_ptr->dynamic()) {
+        // not (yet) possible for both predecessors to be dynamic
+        assert(false && "not implemeted");
+        unreachable();
+    } else if (lhs_ptr->dynamic()) {
+        assert(rhs_ptr->size() == 1);
+        return SizeInfo(lhs_ptr);
+    } else if (rhs_ptr->dynamic()) {
+        assert(lhs_ptr->size() == 1);
+        return SizeInfo(rhs_ptr);
+    }
+
+    // not possible for us to be dynamic and none of our predecessors to be
+    assert(false && "not implemeted");
+    unreachable();
+}
+
 // Uncommented are the tested specializations
 template class BinaryOpNode<std::plus<double>>;
 template class BinaryOpNode<std::minus<double>>;

--- a/releasenotes/notes/BinaryOpNode-sizeinfo-ac3a01130d77efcc.yaml
+++ b/releasenotes/notes/BinaryOpNode-sizeinfo-ac3a01130d77efcc.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - Implement C++ ``BinaryOpNode::sizeinfo()`` overload.
+fixes:
+  - |
+    Fix serializing models with binary operations over dynamic predecessors.
+    Previously it was not possible to estimate the state size which caused
+    serialization to fail.

--- a/tests/cpp/nodes/mathematical/test_binaryop.cpp
+++ b/tests/cpp/nodes/mathematical/test_binaryop.cpp
@@ -290,6 +290,10 @@ TEST_CASE("BinaryOpNode - LessEqualNode") {
         THEN("We have the shape we expect") {
             CHECK(std::ranges::equal(le_ptr->shape(), std::vector{-1}));
             CHECK(std::ranges::equal(ge_ptr->shape(), std::vector{-1}));
+
+            // derives its size from the dynamic node
+            CHECK(le_ptr->sizeinfo() == SizeInfo(y_ptr));
+            CHECK(ge_ptr->sizeinfo() == SizeInfo(y_ptr));
         }
 
         // let's also toss an ArrayValidationNode on there to do most of the


### PR DESCRIPTION
This incidentally fixes a serialization bug.

https://github.com/dwavesystems/dwave-optimization/pull/168 has a broader fix, but this one is simple enough that I think it makes sense to do separately.