### PR TITLE
Format all C++ files with clang-format

### DIFF
--- a/dwave/optimization/include/dwave-optimization/array.hpp
+++ b/dwave/optimization/include/dwave-optimization/array.hpp
@@ -623,7 +623,7 @@ class Array {
                     // current location in the struct returned by it.
                     // Unfortunately std::div() is not templated, but overloaded,
                     // so we use decltype instead.
-                    decltype(std::div(ssize_t(), ssize_t())) qr{ .quot = n, .rem = 0 };
+                    decltype(std::div(ssize_t(), ssize_t())) qr{.quot = n, .rem = 0};
 
                     ssize_t axis = this->ndim - 1;
                     for (; axis >= 1; --axis) {

--- a/dwave/optimization/include/dwave-optimization/graph.hpp
+++ b/dwave/optimization/include/dwave-optimization/graph.hpp
@@ -316,7 +316,7 @@ NodeType* Graph::emplace_node(Args&&... args) {
     return ptr;  // return the observing pointer
 }
 
-class ArrayNode: public Array, public virtual Node {};
+class ArrayNode : public Array, public virtual Node {};
 class DecisionNode : public Decision, public virtual Node {
  public:
     // Decisions don't have predecessors so no one should be calling update().

--- a/dwave/optimization/include/dwave-optimization/nodes/constants.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/constants.hpp
@@ -73,9 +73,7 @@ class ConstantNode : public ArrayOutputMixin<ArrayNode> {
     // Overloads needed by the Array ABC **************************************
 
     // There are never any updates to propagate
-    std::span<const Update> diff(const State& state) const noexcept override {
-        return {};
-    }
+    std::span<const Update> diff(const State& state) const noexcept override { return {}; }
 
     // Whether the values in the array can be interpreted as integers.
     // Returns ``true`` for an empty array. This has the slightly odd effect of

--- a/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
@@ -29,7 +29,7 @@ class ConcatenateNode : public ArrayOutputMixin<ArrayNode> {
  public:
     explicit ConcatenateNode(std::span<ArrayNode*> array_ptrs, ssize_t axis);
     explicit ConcatenateNode(std::ranges::contiguous_range auto&& array_ptrs, ssize_t axis)
-               : ConcatenateNode(std::span<ArrayNode*>(array_ptrs), axis) {}
+            : ConcatenateNode(std::span<ArrayNode*>(array_ptrs), axis) {}
 
     double const* buff(const State& state) const override;
     void commit(State& state) const override;
@@ -61,7 +61,6 @@ class ReshapeNode : public ArrayOutputMixin<ArrayNode> {
     // pointer to the "array" part of the predecessor
     const Array* array_ptr_;
 };
-
 
 class SizeNode : public ScalarOutputMixin<ArrayNode> {
  public:

--- a/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
@@ -58,22 +58,22 @@ struct min {
 template <class T>
 struct modulus {};
 
-template <>  
-struct modulus<double> {  
-    constexpr double operator()(const double& x, const double& y) const {  
-        // Copy numpy behavior and return 0 for `x % 0`  
-        if (y == 0) {  
-            return 0;  
-        }  
-        double result = std::fmod(x, y);  
-    
+template <>
+struct modulus<double> {
+    constexpr double operator()(const double& x, const double& y) const {
+        // Copy numpy behavior and return 0 for `x % 0`
+        if (y == 0) {
+            return 0;
+        }
+        double result = std::fmod(x, y);
+
         if ((std::signbit(x) != std::signbit(y)) && (result != 0)) {
-             // Make result consistent with numpy for different-sign arguments  
-            result += y;  
+            // Make result consistent with numpy for different-sign arguments
+            result += y;
         }
 
         return result;
-    }  
+    }
 };
 
 template <class T>
@@ -272,7 +272,6 @@ class PartialReduceNode : public ArrayOutputMixin<ArrayNode> {
 
     // Calculate the output value based on the state of the predecessor
     double reduce(const State& state, ssize_t index) const;
-
 };
 
 using PartialSumNode = PartialReduceNode<std::plus<double>>;

--- a/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
@@ -54,7 +54,7 @@ class NumberNode : public ArrayOutputMixin<ArrayNode>, public DecisionNode {
     void initialize_state(State& state, std::vector<double>&& number_data) const;
 
     // Initialize a state from an existing container, making a copy.
-    template<std::ranges::range R>
+    template <std::ranges::range R>
     void initialize_state(State& state, const R& values) const {
         return initialize_state(state, std::vector<double>(values.begin(), values.end()));
     }

--- a/dwave/optimization/include/dwave-optimization/nodes/testing.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/testing.hpp
@@ -90,7 +90,7 @@ class DynamicArrayTestingNode : public ArrayOutputMixin<ArrayNode>, public Decis
     void grow(State& state, std::initializer_list<double> values) const;
 
     // Grow the array by one row with random values.
-    template<std::uniform_random_bit_generator Generator>
+    template <std::uniform_random_bit_generator Generator>
     void grow(State& state, Generator& rng) const {
         // generate a new row randomly
         assert(ndim() > 0);
@@ -110,7 +110,7 @@ class DynamicArrayTestingNode : public ArrayOutputMixin<ArrayNode>, public Decis
     void set(State& state, ssize_t index, double value) const;
 
     // Set the value at a random index to a random value.
-    template<std::uniform_random_bit_generator Generator>
+    template <std::uniform_random_bit_generator Generator>
     void set(State& state, Generator& rng) const {
         const ssize_t size = this->size(state);
         assert(size >= 0);  // should always be true

--- a/dwave/optimization/src/array.cpp
+++ b/dwave/optimization/src/array.cpp
@@ -88,8 +88,7 @@ bool SizeInfo::operator==(const SizeInfo& other) const {
     if (this->array_ptr != other.array_ptr) return false;
 
     return (this->multiplier == other.multiplier && this->offset == other.offset &&
-            this->min.value_or(0) == other.min.value_or(0) &&
-            this->max == other.max);
+            this->min.value_or(0) == other.min.value_or(0) && this->max == other.max);
 }
 
 SizeInfo SizeInfo::substitute(ssize_t max_depth) const {
@@ -242,9 +241,7 @@ bool array_shape_equal(const Array* lhs_ptr, const Array* rhs_ptr) {
 
     return false;
 }
-bool array_shape_equal(const Array& lhs, const Array& rhs) {
-    return array_shape_equal(&lhs, &rhs);
-}
+bool array_shape_equal(const Array& lhs, const Array& rhs) { return array_shape_equal(&lhs, &rhs); }
 
 // We follow NumPy's broadcasting rules
 // See https://numpy.org/doc/stable/user/basics.broadcasting.html

--- a/dwave/optimization/src/graph.cpp
+++ b/dwave/optimization/src/graph.cpp
@@ -335,9 +335,9 @@ ssize_t Graph::remove_unused_nodes(bool ignore_listeners) {
     // Now walk backwards through the topologically sorted node list
     // removing any nodes with no successors that we haven't marked.
     for (auto& ptr : nodes_ | std::views::drop(num_decisions) | std::views::reverse) {
-        if (!ptr->removable()) continue;  // some nodes can never be removed
+        if (!ptr->removable()) continue;                // some nodes can never be removed
         if (ptr->topological_index_ == keep) continue;  // we marked these to keep
-        if (ptr->successors().size() > 0) continue;  // this node is used by other nodes
+        if (ptr->successors().size() > 0) continue;     // this node is used by other nodes
 
         // Remove ptr from its predecessor's successor vectors.
         // This very temporarily leaves the node in an invalid state, which is

--- a/dwave/optimization/src/nodes/mathematical.cpp
+++ b/dwave/optimization/src/nodes/mathematical.cpp
@@ -45,7 +45,9 @@ BinaryOpNode<BinaryOp>::BinaryOpNode(ArrayNode* a_ptr, ArrayNode* b_ptr)
         bool strictly_negative = rhs_ptr->min() < 0 && rhs_ptr->max() < 0;
         bool strictly_positive = rhs_ptr->min() > 0 && rhs_ptr->max() > 0;
         if (!strictly_negative && !strictly_positive) {
-            throw std::invalid_argument("Divide's denominator predecessor must be either strictly positive or strictly negative");
+            throw std::invalid_argument(
+                    "Divide's denominator predecessor must be either strictly positive or strictly "
+                    "negative");
         }
     }
 
@@ -786,7 +788,7 @@ std::vector<ssize_t> as_contiguous_strides(const std::span<const ssize_t> shape)
 }
 
 std::span<const ssize_t> nonempty(std::span<const ssize_t> span) {
-    if (span.empty()){
+    if (span.empty()) {
         throw std::invalid_argument("Input span should not be empty");
     }
     return span;
@@ -809,7 +811,7 @@ PartialReduceNode<BinaryOp>::PartialReduceNode(ArrayNode* node_ptr, std::span<co
 
     // Validate axes
     /// TODO: support negative axes
-    if (axes.size() != 1){
+    if (axes.size() != 1) {
         throw std::invalid_argument("Partial reduction support only one axis");
     }
 
@@ -836,9 +838,10 @@ PartialReduceNode<std::plus<double>>::PartialReduceNode(ArrayNode* array_ptr, co
         : PartialReduceNode(array_ptr, axis, 0) {}
 
 template <>
-PartialReduceNode<std::plus<double>>::PartialReduceNode(ArrayNode* array_ptr, std::span<const ssize_t> axes)
+PartialReduceNode<std::plus<double>>::PartialReduceNode(ArrayNode* array_ptr,
+                                                        std::span<const ssize_t> axes)
         : PartialReduceNode(array_ptr, nonempty(axes)[0], 0) {
-    if (axes.size() != 1){
+    if (axes.size() != 1) {
         throw std::invalid_argument("Partial sum supports only one axis");
     }
 }
@@ -854,7 +857,6 @@ PartialReduceNode<BinaryOp>::PartialReduceNode(ArrayNode* array_ptr, const ssize
 
 template <class BinaryOp>
 std::span<const ssize_t> PartialReduceNode<BinaryOp>::axes() const {
-
     // TODO: support multiple axes
     return std::span(axes_.get(), 1);
 }
@@ -1024,9 +1026,8 @@ double PartialReduceNode<BinaryOp>::reduce(const State& state, ssize_t index) co
 
     // 3. We create an iterator that starts from index just found and iterates through the axis we
     // are reducing over
-    const_iterator begin =
-            const_iterator(array_ptr_->buff(state) + start_idx, 1, &array_ptr_->shape()[axis],
-                          &array_ptr_->strides()[axis]);
+    const_iterator begin = const_iterator(array_ptr_->buff(state) + start_idx, 1,
+                                          &array_ptr_->shape()[axis], &array_ptr_->strides()[axis]);
 
     const_iterator end = begin + array_ptr_->shape(state)[axis];
 
@@ -1094,7 +1095,7 @@ struct ExtraData<std::logical_and<double>> {
     ssize_t old_num_zero = num_zero;
 };
 
-template<>
+template <>
 struct ExtraData<std::logical_or<double>> {
     explicit ExtraData(ssize_t num_nonzero) : num_nonzero(num_nonzero) {}
 
@@ -1175,8 +1176,7 @@ template <>
 ReduceNode<std::plus<double>>::ReduceNode(ArrayNode* array_ptr) : ReduceNode(array_ptr, 0) {}
 
 template <class BinaryOp>
-ReduceNode<BinaryOp>::ReduceNode(ArrayNode* array_ptr)
-        : init(), array_ptr_(array_ptr) {
+ReduceNode<BinaryOp>::ReduceNode(ArrayNode* array_ptr) : init(), array_ptr_(array_ptr) {
     if (array_ptr_->dynamic()) {
         throw std::invalid_argument(
                 "cannot do a reduction on a dynamic array with an operation that has no identity "
@@ -1337,10 +1337,10 @@ double ReduceNode<BinaryOp>::max() const {
 
         // more than one element
         return std::max({
-            init * std::pow(low, size),
-            init * std::pow(high, size),
-            init * low * std::pow(high, size - 1),
-            init * high * std::pow(low, size - 1),
+                init * std::pow(low, size),
+                init * std::pow(high, size),
+                init * low * std::pow(high, size - 1),
+                init * high * std::pow(low, size - 1),
         });
     }
     if constexpr (std::is_same<BinaryOp, std::plus<double>>::value) {
@@ -1424,10 +1424,10 @@ double ReduceNode<BinaryOp>::min() const {
 
         // more than one element
         return std::min({
-            init * std::pow(low, size),
-            init * std::pow(high, size),
-            init * low * std::pow(high, size - 1),
-            init * high * std::pow(low, size - 1),
+                init * std::pow(low, size),
+                init * std::pow(high, size),
+                init * low * std::pow(high, size - 1),
+                init * high * std::pow(low, size - 1),
         });
     }
     if constexpr (std::is_same<BinaryOp, std::plus<double>>::value) {

--- a/dwave/optimization/src/nodes/quadratic_model.cpp
+++ b/dwave/optimization/src/nodes/quadratic_model.cpp
@@ -13,6 +13,7 @@
 //    limitations under the License.
 
 #include "dwave-optimization/nodes/quadratic_model.hpp"
+
 #include "dwave-optimization/utils.hpp"
 
 namespace dwave::optimization {

--- a/tests/cpp/nodes/mathematical/test_binaryop.cpp
+++ b/tests/cpp/nodes/mathematical/test_binaryop.cpp
@@ -12,8 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
 #include "catch2/catch_template_test_macros.hpp"
+#include "catch2/catch_test_macros.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
@@ -24,13 +24,13 @@
 
 namespace dwave::optimization {
 
-// NOTE: divides test is disabled because the template-tests have invalid denominators. 
-TEMPLATE_TEST_CASE("BinaryOpNode", "", 
-                    // std::divides<double>, 
-                    std::equal_to<double>, std::less_equal<double>,
-                   std::plus<double>, std::minus<double>, functional::modulus<double>,
-                   std::multiplies<double>, functional::max<double>, functional::min<double>,
-                   std::logical_and<double>, std::logical_or<double>, functional::logical_xor<double>) {
+// NOTE: divides test is disabled because the template-tests have invalid denominators.
+TEMPLATE_TEST_CASE("BinaryOpNode", "",
+                   // std::divides<double>,
+                   std::equal_to<double>, std::less_equal<double>, std::plus<double>,
+                   std::minus<double>, functional::modulus<double>, std::multiplies<double>,
+                   functional::max<double>, functional::min<double>, std::logical_and<double>,
+                   std::logical_or<double>, functional::logical_xor<double>) {
     auto graph = Graph();
 
     auto func = TestType();
@@ -407,8 +407,8 @@ TEST_CASE("BinaryOpNode - DivideNode") {
         auto y_ptr = graph.emplace_node<DivideNode>(x_ptr, a_ptr);
 
         THEN("y's max/min/integral are as expected") {
-            CHECK(std::abs(y_ptr->max() - 5.0/3.0) < 10e-16);
-            CHECK(std::abs(y_ptr->min() - -5.0/3.0) < 10e-16);
+            CHECK(std::abs(y_ptr->max() - 5.0 / 3.0) < 10e-16);
+            CHECK(std::abs(y_ptr->min() - -5.0 / 3.0) < 10e-16);
             CHECK_FALSE(y_ptr->integral());
         }
     }
@@ -420,8 +420,8 @@ TEST_CASE("BinaryOpNode - DivideNode") {
         auto y_ptr = graph.emplace_node<DivideNode>(x_ptr, a_ptr);
 
         THEN("y's max/min/integral are as expected") {
-            CHECK(y_ptr->max() == -5.0/-3.0);
-            CHECK(y_ptr->min() == 5.0/-3.0);
+            CHECK(y_ptr->max() == -5.0 / -3.0);
+            CHECK(y_ptr->min() == 5.0 / -3.0);
             CHECK_FALSE(y_ptr->integral());
         }
     }
@@ -449,7 +449,6 @@ TEST_CASE("BinaryOpNode - DivideNode") {
             CHECK_THROWS(graph.emplace_node<DivideNode>(x_ptr, a_ptr));
         }
     }
-
 }
 
 TEST_CASE("BinaryOpNode - SubtractNode") {

--- a/tests/cpp/nodes/mathematical/test_naryop.cpp
+++ b/tests/cpp/nodes/mathematical/test_naryop.cpp
@@ -12,8 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
 #include "catch2/catch_template_test_macros.hpp"
+#include "catch2/catch_test_macros.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"

--- a/tests/cpp/nodes/mathematical/test_reduce.cpp
+++ b/tests/cpp/nodes/mathematical/test_reduce.cpp
@@ -12,8 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
 #include "catch2/catch_template_test_macros.hpp"
+#include "catch2/catch_test_macros.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
@@ -193,10 +193,9 @@ TEST_CASE("PartialReduceNode - PartialSumNode") {
     }
 }
 
-TEMPLATE_TEST_CASE("ReduceNode", "",
-                   functional::max<double>, functional::min<double>,
-                   std::logical_and<double>, std::logical_or<double>,
-                   std::multiplies<double>, std::plus<double>) {
+TEMPLATE_TEST_CASE("ReduceNode", "", functional::max<double>, functional::min<double>,
+                   std::logical_and<double>, std::logical_or<double>, std::multiplies<double>,
+                   std::plus<double>) {
     auto graph = Graph();
 
     auto func = TestType();

--- a/tests/cpp/nodes/mathematical/test_unaryop.cpp
+++ b/tests/cpp/nodes/mathematical/test_unaryop.cpp
@@ -12,8 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
 #include "catch2/catch_template_test_macros.hpp"
+#include "catch2/catch_test_macros.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
@@ -349,7 +349,6 @@ TEST_CASE("UnaryOpNode - SquareRootNode") {
         auto c_ptr = graph.emplace_node<ConstantNode>(c);
         CHECK_THROWS(graph.emplace_node<SquareRootNode>(c_ptr));
     }
-    
 }
 
 }  // namespace dwave::optimization

--- a/tests/cpp/nodes/test_manipulation.cpp
+++ b/tests/cpp/nodes/test_manipulation.cpp
@@ -27,19 +27,18 @@
 namespace dwave::optimization {
 
 TEST_CASE("ConcatenateNode") {
-
     GIVEN("Two constant nodes with 8 elements each") {
         auto a = ConstantNode(std::vector{1, 2, 3, 4, 5, 6, 7, 8});
         auto b = ConstantNode(std::vector{9, 10, 11, 12, 13, 14, 15, 16});
 
         WHEN("Reshaped to (2,2,2) and concatenated on axis 1") {
-            auto ra = ReshapeNode(&a, std::vector<ssize_t>({2,2,2}));
-            auto rb = ReshapeNode(&b, std::vector<ssize_t>({2,2,2}));
+            auto ra = ReshapeNode(&a, std::vector<ssize_t>({2, 2, 2}));
+            auto rb = ReshapeNode(&b, std::vector<ssize_t>({2, 2, 2}));
 
-            auto c = ConcatenateNode(std::vector<ArrayNode*>{&ra,&rb}, 1);
+            auto c = ConcatenateNode(std::vector<ArrayNode*>{&ra, &rb}, 1);
 
             THEN("The concatenated node has shape (2,4,2) and ndim 3") {
-                CHECK(std::ranges::equal(c.shape(), std::vector{2,4,2}));
+                CHECK(std::ranges::equal(c.shape(), std::vector{2, 4, 2}));
                 CHECK(c.ndim() == 3);
             }
         }
@@ -48,13 +47,12 @@ TEST_CASE("ConcatenateNode") {
     GIVEN("Two constant nodes with shape (2,2,2,1)") {
         auto graph = Graph();
 
-        auto a_ptr = graph.emplace_node<ConstantNode>(
-                            std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8});
+        auto a_ptr = graph.emplace_node<ConstantNode>(std::vector<double>{1, 2, 3, 4, 5, 6, 7, 8});
         auto b_ptr = graph.emplace_node<ConstantNode>(
-                            std::vector<double>{9, 10, 11, 12, 13, 14, 15, 16});
+                std::vector<double>{9, 10, 11, 12, 13, 14, 15, 16});
 
-        auto ra_ptr = graph.emplace_node<ReshapeNode>(a_ptr, std::vector<ssize_t>{2,2,2,1});
-        auto rb_ptr = graph.emplace_node<ReshapeNode>(b_ptr, std::vector<ssize_t>{2,2,2,1});
+        auto ra_ptr = graph.emplace_node<ReshapeNode>(a_ptr, std::vector<ssize_t>{2, 2, 2, 1});
+        auto rb_ptr = graph.emplace_node<ReshapeNode>(b_ptr, std::vector<ssize_t>{2, 2, 2, 1});
 
         std::vector<ArrayNode*> v{ra_ptr, rb_ptr};
 
@@ -62,12 +60,13 @@ TEST_CASE("ConcatenateNode") {
             auto c_ptr = graph.emplace_node<ConcatenateNode>(v, 0);
 
             THEN("The concatenated node has shape (4,2,2,1)") {
-                CHECK(std::ranges::equal(c_ptr->shape(), std::vector{4,2,2,1}));
+                CHECK(std::ranges::equal(c_ptr->shape(), std::vector{4, 2, 2, 1}));
             }
 
             AND_WHEN("The graph is initialized") {
                 auto state = graph.initialize_state();
-                auto expected = std::vector<ssize_t>{1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16};
+                auto expected =
+                        std::vector<ssize_t>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
                 THEN("Buffer is initialized correctly") {
                     CHECK(std::ranges::equal(c_ptr->view(state), expected));
                 }
@@ -78,12 +77,13 @@ TEST_CASE("ConcatenateNode") {
             auto c_ptr = graph.emplace_node<ConcatenateNode>(v, 1);
 
             THEN("The concatenated node has shape (2,4,2,1)") {
-                CHECK(std::ranges::equal(c_ptr->shape(), std::vector{2,4,2,1}));
+                CHECK(std::ranges::equal(c_ptr->shape(), std::vector{2, 4, 2, 1}));
             }
 
             AND_WHEN("The graph is initialized") {
                 auto state = graph.initialize_state();
-                auto expected = std::vector<ssize_t>{1,2,3,4,9,10,11,12,5,6,7,8,13,14,15,16};
+                auto expected =
+                        std::vector<ssize_t>{1, 2, 3, 4, 9, 10, 11, 12, 5, 6, 7, 8, 13, 14, 15, 16};
                 THEN("Buffer is initialized correctly") {
                     CHECK(std::ranges::equal(c_ptr->view(state), expected));
                 }
@@ -94,12 +94,13 @@ TEST_CASE("ConcatenateNode") {
             auto c_ptr = graph.emplace_node<ConcatenateNode>(v, 2);
 
             THEN("The concatenated node has shape (2,2,4,1)") {
-                CHECK(std::ranges::equal(c_ptr->shape(), std::vector{2,2,4,1}));
+                CHECK(std::ranges::equal(c_ptr->shape(), std::vector{2, 2, 4, 1}));
             }
 
             AND_WHEN("The graph is initialized") {
                 auto state = graph.initialize_state();
-                auto expected = std::vector<ssize_t>{1,2,9,10,3,4,11,12,5,6,13,14,7,8,15,16};
+                auto expected =
+                        std::vector<ssize_t>{1, 2, 9, 10, 3, 4, 11, 12, 5, 6, 13, 14, 7, 8, 15, 16};
                 THEN("Buffer is initialized correctly") {
                     CHECK(std::ranges::equal(c_ptr->view(state), expected));
                 }
@@ -109,41 +110,40 @@ TEST_CASE("ConcatenateNode") {
 
     GIVEN("Two arrays with shapes (2,2,2) and (3,2,2) that are concatenated on axis 0") {
         auto graph = Graph();
-        auto a_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{2,2,2}, 0, 100);
-        auto b_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{3,2,2}, 0, 100);
-        auto c_ptr = graph.emplace_node<ConcatenateNode>(
-                            std::vector<ArrayNode*>{a_ptr, b_ptr}, 0);
+        auto a_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{2, 2, 2}, 0, 100);
+        auto b_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{3, 2, 2}, 0, 100);
+        auto c_ptr = graph.emplace_node<ConcatenateNode>(std::vector<ArrayNode*>{a_ptr, b_ptr}, 0);
 
         WHEN("The graph is initialized and the arrays are given new values") {
             auto state = graph.initialize_state();
 
             // Ranges 1-8, 9-20
-            for (auto i : std::ranges::iota_view(0,8)) a_ptr->set_value(state, i, i+1);
-            for (auto i : std::ranges::iota_view(0,12)) b_ptr->set_value(state, i, i+9);
+            for (auto i : std::ranges::iota_view(0, 8)) a_ptr->set_value(state, i, i + 1);
+            for (auto i : std::ranges::iota_view(0, 12)) b_ptr->set_value(state, i, i + 9);
 
             graph.propose(state, {a_ptr, b_ptr}, [](const Graph&, State&) { return true; });
             THEN("ConcatenateNode values are propagated correctly") {
-                CHECK(std::ranges::equal(c_ptr->view(state), std::ranges::iota_view{1,21}));
+                CHECK(std::ranges::equal(c_ptr->view(state), std::ranges::iota_view{1, 21}));
             }
         }
     }
 
     GIVEN("Two arrays with shapes (2,2,2) and (2,3,2) that are concatenated on axis 1") {
         auto graph = Graph();
-        auto a_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{2,2,2}, 0, 100);
-        auto b_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{2,3,2}, 0, 100);
-        auto c_ptr = graph.emplace_node<ConcatenateNode>(
-                            std::vector<ArrayNode*>{a_ptr, b_ptr}, 1);
+        auto a_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{2, 2, 2}, 0, 100);
+        auto b_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{2, 3, 2}, 0, 100);
+        auto c_ptr = graph.emplace_node<ConcatenateNode>(std::vector<ArrayNode*>{a_ptr, b_ptr}, 1);
 
         WHEN("The graph is initialized and the arrays are given new values") {
             auto state = graph.initialize_state();
 
             // Ranges 1-8, 9-20
-            for (auto i : std::ranges::iota_view(0,8)) a_ptr->set_value(state, i, i+1);
-            for (auto i : std::ranges::iota_view(0,12)) b_ptr->set_value(state, i, i+9);
+            for (auto i : std::ranges::iota_view(0, 8)) a_ptr->set_value(state, i, i + 1);
+            for (auto i : std::ranges::iota_view(0, 12)) b_ptr->set_value(state, i, i + 9);
 
             graph.propose(state, {a_ptr, b_ptr}, [](const Graph&, State&) { return true; });
-            std::vector<ssize_t> expected = {1,2,3,4,9,10,11,12,13,14,5,6,7,8,15,16,17,18,19,20};
+            std::vector<ssize_t> expected = {1, 2, 3, 4, 9,  10, 11, 12, 13, 14,
+                                             5, 6, 7, 8, 15, 16, 17, 18, 19, 20};
             THEN("ConcatenateNode values are propagated correctly") {
                 CHECK(std::ranges::equal(c_ptr->view(state), expected));
             }
@@ -152,20 +152,20 @@ TEST_CASE("ConcatenateNode") {
 
     GIVEN("Two arrays with shapes (2,2,2) and (2,2,3) that are concatenated on axis 2") {
         auto graph = Graph();
-        auto a_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{2,2,2}, 0, 100);
-        auto b_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{2,2,3}, 0, 100);
-        auto c_ptr = graph.emplace_node<ConcatenateNode>(
-                            std::vector<ArrayNode*>{a_ptr, b_ptr}, 2);
+        auto a_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{2, 2, 2}, 0, 100);
+        auto b_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{2, 2, 3}, 0, 100);
+        auto c_ptr = graph.emplace_node<ConcatenateNode>(std::vector<ArrayNode*>{a_ptr, b_ptr}, 2);
 
         WHEN("The graph is initialized and the arrays are given new values") {
             auto state = graph.initialize_state();
 
             // Ranges 1-8, 9-20
-            for (auto i : std::ranges::iota_view(0,8)) a_ptr->set_value(state, i, i+1);
-            for (auto i : std::ranges::iota_view(0,12)) b_ptr->set_value(state, i, i+9);
+            for (auto i : std::ranges::iota_view(0, 8)) a_ptr->set_value(state, i, i + 1);
+            for (auto i : std::ranges::iota_view(0, 12)) b_ptr->set_value(state, i, i + 9);
 
             graph.propose(state, {a_ptr, b_ptr}, [](const Graph&, State&) { return true; });
-            std::vector<ssize_t> expected = {1,2,9,10,11,3,4,12,13,14,5,6,15,16,17,7,8,18,19,20};
+            std::vector<ssize_t> expected = {1, 2, 9,  10, 11, 3, 4, 12, 13, 14,
+                                             5, 6, 15, 16, 17, 7, 8, 18, 19, 20};
             THEN("ConcatenateNode values are propagated correctly") {
                 CHECK(std::ranges::equal(c_ptr->view(state), expected));
             }
@@ -180,44 +180,46 @@ TEST_CASE("ConcatenateNode") {
         auto c = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{24}, 0, 100);
 
         WHEN("The arrays are reshaped, concatenated on axis 0, and assigned new values") {
-            auto a_r = graph.emplace_node<ReshapeNode>(a, std::vector<ssize_t>{2,3,2,1});
-            auto b_r = graph.emplace_node<ReshapeNode>(b, std::vector<ssize_t>{3,3,2,1});
-            auto c_r = graph.emplace_node<ReshapeNode>(c, std::vector<ssize_t>{4,3,2,1});
-            auto abc_ptr = graph.emplace_node<ConcatenateNode>(std::vector<ArrayNode*>{a_r,b_r,c_r}, 0);
+            auto a_r = graph.emplace_node<ReshapeNode>(a, std::vector<ssize_t>{2, 3, 2, 1});
+            auto b_r = graph.emplace_node<ReshapeNode>(b, std::vector<ssize_t>{3, 3, 2, 1});
+            auto c_r = graph.emplace_node<ReshapeNode>(c, std::vector<ssize_t>{4, 3, 2, 1});
+            auto abc_ptr =
+                    graph.emplace_node<ConcatenateNode>(std::vector<ArrayNode*>{a_r, b_r, c_r}, 0);
 
             auto state = graph.initialize_state();
 
             // Values 1-12, 13-30, 31-54
-            for (auto i : std::ranges::iota_view(0,12)) a->set_value(state, i, i+1);
-            for (auto i : std::ranges::iota_view(0,18)) b->set_value(state, i, i+13);
-            for (auto i : std::ranges::iota_view(0,24)) c->set_value(state, i, i+31);
+            for (auto i : std::ranges::iota_view(0, 12)) a->set_value(state, i, i + 1);
+            for (auto i : std::ranges::iota_view(0, 18)) b->set_value(state, i, i + 13);
+            for (auto i : std::ranges::iota_view(0, 24)) c->set_value(state, i, i + 31);
 
-            graph.propose(state, {a,b,c}, [](const Graph&, State&) { return true; });
-            auto expected = std::ranges::iota_view(1,55);
+            graph.propose(state, {a, b, c}, [](const Graph&, State&) { return true; });
+            auto expected = std::ranges::iota_view(1, 55);
 
             THEN("ConcatenatedNode values are propagated correctly") {
-               CHECK(std::ranges::equal(abc_ptr->view(state), expected));
+                CHECK(std::ranges::equal(abc_ptr->view(state), expected));
             }
         }
 
         WHEN("The arrays are reshaped, concatenated on axis 1, and assigned new values") {
-            auto a_r = graph.emplace_node<ReshapeNode>(a, std::vector<ssize_t>{3,2,2,1});
-            auto b_r = graph.emplace_node<ReshapeNode>(b, std::vector<ssize_t>{3,3,2,1});
-            auto c_r = graph.emplace_node<ReshapeNode>(c, std::vector<ssize_t>{3,4,2,1});
-            auto abc_ptr = graph.emplace_node<ConcatenateNode>(std::vector<ArrayNode*>{a_r,b_r,c_r}, 1);
+            auto a_r = graph.emplace_node<ReshapeNode>(a, std::vector<ssize_t>{3, 2, 2, 1});
+            auto b_r = graph.emplace_node<ReshapeNode>(b, std::vector<ssize_t>{3, 3, 2, 1});
+            auto c_r = graph.emplace_node<ReshapeNode>(c, std::vector<ssize_t>{3, 4, 2, 1});
+            auto abc_ptr =
+                    graph.emplace_node<ConcatenateNode>(std::vector<ArrayNode*>{a_r, b_r, c_r}, 1);
 
             auto state = graph.initialize_state();
 
             // Values 1-12, 13-30, 31-54
-            for (auto i : std::ranges::iota_view(0,12)) a->set_value(state, i, i+1);
-            for (auto i : std::ranges::iota_view(0,18)) b->set_value(state, i, i+13);
-            for (auto i : std::ranges::iota_view(0,24)) c->set_value(state, i, i+31);
+            for (auto i : std::ranges::iota_view(0, 12)) a->set_value(state, i, i + 1);
+            for (auto i : std::ranges::iota_view(0, 18)) b->set_value(state, i, i + 13);
+            for (auto i : std::ranges::iota_view(0, 24)) c->set_value(state, i, i + 31);
 
-            graph.propose(state, {a,b,c}, [](const Graph&, State&) { return true; });
-            std::vector<double> expected{
-                1,  2,  3,  4, 13, 14, 15, 16, 17, 18, 31, 32, 33, 34, 35, 36, 37, 38,
-                5,  6,  7,  8, 19, 20, 21, 22, 23, 24, 39, 40, 41, 42, 43, 44, 45, 46,
-                9, 10, 11, 12, 25, 26, 27, 28, 29, 30, 47, 48, 49, 50, 51, 52, 53, 54};
+            graph.propose(state, {a, b, c}, [](const Graph&, State&) { return true; });
+            std::vector<double> expected{1,  2,  3,  4,  13, 14, 15, 16, 17, 18, 31, 32, 33, 34,
+                                         35, 36, 37, 38, 5,  6,  7,  8,  19, 20, 21, 22, 23, 24,
+                                         39, 40, 41, 42, 43, 44, 45, 46, 9,  10, 11, 12, 25, 26,
+                                         27, 28, 29, 30, 47, 48, 49, 50, 51, 52, 53, 54};
 
             THEN("ConcatenatedNode values are propagated correctly") {
                 CHECK(std::ranges::equal(abc_ptr->view(state), expected));
@@ -225,26 +227,24 @@ TEST_CASE("ConcatenateNode") {
         }
 
         WHEN("The arrays are reshaped, concatenated on axis 2, and assigned new values") {
-            auto a_r = graph.emplace_node<ReshapeNode>(a, std::vector<ssize_t>{3,2,2,1});
-            auto b_r = graph.emplace_node<ReshapeNode>(b, std::vector<ssize_t>{3,2,3,1});
-            auto c_r = graph.emplace_node<ReshapeNode>(c, std::vector<ssize_t>{3,2,4,1});
-            auto abc_ptr = graph.emplace_node<ConcatenateNode>(std::vector<ArrayNode*>{a_r,b_r,c_r}, 2);
+            auto a_r = graph.emplace_node<ReshapeNode>(a, std::vector<ssize_t>{3, 2, 2, 1});
+            auto b_r = graph.emplace_node<ReshapeNode>(b, std::vector<ssize_t>{3, 2, 3, 1});
+            auto c_r = graph.emplace_node<ReshapeNode>(c, std::vector<ssize_t>{3, 2, 4, 1});
+            auto abc_ptr =
+                    graph.emplace_node<ConcatenateNode>(std::vector<ArrayNode*>{a_r, b_r, c_r}, 2);
 
             auto state = graph.initialize_state();
 
             // Values 1-12, 13-30, 31-54
-            for (auto i : std::ranges::iota_view(0,12)) a->set_value(state, i, i+1);
-            for (auto i : std::ranges::iota_view(0,18)) b->set_value(state, i, i+13);
-            for (auto i : std::ranges::iota_view(0,24)) c->set_value(state, i, i+31);
+            for (auto i : std::ranges::iota_view(0, 12)) a->set_value(state, i, i + 1);
+            for (auto i : std::ranges::iota_view(0, 18)) b->set_value(state, i, i + 13);
+            for (auto i : std::ranges::iota_view(0, 24)) c->set_value(state, i, i + 31);
 
-            graph.propose(state, {a,b,c}, [](const Graph&, State&) { return true; });
-            std::vector<double> expected{
-                 1,  2, 13, 14, 15, 31, 32, 33, 34,
-                 3,  4, 16, 17, 18, 35, 36, 37, 38,
-                 5,  6, 19, 20, 21, 39, 40, 41, 42,
-                 7,  8, 22, 23, 24, 43, 44, 45, 46,
-                 9, 10, 25, 26, 27, 47, 48, 49, 50,
-                11, 12, 28, 29, 30, 51, 52, 53, 54};
+            graph.propose(state, {a, b, c}, [](const Graph&, State&) { return true; });
+            std::vector<double> expected{1,  2,  13, 14, 15, 31, 32, 33, 34, 3,  4,  16, 17, 18,
+                                         35, 36, 37, 38, 5,  6,  19, 20, 21, 39, 40, 41, 42, 7,
+                                         8,  22, 23, 24, 43, 44, 45, 46, 9,  10, 25, 26, 27, 47,
+                                         48, 49, 50, 11, 12, 28, 29, 30, 51, 52, 53, 54};
 
             THEN("ConcatenatedNode values are propagated correctly") {
                 CHECK(std::ranges::equal(abc_ptr->view(state), expected));
@@ -252,33 +252,30 @@ TEST_CASE("ConcatenateNode") {
         }
 
         WHEN("The arrays are reshaped, concatenated on axis 3, and assigned new values") {
-            auto a_r = graph.emplace_node<ReshapeNode>(a, std::vector<ssize_t>{3,2,1,2});
-            auto b_r = graph.emplace_node<ReshapeNode>(b, std::vector<ssize_t>{3,2,1,3});
-            auto c_r = graph.emplace_node<ReshapeNode>(c, std::vector<ssize_t>{3,2,1,4});
-            auto abc_ptr = graph.emplace_node<ConcatenateNode>(std::vector<ArrayNode*>{a_r,b_r,c_r}, 3);
+            auto a_r = graph.emplace_node<ReshapeNode>(a, std::vector<ssize_t>{3, 2, 1, 2});
+            auto b_r = graph.emplace_node<ReshapeNode>(b, std::vector<ssize_t>{3, 2, 1, 3});
+            auto c_r = graph.emplace_node<ReshapeNode>(c, std::vector<ssize_t>{3, 2, 1, 4});
+            auto abc_ptr =
+                    graph.emplace_node<ConcatenateNode>(std::vector<ArrayNode*>{a_r, b_r, c_r}, 3);
 
             auto state = graph.initialize_state();
 
             // Values 1-12, 13-30, 31-54
-            for (auto i : std::ranges::iota_view(0,12)) a->set_value(state, i, i+1);
-            for (auto i : std::ranges::iota_view(0,18)) b->set_value(state, i, i+13);
-            for (auto i : std::ranges::iota_view(0,24)) c->set_value(state, i, i+31);
+            for (auto i : std::ranges::iota_view(0, 12)) a->set_value(state, i, i + 1);
+            for (auto i : std::ranges::iota_view(0, 18)) b->set_value(state, i, i + 13);
+            for (auto i : std::ranges::iota_view(0, 24)) c->set_value(state, i, i + 31);
 
-            graph.propose(state, {a,b,c}, [](const Graph&, State&) { return true; });
-            std::vector<double> expected{
-                 1,  2, 13, 14, 15, 31, 32, 33, 34,
-                 3,  4, 16, 17, 18, 35, 36, 37, 38,
-                 5,  6, 19, 20, 21, 39, 40, 41, 42,
-                 7,  8, 22, 23, 24, 43, 44, 45, 46,
-                 9, 10, 25, 26, 27, 47, 48, 49, 50,
-                11, 12, 28, 29, 30, 51, 52, 53, 54};
+            graph.propose(state, {a, b, c}, [](const Graph&, State&) { return true; });
+            std::vector<double> expected{1,  2,  13, 14, 15, 31, 32, 33, 34, 3,  4,  16, 17, 18,
+                                         35, 36, 37, 38, 5,  6,  19, 20, 21, 39, 40, 41, 42, 7,
+                                         8,  22, 23, 24, 43, 44, 45, 46, 9,  10, 25, 26, 27, 47,
+                                         48, 49, 50, 11, 12, 28, 29, 30, 51, 52, 53, 54};
 
             THEN("ConcatenatedNode values are propagated correctly") {
                 CHECK(std::ranges::equal(abc_ptr->view(state), expected));
             }
         }
     }
-
 }
 
 TEST_CASE("ReshapeNode") {

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -95,9 +95,8 @@ TEST_CASE("ArrayIterator and ConstArrayIterator") {
         auto shape = std::array<ssize_t, 2>{2, 3};
         // auto strides = std::array<ssize_t, 2>{24, 8};
 
-        auto [strides, start] = GENERATE(
-            std::pair(std::array<ssize_t, 2>{24, 8}, 0),
-            std::pair(std::array<ssize_t, 2>{-24, 8}, 3));
+        auto [strides, start] = GENERATE(std::pair(std::array<ssize_t, 2>{24, 8}, 0),
+                                         std::pair(std::array<ssize_t, 2>{-24, 8}, 3));
 
         auto n = GENERATE(0, 3, 4, 5);
 
@@ -115,9 +114,7 @@ TEST_CASE("ArrayIterator and ConstArrayIterator") {
                 ConstArrayIterator d = a;
                 CHECK(c == (d += n));
             }
-            THEN("(a + n) is equal to (n + a)") {
-                CHECK(a + n == n + a);
-            }
+            THEN("(a + n) is equal to (n + a)") { CHECK(a + n == n + a); }
             THEN("If (a + (n - 1)) is valid, then --b is equal to (a + (n - 1))") {
                 ConstArrayIterator c = b;
                 CHECK(--c == a + (n - 1));
@@ -135,9 +132,7 @@ TEST_CASE("ArrayIterator and ConstArrayIterator") {
             THEN("If b is dereferenceable, then a[n] is valid and is equal to *b") {
                 CHECK(a[n] == *b);
             }
-            THEN("bool(a <= b) is true") {
-                CHECK(a <= b);
-            }
+            THEN("bool(a <= b) is true") { CHECK(a <= b); }
         }
     }
 
@@ -531,7 +526,6 @@ TEST_CASE("Dynamically Sized 1d Array") {
                 CHECK_THROWS_AS(v.view(state).at(100), std::out_of_range);
                 CHECK_THROWS_AS(v.view(state).at(-1), std::out_of_range);
 
-
                 // for contiguous view is the same as span(buff(), size())
                 CHECK(std::ranges::equal(std::span(v.buff(state), v.size(state)), v.view(state)));
             }
@@ -734,7 +728,8 @@ TEST_CASE("Ravelling-unravelling indices") {
         auto arr = Array3d();
         auto last_element_flat = arr.size() - 1;
         CHECK(ravel_multi_index(arr.strides(), {2, 3, 4}) == last_element_flat);
-        CHECK(ravel_multi_index(arr.strides(), unravel_index(arr.strides(), last_element_flat)) == last_element_flat);
+        CHECK(ravel_multi_index(arr.strides(), unravel_index(arr.strides(), last_element_flat)) ==
+              last_element_flat);
     }
 }
 

--- a/tests/cpp/test_graph.cpp
+++ b/tests/cpp/test_graph.cpp
@@ -137,8 +137,10 @@ TEST_CASE("Topological Sort", "[topological_sort]") {
             graph.topological_sort();
 
             THEN("The order remains stable wrt successor order") {
-                CHECK(disjoint_bitset0->topological_index() < disjoint_bitset1->topological_index());
-                CHECK(disjoint_bitset1->topological_index() < disjoint_bitset2->topological_index());
+                CHECK(disjoint_bitset0->topological_index() <
+                      disjoint_bitset1->topological_index());
+                CHECK(disjoint_bitset1->topological_index() <
+                      disjoint_bitset2->topological_index());
             }
         }
 
@@ -149,8 +151,10 @@ TEST_CASE("Topological Sort", "[topological_sort]") {
             graph.topological_sort();
 
             THEN("The order remains stable wrt successor order") {
-                CHECK(disjoint_bitset0->topological_index() < disjoint_bitset1->topological_index());
-                CHECK(disjoint_bitset1->topological_index() < disjoint_bitset2->topological_index());
+                CHECK(disjoint_bitset0->topological_index() <
+                      disjoint_bitset1->topological_index());
+                CHECK(disjoint_bitset1->topological_index() <
+                      disjoint_bitset2->topological_index());
             }
         }
     }

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -159,8 +159,8 @@ TEST_CASE("Test deduplicate_diff") {
         WHEN("We call deduplicate_diff") {
             deduplicate_diff(updates);
             THEN("deduplicate_diff() sorts them and removes noops") {
-                CHECK(std::ranges::equal(
-                        updates, std::vector<Update>{Update(2, 1, 0), Update(3, 0, 1)}));
+                CHECK(std::ranges::equal(updates,
+                                         std::vector<Update>{Update(2, 1, 0), Update(3, 0, 1)}));
             }
         }
     }


### PR DESCRIPTION
While we don't require files to be formatted to be merged, it is nice to go back to ground every so often.

This PR makes no functional changes, but runs everything through `clang-format`.