### PR TITLE
Update README's Contributing section with Release Note subsection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,3 +120,23 @@ has guidelines for contributing to Ocean packages.
 
 ``dwave-optimization`` includes some formatting customization in the
 `.clang-format <.clang-format>`_ and `setup.cfg <setup.cfg>`_ files.
+
+Release Notes
+~~~~~~~~~~~~~
+
+``dwave-optimization`` makes use of `reno <https://docs.openstack.org/reno/>`_
+to manage its release notes.
+
+When making a contribution to ``dwave-optimization`` that will affect users,
+create a new release note file by running
+
+.. code-block:: bash
+
+    reno new your-short-descriptor-here
+
+You can then edit the file created under ``releasenotes/notes/``.
+Remove any sections not relevant to your changes.
+Commit the file along with your changes.
+
+See reno's `user guide <https://docs.openstack.org/reno/latest/user/usage.html>`_
+for details.


### PR DESCRIPTION
This way I can stop [linking dimod](https://github.com/dwavesystems/dwave-optimization/pull/169#issuecomment-2483516712).