### PR TITLE
Add C++ StackNode

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
@@ -149,4 +149,25 @@ class SizeNode : public ScalarOutputMixin<ArrayNode> {
     const Array* array_ptr_;
 };
 
+class StackNode : public ArrayOutputMixin<ArrayNode> {
+ public:
+    explicit StackNode(std::span<ArrayNode*> array_ptrs, ssize_t axis);
+    explicit StackNode(std::ranges::contiguous_range auto&& array_ptrs, ssize_t axis)
+            : StackNode(std::span<ArrayNode*>(array_ptrs), axis) {}
+
+    double const* buff(const State& state) const override;
+    void commit(State& state) const override;
+    std::span<const Update> diff(const State& state) const override;
+    void initialize_state(State& state) const override;
+    void propagate(State& state) const override;
+    void revert(State& state) const override;
+
+    ssize_t axis() const { return axis_; }
+
+ private:
+    ssize_t axis_;
+    std::vector<ArrayNode*> array_ptrs_;
+    std::vector<ssize_t> array_starts_;
+};
+
 }  // namespace dwave::optimization

--- a/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
@@ -159,6 +159,9 @@ class StackNode : public ArrayOutputMixin<ArrayNode> {
     void commit(State& state) const override;
     std::span<const Update> diff(const State& state) const override;
     void initialize_state(State& state) const override;
+    bool integral() const override;
+    double min() const override;
+    double max() const override;
     void propagate(State& state) const override;
     void revert(State& state) const override;
 

--- a/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
@@ -171,6 +171,7 @@ class StackNode : public ArrayOutputMixin<ArrayNode> {
     ssize_t axis_;
     std::vector<ArrayNode*> array_ptrs_;
     std::vector<ssize_t> array_starts_;
+    std::vector<ssize_t> strided_iter_shape_;
 };
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/libcpp/nodes.pxd
+++ b/dwave/optimization/libcpp/nodes.pxd
@@ -87,6 +87,9 @@ cdef extern from "dwave-optimization/nodes/manipulation.hpp" namespace "dwave::o
     cdef cppclass SizeNode(ArrayNode):
         pass
 
+    cdef cppclass StackNode(ArrayNode):
+        Py_ssize_t axis()
+
 
 cdef extern from "dwave-optimization/nodes/mathematical.hpp" namespace "dwave::optimization" nogil:
     cdef cppclass AbsoluteNode(ArrayNode):

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -36,6 +36,7 @@ from dwave.optimization.symbols import (
     Put,
     Rint,
     SquareRoot,
+    Stack,
     Where,
     Xor,
 )
@@ -683,13 +684,11 @@ def stack(arrays: collections.abc.Iterable[ArraySymbol], axis: int = 0) -> Array
         [[1. 3. 5.]
          [2. 4. 6.]]
     """
-    if all(isinstance(arr, ArraySymbol) for arr in arrays):
-        if not 0 <= axis <= arrays[0].ndim():
-            raise ValueError(f'axis {axis} is out of bounds for array'
-                             f' of dimension {arrays[0].ndim() + 1}')
+    if isinstance(arrays, ArraySymbol):
+        return arrays
 
-        make_shape = lambda x: (x.shape()[:axis]) + (1, ) + (x.shape()[axis:])
-        return concatenate([arr.reshape(make_shape(arr)) for arr in arrays], axis)
+    if all(isinstance(arr, ArraySymbol) for arr in arrays):
+        return Stack(tuple(arrays), axis)
 
     raise ValueError("stack takes an Iterable of ArraySymbols of same shape")
 

--- a/dwave/optimization/src/nodes/manipulation.cpp
+++ b/dwave/optimization/src/nodes/manipulation.cpp
@@ -615,6 +615,21 @@ void StackNode::initialize_state(State& state) const {
     state[index] = std::make_unique<ArrayNodeStateData>(std::move(values));
 }
 
+bool StackNode::integral() const {
+    return std::accumulate(std::next(array_ptrs_.begin()), array_ptrs_.end(), array_ptrs_[0]->integral(),
+                            [](bool b, ArrayNode* node) { return b && node->integral(); });
+}
+
+double StackNode::max() const {
+    return std::accumulate(std::next(array_ptrs_.begin()), array_ptrs_.end(), array_ptrs_[0]->max(),
+                            [](double m, ArrayNode* node) { return std::max(m, node->max()); });
+}
+
+double StackNode::min() const {
+    return std::accumulate(std::next(array_ptrs_.begin()), array_ptrs_.end(), array_ptrs_[0]->min(),
+                            [](double m, ArrayNode* node) { return std::min(m, node->min()); });
+}
+
 void StackNode::propagate(State& state) const {
     auto ptr = data_ptr<ArrayNodeStateData>(state);
 

--- a/dwave/optimization/src/nodes/manipulation.cpp
+++ b/dwave/optimization/src/nodes/manipulation.cpp
@@ -616,17 +616,20 @@ void StackNode::initialize_state(State& state) const {
 }
 
 bool StackNode::integral() const {
-    return std::accumulate(std::next(array_ptrs_.begin()), array_ptrs_.end(), array_ptrs_[0]->integral(),
+    return std::accumulate(std::next(array_ptrs_.begin()), array_ptrs_.end(),
+                            array_ptrs_[0]->integral(),
                             [](bool b, ArrayNode* node) { return b && node->integral(); });
 }
 
 double StackNode::max() const {
-    return std::accumulate(std::next(array_ptrs_.begin()), array_ptrs_.end(), array_ptrs_[0]->max(),
+    return std::accumulate(std::next(array_ptrs_.begin()), array_ptrs_.end(),
+                            array_ptrs_[0]->max(),
                             [](double m, ArrayNode* node) { return std::max(m, node->max()); });
 }
 
 double StackNode::min() const {
-    return std::accumulate(std::next(array_ptrs_.begin()), array_ptrs_.end(), array_ptrs_[0]->min(),
+    return std::accumulate(std::next(array_ptrs_.begin()), array_ptrs_.end(),
+                            array_ptrs_[0]->min(),
                             [](double m, ArrayNode* node) { return std::min(m, node->min()); });
 }
 

--- a/dwave/optimization/symbols.pyi
+++ b/dwave/optimization/symbols.pyi
@@ -210,6 +210,10 @@ class SquareRoot(ArraySymbol):
     ...
 
 
+class Stack(ArraySymbol):
+    ...
+
+
 class Subtract(ArraySymbol):
     ...
 

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -3100,9 +3100,9 @@ cdef class Stack(ArraySymbol):
         >>> from dwave.optimization.model import Model
         >>> from dwave.optimization.symbols import Stack
         >>> model = Model()
-        >>> a = model.constant([1,2])
-        >>> b = model.constant([3,4])
-        >>> a_b = Stack((a,b), axis=0)
+        >>> a = model.constant([1, 2])
+        >>> b = model.constant([3, 4])
+        >>> a_b = Stack((a, b), axis=0)
         >>> type(a_b)
         <class 'dwave.optimization.symbols.Stack'>
     """

--- a/releasenotes/notes/add-stack-node-34bc59ce46c81256.yaml
+++ b/releasenotes/notes/add-stack-node-34bc59ce46c81256.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add C++ ``StackNode``. ``StackNode``joins its array predecessors
+    along a new axis. Python symbol ``Stack`` now uses ``StackNode``.

--- a/tests/cpp/nodes/test_manipulation.cpp
+++ b/tests/cpp/nodes/test_manipulation.cpp
@@ -966,7 +966,7 @@ TEST_CASE("StackNode") {
         auto a = ConstantNode(std::vector{5.5});
         auto s = StackNode(std::vector<ArrayNode*>{&a}, 0);
 
-        THEN("THe stack node is not integral and we know the min and max") {
+        THEN("The stack node is not integral and we know the min and max") {
             CHECK(s.integral() == false);
             CHECK(s.min() == 5.5);
             CHECK(s.max() == 5.5);

--- a/tests/cpp/nodes/test_manipulation.cpp
+++ b/tests/cpp/nodes/test_manipulation.cpp
@@ -894,7 +894,7 @@ TEST_CASE("StackNode") {
 
             graph.propose(state, {a_ptr, b_ptr, c_ptr}, [](const Graph&, State&) { return true; });
             THEN("StackNode values are propagated correctly") {
-                std::vector<ssize_t> expected = { 1, 2, 5, 6, 9, 10, 3, 4, 7, 8, 11, 12 };
+                std::vector<ssize_t> expected = {1, 2, 5, 6, 9, 10, 3, 4, 7, 8, 11, 12};
                 CHECK(std::ranges::equal(abc_ptr->view(state), expected));
             }
         }
@@ -915,7 +915,7 @@ TEST_CASE("StackNode") {
 
             graph.propose(state, {a_ptr, b_ptr, c_ptr}, [](const Graph&, State&) { return true; });
             THEN("StackNode values are propagated correctly") {
-                std::vector<ssize_t> expected = { 1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12 };
+                std::vector<ssize_t> expected = {1, 5, 9, 2, 6, 10, 3, 7, 11, 4, 8, 12};
                 CHECK(std::ranges::equal(abc_ptr->view(state), expected));
             }
         }
@@ -926,7 +926,7 @@ TEST_CASE("StackNode") {
         auto b = ConstantNode(std::vector{11, 12, 13, 14, 15, 16, 17, 18, 19, 20});
 
         WHEN("When stacked") {
-            auto s = StackNode(std::vector<ArrayNode*>{&a,&b}, 0);
+            auto s = StackNode(std::vector<ArrayNode*>{&a, &b}, 0);
 
             THEN("The stack node is integral and we know the min and max") {
                 CHECK(s.integral());
@@ -941,7 +941,7 @@ TEST_CASE("StackNode") {
         auto b = ConstantNode(std::vector{7});
 
         WHEN("When stacked") {
-            auto s = StackNode(std::vector<ArrayNode*>{&a,&b}, 0);
+            auto s = StackNode(std::vector<ArrayNode*>{&a, &b}, 0);
 
             THEN("The stack node is integral and we know the min and max") {
                 CHECK(s.integral());

--- a/tests/cpp/nodes/test_manipulation.cpp
+++ b/tests/cpp/nodes/test_manipulation.cpp
@@ -920,6 +920,57 @@ TEST_CASE("StackNode") {
             }
         }
     }
-}
 
+    GIVEN("Integral constant nodes with many elements") {
+        auto a = ConstantNode(std::vector{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        auto b = ConstantNode(std::vector{11, 12, 13, 14, 15, 16, 17, 18, 19, 20});
+
+        WHEN("When stacked") {
+            auto s = StackNode(std::vector<ArrayNode*>{&a,&b}, 0);
+
+            THEN("The stack node is integral and we know the min and max") {
+                CHECK(s.integral());
+                CHECK(s.min() == 1);
+                CHECK(s.max() == 20);
+            }
+        }
+    }
+
+    GIVEN("Two integral scalars") {
+        auto a = ConstantNode(std::vector{-5});
+        auto b = ConstantNode(std::vector{7});
+
+        WHEN("When stacked") {
+            auto s = StackNode(std::vector<ArrayNode*>{&a,&b}, 0);
+
+            THEN("The stack node is integral and we know the min and max") {
+                CHECK(s.integral());
+                CHECK(s.min() == -5);
+                CHECK(s.max() == 7);
+            }
+        }
+    }
+
+    GIVEN("One integral scalar that is stacked") {
+        auto a = ConstantNode(std::vector{9});
+        auto s = StackNode(std::vector<ArrayNode*>{&a}, 0);
+
+        THEN("The stack node is integral and we know the min and max") {
+            CHECK(s.integral());
+            CHECK(s.min() == 9);
+            CHECK(s.max() == 9);
+        }
+    }
+
+    GIVEN("A non-integral scalar that is stacked") {
+        auto a = ConstantNode(std::vector{5.5});
+        auto s = StackNode(std::vector<ArrayNode*>{&a}, 0);
+
+        THEN("THe stack node is not integral and we know the min and max") {
+            CHECK(s.integral() == false);
+            CHECK(s.min() == 5.5);
+            CHECK(s.max() == 5.5);
+        }
+    }
+}
 }  // namespace dwave::optimization

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -2495,23 +2495,23 @@ class TestStack(utils.SymbolTests):
 
     def test_single_array_symbol(self):
         model = Model()
-        A = model.constant(np.arange(4).reshape(2,2))
+        A = model.constant(np.arange(4).reshape(2, 2))
         s = stack(A)
-        self.assertEqual(s.shape(), (2,2))
+        self.assertEqual(s.shape(), (2, 2))
         self.assertEqual(s.ndim(), 2)
         self.assertTrue(s is A)
         self.assertIsInstance(s, dwave.optimization.symbols.Constant)
 
     def test_single_array(self):
         model = Model()
-        A = model.constant(np.arange(4).reshape((2,2)))
-        s = stack((A,))
+        A = model.constant(np.arange(4).reshape((2, 2)))
+        s = stack((A, ))
         with model.lock():
             model.states.resize(1)
             self.assertIsInstance(s, dwave.optimization.symbols.Stack)
-            self.assertEqual(s.shape(), (1,2,2))
+            self.assertEqual(s.shape(), (1, 2, 2))
             self.assertEqual(s.ndim(), 3)
-            np.testing.assert_array_equal(s.state(0), np.stack((A,)))
+            np.testing.assert_array_equal(s.state(0), np.stack((A, )))
 
     def test_1d_arrays(self):
         model = Model()
@@ -2580,23 +2580,23 @@ class TestStack(utils.SymbolTests):
 
         with self.subTest("input arrays must have same shape"):
             model = Model()
-            A = model.constant(np.arange(4).reshape((2,2)))
-            B = model.constant(np.arange(8).reshape((4,2)))
+            A = model.constant(np.arange(4).reshape((2, 2)))
+            B = model.constant(np.arange(8).reshape((4, 2)))
             with self.assertRaisesRegex(
                 ValueError,
                 (r"all input arrays must have the same shape")
             ):
-                stack((A,B))
+                stack((A, B))
 
         with self.subTest("input arrays must have same shape and ndim"):
             model = Model()
-            A = model.constant(np.arange(4).reshape((2,2)))
-            B = model.constant(np.arange(4).reshape((2,1,2)))
+            A = model.constant(np.arange(4).reshape((2, 2)))
+            B = model.constant(np.arange(4).reshape((2, 1, 2)))
             with self.assertRaisesRegex(
                 ValueError,
                 (r"all input arrays must have the same shape")
             ):
-                stack((A,B))
+                stack((A, B))
 
         with self.subTest("at least one input array is required"):
             model = Model()


### PR DESCRIPTION
Removed python implementation of stack which was using a combination of Reshape + Concatenate. 
Python side now relies on C++ StackNode implementation.
Few updated tests, and new tests added for C++ and Python