### PR TITLE
Add protected `Node::emplace_data_ptr` method to reduce repeated boilerplate

### DIFF
--- a/dwave/optimization/include/dwave-optimization/graph.hpp
+++ b/dwave/optimization/include/dwave-optimization/graph.hpp
@@ -256,23 +256,33 @@ class Node {
         successor->predecessors_.emplace_back(this);
     }
 
-    template <class StateData>
+    template <std::derived_from<NodeStateData> StateData>
     StateData* data_ptr(State& state) const {
-        int index = topological_index();
+        const ssize_t index = topological_index();
         assert(index >= 0 && "must be topologically sorted");
-        assert(static_cast<int>(state.size()) > index && "unexpected state length");
+        assert(state.size() > static_cast<std::size_t>(index) && "unexpected state length");
         assert(state[index] != nullptr && "uninitialized state");
 
         return static_cast<StateData*>(state[index].get());
     }
-    template <class StateData>
+    template <std::derived_from<NodeStateData> StateData>
     const StateData* data_ptr(const State& state) const {
-        int index = topological_index();
+        const ssize_t index = topological_index();
         assert(index >= 0 && "must be topologically sorted");
-        assert(static_cast<int>(state.size()) > index && "unexpected state length");
+        assert(state.size() > static_cast<std::size_t>(index) && "unexpected state length");
         assert(state[index] != nullptr && "uninitialized state");
 
         return static_cast<const StateData*>(state[index].get());
+    }
+
+    template <std::derived_from<NodeStateData> StateData, class... Args>
+    void emplace_data_ptr(State& state, Args&&... args) const {
+        const ssize_t index = topological_index();
+        assert(index >= 0 && "must be topologically sorted");
+        assert(state.size() > static_cast<std::size_t>(index) && "unexpected state length");
+        assert(state[index] == nullptr && "already initialized state");
+
+        state[index] = std::make_unique<StateData>(std::forward<Args&&>(args)...);
     }
 
     // Whether this node type is elegible to be removed from the model

--- a/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
@@ -94,8 +94,6 @@ class NumberNode : public ArrayOutputMixin<ArrayNode>, public DecisionNode {
 
     virtual bool is_valid(double value) const = 0;
     virtual double default_value() const = 0;
-    virtual std::unique_ptr<NodeStateData> new_data_ptr(
-            std::vector<double>&& number_data) const = 0;
 
     double lower_bound_;
     double upper_bound_;
@@ -129,7 +127,6 @@ class IntegerNode : public NumberNode {
 
     bool is_valid(double value) const override;
     double default_value() const override;
-    std::unique_ptr<NodeStateData> new_data_ptr(std::vector<double>&& number_data) const override;
 
     // Specializations for the linear case
     bool set_value(State& state, ssize_t i, int value) const;
@@ -140,10 +137,6 @@ class BinaryNode : public IntegerNode {
  public:
     explicit BinaryNode(std::initializer_list<ssize_t> shape) : IntegerNode(shape, 0, 1) {}
     explicit BinaryNode(std::span<const ssize_t> shape) : IntegerNode(shape, 0, 1) {}
-
-    // Overloads needed by the NumberNode ABC **************************************
-
-    std::unique_ptr<NodeStateData> new_data_ptr(std::vector<double>&& number_data) const override;
 
     // Specializations for the linear case
     void flip(State& state, ssize_t i) const;

--- a/dwave/optimization/src/nodes/collections.cpp
+++ b/dwave/optimization/src/nodes/collections.cpp
@@ -149,11 +149,6 @@ void CollectionNode::grow(State& state) const {
 }
 
 void CollectionNode::initialize_state(State& state, std::vector<double> contents) const {
-    int index = this->topological_index();
-    assert(index >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > index && "unexpected state length");
-    assert(state[index] == nullptr && "already initialized state");
-
     if (static_cast<ssize_t>(contents.size()) < min_size_) {
         throw std::invalid_argument("contents is shorter than the List's minimum size");
     }
@@ -181,7 +176,7 @@ void CollectionNode::initialize_state(State& state, std::vector<double> contents
 
     assert(static_cast<ssize_t>(contents.size()) == max_value_);
 
-    state[index] = std::make_unique<CollectionStateData>(std::move(contents), set.size());
+    emplace_data_ptr<CollectionStateData>(state, std::move(contents), set.size());
 }
 
 void CollectionNode::revert(State& state) const { data_ptr<CollectionStateData>(state)->revert(); }
@@ -321,15 +316,13 @@ DisjointBitSetsNode::DisjointBitSetsNode(ssize_t primary_set_size, ssize_t num_d
 }
 
 void DisjointBitSetsNode::initialize_state(State& state) const {
-    int index = this->topological_index();
-    state[index] = std::make_unique<DisjointBitSetsNodeData>(primary_set_size_, num_disjoint_sets_);
+    emplace_data_ptr<DisjointBitSetsNodeData>(state, primary_set_size_, num_disjoint_sets_);
 }
 
 void DisjointBitSetsNode::initialize_state(State& state,
                                            const std::vector<std::vector<double>>& contents) const {
-    int index = this->topological_index();
-    state[index] = std::make_unique<DisjointBitSetsNodeData>(primary_set_size_, num_disjoint_sets_,
-                                                             contents);
+    emplace_data_ptr<DisjointBitSetsNodeData>(state, primary_set_size_, num_disjoint_sets_,
+                                              contents);
 }
 
 void DisjointBitSetsNode::commit(State& state) const {
@@ -580,20 +573,14 @@ DisjointListsNode::DisjointListsNode(ssize_t primary_set_size, ssize_t num_disjo
 }
 
 void DisjointListsNode::initialize_state(State& state) const {
-    int index = this->topological_index();
-    state[index] = std::make_unique<DisjointListStateData>(this->primary_set_size(),
-                                                           this->num_disjoint_lists());
+    emplace_data_ptr<DisjointListStateData>(state, this->primary_set_size(),
+                                            this->num_disjoint_lists());
 }
 
 void DisjointListsNode::initialize_state(State& state,
                                          std::vector<std::vector<double>> contents) const {
-    int index = this->topological_index();
-    assert(index >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > index && "unexpected state length");
-    assert(state[index] == nullptr && "already initialized state");
-
-    state[index] = std::make_unique<DisjointListStateData>(
-            this->primary_set_size(), this->num_disjoint_lists(), std::move(contents));
+    emplace_data_ptr<DisjointListStateData>(state, this->primary_set_size(),
+                                            this->num_disjoint_lists(), std::move(contents));
 }
 
 void DisjointListsNode::commit(State& state) const {
@@ -704,22 +691,11 @@ ssize_t DisjointListNode::size_diff(const State& state) const {
 }
 
 void ListNode::initialize_state(State& state) const {
-    int index = this->topological_index();
-    assert(index >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > index && "unexpected state length");
-    assert(state[index] == nullptr && "already initialized state");
-
-    state[index] = std::make_unique<CollectionStateData>(max_size_);
+    emplace_data_ptr<CollectionStateData>(state, max_size_);
 }
 
 void SetNode::initialize_state(State& state) const {
-    int index = this->topological_index();
-    assert(index >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > index && "unexpected state length");
-    assert(state[index] == nullptr && "already initialized state");
-
-    // default to range(min_size_)
-    state[index] = std::make_unique<CollectionStateData>(max_value_, min_size_);
+    emplace_data_ptr<CollectionStateData>(state, max_value_, min_size_);
 }
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/src/nodes/flow.cpp
+++ b/dwave/optimization/src/nodes/flow.cpp
@@ -141,11 +141,6 @@ std::span<const Update> WhereNode::diff(const State& state) const {
 }
 
 void WhereNode::initialize_state(State& state) const {
-    int index = this->topological_index();
-    assert(index >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > index && "unexpected state length");
-    assert(state[index] == nullptr && "already initialized state");
-
     if (condition_ptr_->size() != 1) {
         // `condition` has the same shape as x/y and isn't a single value
         const Array::View condition = condition_ptr_->view(state);
@@ -161,15 +156,15 @@ void WhereNode::initialize_state(State& state) const {
             values.emplace_back((*cit) ? *xit : *yit);
         }
 
-        state[index] = std::make_unique<WhereNodeData>(std::move(values));
+        emplace_data_ptr<WhereNodeData>(state, std::move(values));
     } else if (condition_ptr_->buff(state)[0]) {
         // `condition` is a single value and is currently selecting x
         // so our state is just a copy of x's
-        state[index] = std::make_unique<WhereNodeData>(x_ptr_->view(state));
+        emplace_data_ptr<WhereNodeData>(state, x_ptr_->view(state));
     } else {
         // `condition` is a single value and is currently selecting y
         // so our state is just a copy of y's
-        state[index] = std::make_unique<WhereNodeData>(y_ptr_->view(state));
+        emplace_data_ptr<WhereNodeData>(state, y_ptr_->view(state));
     }
 }
 

--- a/dwave/optimization/src/nodes/manipulation.cpp
+++ b/dwave/optimization/src/nodes/manipulation.cpp
@@ -57,11 +57,6 @@ std::span<const Update> ConcatenateNode::diff(const State& state) const {
 }
 
 void ConcatenateNode::initialize_state(State& state) const {
-    int index = topological_index();
-    assert(index >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > index && "unexpected state length");
-    assert(state[index] == nullptr && "already initialized state");
-
     std::vector<double> values;
     values.resize(size());
 
@@ -74,7 +69,7 @@ void ConcatenateNode::initialize_state(State& state) const {
         std::copy(array_ptrs_[arr_i]->begin(state), array_ptrs_[arr_i]->end(state), view_it);
     }
 
-    state[index] = std::make_unique<ArrayNodeStateData>(std::move(values));
+    emplace_data_ptr<ArrayNodeStateData>(state, std::move(values));
 }
 
 std::vector<ssize_t> make_concatenate_shape(std::span<ArrayNode*> array_ptrs, ssize_t axis) {
@@ -174,12 +169,7 @@ std::span<const Update> CopyNode::diff(const State& state) const {
 bool CopyNode::integral() const { return array_ptr_->integral(); }
 
 void CopyNode::initialize_state(State& state) const {
-    int index = this->topological_index();
-    assert(index >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > index && "unexpected state length");
-    assert(state[index] == nullptr && "already initialized state");
-
-    state[index] = std::make_unique<ArrayNodeStateData>(array_ptr_->view(state));
+    emplace_data_ptr<ArrayNodeStateData>(state, array_ptr_->view(state));
 }
 
 double CopyNode::max() const { return array_ptr_->max(); }
@@ -367,11 +357,6 @@ std::span<const Update> PutNode::diff(const State& state) const {
 }
 
 void PutNode::initialize_state(State& state) const {
-    int index = this->topological_index();
-    assert(index >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > index && "unexpected state length");
-    assert(state[index] == nullptr && "already initialized state");
-
     // Begin by copying the array
     std::vector<double> values(array_ptr_->begin(state), array_ptr_->end(state));
 
@@ -393,7 +378,7 @@ void PutNode::initialize_state(State& state) const {
         }
     }
 
-    state[index] = std::make_unique<PutNodeState>(std::move(values), std::move(mask));
+    emplace_data_ptr<PutNodeState>(state, std::move(values), std::move(mask));
 }
 
 bool PutNode::integral() const {
@@ -589,12 +574,7 @@ std::span<const Update> SizeNode::diff(const State& state) const {
 }
 
 void SizeNode::initialize_state(State& state) const {
-    int index = this->topological_index();
-    assert(index >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > index && "unexpected state length");
-    assert(state[index] == nullptr && "already initialized state");
-
-    state[index] = std::make_unique<SizeNodeData>(array_ptr_->size(state));
+    emplace_data_ptr<SizeNodeData>(state, array_ptr_->size(state));
 }
 
 double SizeNode::max() const {

--- a/dwave/optimization/src/nodes/numbers.cpp
+++ b/dwave/optimization/src/nodes/numbers.cpp
@@ -43,10 +43,6 @@ double NumberNode::upper_bound() const { return upper_bound_; }
 double NumberNode::max() const { return upper_bound_; }
 
 void NumberNode::initialize_state(State& state, std::vector<double>&& number_data) const {
-    assert(this->topological_index() >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > this->topological_index() && "unexpected state length");
-    assert(state[this->topological_index()] == nullptr && "already initialized state");
-
     if (number_data.size() != static_cast<size_t>(this->size())) {
         throw std::invalid_argument("Size of data provided does not match node size");
     }
@@ -56,16 +52,11 @@ void NumberNode::initialize_state(State& state, std::vector<double>&& number_dat
         throw std::invalid_argument("Invalid data provided for node");
     }
 
-    state[this->topological_index()] = new_data_ptr(std::move(number_data));
+    emplace_data_ptr<ArrayNodeStateData>(state, std::move(number_data));
 }
 
 void NumberNode::initialize_state(State& state) const {
-    assert(this->topological_index() >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > this->topological_index() && "unexpected state length");
-    assert(state[this->topological_index()] == nullptr && "already initialized state");
-
-    std::vector<double> number_data(this->size(), default_value());
-    initialize_state(state, std::move(number_data));
+    initialize_state(state, std::vector<double>(this->size(), default_value()));
 }
 
 // Specializations for the linear case
@@ -112,10 +103,6 @@ double IntegerNode::default_value() const {
     return (lower_bound() <= 0 && upper_bound() >= 0) ? 0 : lower_bound();
 }
 
-std::unique_ptr<NodeStateData> IntegerNode::new_data_ptr(std::vector<double>&& number_data) const {
-    return make_unique<ArrayNodeStateData>(std::move(number_data));
-}
-
 bool IntegerNode::set_value(State& state, ssize_t i, int value) const {
     if (!is_valid(value)) {
         throw std::invalid_argument("Invalid integer value provided");
@@ -124,10 +111,6 @@ bool IntegerNode::set_value(State& state, ssize_t i, int value) const {
 }
 
 // Binary Node
-
-std::unique_ptr<NodeStateData> BinaryNode::new_data_ptr(std::vector<double>&& number_data) const {
-    return make_unique<ArrayNodeStateData>(std::move(number_data));
-}
 
 void BinaryNode::flip(State& state, ssize_t i) const {
     auto ptr = data_ptr<ArrayNodeStateData>(state);

--- a/dwave/optimization/src/nodes/quadratic_model.cpp
+++ b/dwave/optimization/src/nodes/quadratic_model.cpp
@@ -292,15 +292,11 @@ void QuadraticModelNode::revert(State& state) const {
 }
 
 void QuadraticModelNode::initialize_state(State& state) const {
-    int index = this->topological_index();
-    assert(index >= 0 && "must be topologically sorted");
-    assert(static_cast<int>(state.size()) > index && "unexpected state length");
-    assert(state[index] == nullptr && "already initialized state");
     auto state_data = dynamic_cast<Array*>(predecessors()[0])->view(state);
     std::vector<double> state_copy(state_data.begin(), state_data.end());
     double value = quadratic_model_.compute_value(state_copy);
-    state[index] = std::make_unique<QuadraticModelNodeData>(value, std::move(state_copy),
-                                                            quadratic_model_.num_variables());
+    emplace_data_ptr<QuadraticModelNodeData>(state, value, std::move(state_copy),
+                                             quadratic_model_.num_variables());
 }
 
 void QuadraticModelNode::propagate(State& state) const {

--- a/dwave/optimization/src/nodes/testing.cpp
+++ b/dwave/optimization/src/nodes/testing.cpp
@@ -60,7 +60,7 @@ void ArrayValidationNode::commit(State& state) const {
 }
 
 void ArrayValidationNode::initialize_state(State& state) const {
-    state[topological_index()] = std::make_unique<ArrayValidationNodeData>(array_ptr->view(state));
+    emplace_data_ptr<ArrayValidationNodeData>(state, array_ptr->view(state));
     assert(array_ptr->diff(state).size() == 0);
     assert(array_ptr->size_diff(state) == 0);
     assert(array_ptr->view(state).size() == static_cast<ssize_t>(array_ptr->size(state)));
@@ -300,7 +300,7 @@ void DynamicArrayTestingNode::initialize_state(State& state, std::span<const dou
     assert(shape.size() > 0);
     shape[0] = values.size() / (strides()[0] / itemsize());
 
-    state[topological_index()] = std::make_unique<DynamicArrayTestingNodeData>(shape, values);
+    emplace_data_ptr<DynamicArrayTestingNodeData>(state, shape, values);
 }
 
 double const* DynamicArrayTestingNode::buff(const State& state) const noexcept {


### PR DESCRIPTION
I kind of hate the name but its consistent with `data_ptr()` so...