### PR TITLE
Fix for issue 190

### DIFF
--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -146,12 +146,14 @@ def concatenate(array_likes : typing.Union[collections.abc.Iterable, ArraySymbol
     if isinstance(array_likes, ArraySymbol):
         return array_likes
 
-    if isinstance(array_likes, collections.abc.Sequence) and (0 < len(array_likes)):
-        if isinstance(array_likes[0], ArraySymbol):
-            if len(array_likes) == 1:
-                return array_likes[0]
+    if (isinstance(array_likes, collections.abc.Iterable)
+        and isinstance(array_likes, collections.abc.Sized)
+        and (0 < len(array_likes))):
 
-            return Concatenate(tuple(array_likes), axis)
+        if len(array_likes) == 1:
+            return array_likes[0]
+
+        return Concatenate(tuple(array_likes), axis)
 
     raise TypeError("concatenate takes one or more ArraySymbol as input")
 

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -778,6 +778,39 @@ class TestConcatenate(utils.SymbolTests):
         model.lock()
         yield c
 
+    def test_simple_concatenate(self):
+        model = Model()
+        with self.subTest("Concatenate ndarray of constants returns ndarray"):
+            A = [model.constant(0), model.constant(1)]
+            self.assertIsInstance(
+                dwave.optimization.concatenate(np.asarray((A,), dtype=object)),
+                np.ndarray
+            )
+        with self.subTest("Concatenate ndarray of binary returns Concatenate"):
+            A = [model.binary(5), model.binary(5)]
+            self.assertIsInstance(
+                dwave.optimization.concatenate(np.asarray(tuple(A), dtype=object)),
+                dwave.optimization.symbols.Concatenate
+            )
+        with self.subTest("Concatenate ArraySymbol returns ArraySymbol"):
+            self.assertIsInstance(
+                dwave.optimization.concatenate(model.constant(5)),
+                dwave.optimization.model.ArraySymbol
+            )
+            self.assertIsInstance(
+                dwave.optimization.concatenate(model.binary(5)),
+                dwave.optimization.model.ArraySymbol
+            )
+        with self.subTest("Concatenate Iterable and Sized of length 1 returns ArraySymbol"):
+            self.assertIsInstance(
+                dwave.optimization.concatenate((model.binary(5), )),
+                dwave.optimization.model.ArraySymbol
+            )
+            self.assertIsInstance(
+                dwave.optimization.concatenate((model.constant(5),)),
+                dwave.optimization.model.ArraySymbol
+            )
+
     def test_errors(self):
         model = Model()
         with self.subTest("same number of dimensions"):

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -780,12 +780,6 @@ class TestConcatenate(utils.SymbolTests):
 
     def test_simple_concatenate(self):
         model = Model()
-        with self.subTest("Concatenate ndarray of constants returns ndarray"):
-            A = [model.constant(0), model.constant(1)]
-            self.assertIsInstance(
-                dwave.optimization.concatenate(np.asarray((A,), dtype=object)),
-                np.ndarray
-            )
         with self.subTest("Concatenate ndarray of binary returns Concatenate"):
             A = [model.binary(5), model.binary(5)]
             self.assertIsInstance(


### PR DESCRIPTION
`concatenate()` should handle a numpy object array of symbols