### PR TITLE
Remove old distutils file headers

### DIFF
--- a/dwave/optimization/libcpp/array.pxd
+++ b/dwave/optimization/libcpp/array.pxd
@@ -1,7 +1,4 @@
-# distutils: language = c++
-# distutils: include_dirs = dwave/optimization/include/
-
-# Copyright 2024 D-Wave Systems Inc.
+# Copyright 2024 D-Wave
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/dwave/optimization/libcpp/graph.pxd
+++ b/dwave/optimization/libcpp/graph.pxd
@@ -1,7 +1,4 @@
-# distutils: language = c++
-# distutils: include_dirs = dwave/optimization/include/
-
-# Copyright 2024 D-Wave Systems Inc.
+# Copyright 2024 D-Wave
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/dwave/optimization/libcpp/nodes.pxd
+++ b/dwave/optimization/libcpp/nodes.pxd
@@ -1,7 +1,4 @@
-# distutils: language = c++
-# distutils: include_dirs = dwave/optimization/include/
-
-# Copyright 2024 D-Wave Systems Inc.
+# Copyright 2024 D-Wave
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/dwave/optimization/libcpp/state.pxd
+++ b/dwave/optimization/libcpp/state.pxd
@@ -1,7 +1,4 @@
-# distutils: language = c++
-# distutils: include_dirs = dwave/optimization/include/
-
-# Copyright 2024 D-Wave Systems Inc.
+# Copyright 2024 D-Wave
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/dwave/optimization/symbols.pxd
+++ b/dwave/optimization/symbols.pxd
@@ -1,6 +1,4 @@
-# distutils: language = c++
-
-# Copyright 2024 D-Wave Systems Inc.
+# Copyright 2024 D-Wave
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -1,6 +1,4 @@
-# distutils: language = c++
-
-# Copyright 2024 D-Wave Systems Inc.
+# Copyright 2024 D-Wave
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.


### PR DESCRIPTION
`distutils` is long-since deprecated and we use `meson` to build our files now anyway.