### PR TITLE
Flatten the docs for Model, State, and mathematical functions

### DIFF
--- a/docs/reference/math.rst
+++ b/docs/reference/math.rst
@@ -7,20 +7,4 @@ Mathematical Functions
 .. currentmodule:: dwave.optimization
 
 .. automodule:: dwave.optimization.mathematical
-
-.. autosummary::
-   :toctree: generated/
-
-   ~add
-   ~concatenate
-   ~divide
-   ~logical
-   ~logical_and
-   ~logical_or
-   ~logical_not
-   ~logical_xor
-   ~maximum
-   ~minimum
-   ~mod
-   ~multiply
-   ~where
+    :members:

--- a/docs/reference/models.rst
+++ b/docs/reference/models.rst
@@ -18,60 +18,9 @@ Model Class
 -----------
 
 .. autoclass:: Model
-
-Model Attributes 
-----------------
-
-.. autosummary::
-    :toctree: generated/
-
-    ~Model.objective
-    ~Model.states
-
-Model Primitives  
-----------------
-
-Instantiation of the model's decision (and constant) symbols. 
-For the full list of supported symbols, see the :ref:`optimization_symbols`
-page.
-
-.. autosummary::
-    :toctree: generated/
-
-    ~Model.binary
-    ~Model.constant
-    ~Model.disjoint_bit_sets
-    ~Model.disjoint_lists
-    ~Model.integer
-    ~Model.list
-    ~Model.set
-
-Model Methods
--------------
-
-.. autosummary::
-    :toctree: generated/
-
-    ~Model.add_constraint
-    ~Model.decision_state_size
-    ~Model.from_file
-    ~Model.into_file
-    ~Model.is_locked
-    ~Model.iter_constraints
-    ~Model.iter_decisions
-    ~Model.iter_symbols
-    ~Model.lock
-    ~Model.minimize
-    ~Model.num_constraints
-    ~Model.num_decisions
-    ~Model.num_nodes
-    ~Model.num_symbols
-    ~Model.quadratic_model
-    ~Model.remove_unused_symbols
-    ~Model.state_size
-    ~Model.to_file
-    ~Model.to_networkx
-    ~Model.unlock
+    :members:
+    :inherited-members:
+    :member-order: bysource
    
 States Class
 ------------
@@ -79,18 +28,6 @@ States Class
 .. currentmodule:: dwave.optimization.states
 
 .. autoclass:: States
-
-States Methods
---------------
-
-.. autosummary::
-   :toctree: generated/
-
-   ~States.clear
-   ~States.from_file
-   ~States.from_future
-   ~States.into_file
-   ~States.resize
-   ~States.resolve
-   ~States.size
-   ~States.to_file
+    :members:
+    :inherited-members:
+    :member-order: bysource

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -532,7 +532,7 @@ def sqrt(x: ArraySymbol) -> SquareRoot:
         >>> model.states.resize(1)
         >>> with model.lock():
         ...     print(sqrt_x.state())
-        4
+        4.0
     See Also:
         :class:`~dwave.optimization.symbols.SquareRoot`: equivalent symbol.
     """

--- a/dwave/optimization/model.py
+++ b/dwave/optimization/model.py
@@ -244,7 +244,7 @@ class Model(_Graph):
             >>> model = Model()
             >>> b = model.binary()
             >>> model.add_constraint(b) # doctest: +ELLIPSIS
-            <dwave.optimization.BinaryVariable at ...>
+            <dwave.optimization.symbols.BinaryVariable at ...>
             >>> model.states.resize(2)
             >>> b.set_state(0, 1) # Feasible
             >>> b.set_state(1, 0) # Infeasible


### PR DESCRIPTION
The main benefit is that new methods etc are automatically incorporated into the docs.

Similar to https://github.com/dwavesystems/dwave-optimization/pull/73, except for the other classes.