### PR TITLE
Mark Decision::update() and ConstantNode::update() as noreturn

### DIFF
--- a/dwave/optimization/include/dwave-optimization/graph.hpp
+++ b/dwave/optimization/include/dwave-optimization/graph.hpp
@@ -348,7 +348,12 @@ NodeType* Graph::emplace_node(Args&&... args) {
 }
 
 class ArrayNode: public Array, public virtual Node {};
-class DecisionNode: public Decision, public virtual Node {
+class DecisionNode : public Decision, public virtual Node {
+ public:
+    // Decisions don't have predecessors so no one should be calling update().
+    // Always throws a logic_error.
+    [[noreturn]] void update(State& state, int index) const override;
+
  protected:
     // In general we do not allow decisions to be removed from models.
     bool removable() const override { return false; }

--- a/dwave/optimization/include/dwave-optimization/nodes/collections.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/collections.hpp
@@ -57,10 +57,6 @@ class CollectionNode : public ArrayOutputMixin<ArrayNode>, public DecisionNode {
     void commit(State&) const override;
     void revert(State&) const override;
 
-    void update [[noreturn]] (State&, int) const override {
-        throw std::logic_error("update() called on a decisison variable");
-    }
-
     // Exchange the values in the list at index i and index j
     // Note that for variable-length collections these indices might not
     // be in the "visible" range.
@@ -125,10 +121,6 @@ class DisjointBitSetsNode : public DecisionNode {
 
     void commit(State&) const override;
     void revert(State&) const override;
-
-    void update [[noreturn]] (State&, int) const override {
-        throw std::logic_error("update() called on a decisison variable");
-    }
 
     // Overloads required by the Decision ABC
 
@@ -211,10 +203,6 @@ class DisjointListsNode : public DecisionNode {
     void commit(State&) const override;
     void revert(State&) const override;
     void propagate(State&) const override;
-
-    void update [[noreturn]] (State&, int) const override {
-        throw std::logic_error("update() called on a decisison variable");
-    }
 
     // Overloads required by the Decision ABC
 

--- a/dwave/optimization/include/dwave-optimization/nodes/constants.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/constants.hpp
@@ -96,6 +96,10 @@ class ConstantNode : public ArrayOutputMixin<ArrayNode> {
     // This node never needs to update its successors
     void propagate(State&) const noexcept override {}
 
+    // Constants don't have predecessors so no one should be calling update().
+    // Always throws a logic_error.
+    [[noreturn]] void update(State& state, int index) const override;
+
     // Never any changes to revert or commit
     void commit(State&) const noexcept override {}
     void revert(State&) const noexcept override {}

--- a/dwave/optimization/src/graph.cpp
+++ b/dwave/optimization/src/graph.cpp
@@ -371,4 +371,10 @@ void Node::initialize_state(State& state) const {
     state[topological_index_] = std::make_unique<NodeStateData>();
 }
 
+// DecisionNode ***************************************************************
+
+[[noreturn]] void DecisionNode::update(State& state, int index) const {
+    throw std::logic_error("update() called on a decisison variable");
+}
+
 }  // namespace dwave::optimization

--- a/dwave/optimization/src/nodes/constants.cpp
+++ b/dwave/optimization/src/nodes/constants.cpp
@@ -110,4 +110,8 @@ double ConstantNode::min() const {
     return buffer_stats_->min;
 }
 
+void ConstantNode::update(State& state, int index) const {
+    throw std::logic_error("update() called on a constant");
+}
+
 }  // namespace dwave::optimization


### PR DESCRIPTION
A slight tidying of some `::update()` methods. IMO it makes sense to do this as an intermediate step while still contemplating https://github.com/dwavesystems/dwave-optimization/issues/188.