### PR TITLE
Fix `sqrt()` example formatting

### DIFF
--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -3057,10 +3057,12 @@ _register(Square, typeid(cppSquareNode))
 
 
 cdef class SquareRoot(ArraySymbol):
-    """Takes the SquareRoot a symbol.
+    """Square root of a symbol.
+
     Examples:
-        This example adds the square-roots of an integer decision
-        variable to a model.
+        This example adds the square root of an integer decision variable to a
+        model.
+
         >>> from dwave.optimization.model import Model
         >>> from dwave.optimization.mathematical import sqrt
         >>> model = Model()


### PR DESCRIPTION
Currently renders like this:
![image](https://github.com/user-attachments/assets/3b5bd2f9-bb43-4758-af42-5dcfcf636017)

 Updated to:
![image](https://github.com/user-attachments/assets/081f51ea-fe40-4af3-8100-d9ba29794822)
