### PR TITLE
Use catch2 v3.8.0 for C++ testing

### DIFF
--- a/subprojects/catch2.wrap
+++ b/subprojects/catch2.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = Catch2-3.7.1
-source_url = https://github.com/catchorg/Catch2/archive/v3.7.1.tar.gz
-source_filename = Catch2-3.7.1.tar.gz
-source_hash = c991b247a1a0d7bb9c39aa35faf0fe9e19764213f28ffba3109388e62ee0269c
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/catch2_3.7.1-1/Catch2-3.7.1.tar.gz
-wrapdb_version = 3.7.1-1
+directory = Catch2-3.8.0
+source_url = https://github.com/catchorg/Catch2/archive/v3.8.0.tar.gz
+source_filename = Catch2-3.8.0.tar.gz
+source_hash = 1ab2de20460d4641553addfdfe6acd4109d871d5531f8f519a52ea4926303087
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/catch2_3.8.0-1/Catch2-3.8.0.tar.gz
+wrapdb_version = 3.8.0-1
 
 [provide]
 catch2 = catch2_dep

--- a/tests/cpp/nodes/indexing/test_advanced.cpp
+++ b/tests/cpp/nodes/indexing/test_advanced.cpp
@@ -14,6 +14,7 @@
 
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators.hpp"
+#include "catch2/matchers/catch_matchers_all.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
@@ -21,6 +22,8 @@
 #include "dwave-optimization/nodes/mathematical.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"
 #include "dwave-optimization/nodes/testing.hpp"
+
+using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
@@ -43,7 +46,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(out_ptr->size() == 3);
-                CHECK(std::ranges::equal(out_ptr->shape(), std::vector{3}));
+                CHECK_THAT(out_ptr->shape(), RangeEquals({3}));
 
                 CHECK(array_shape_equal(i_ptr, out_ptr));
                 CHECK(array_shape_equal(j_ptr, out_ptr));
@@ -65,9 +68,9 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 THEN("We can read out the state of the nodes") {
                     CHECK(std::ranges::equal(arr_ptr->view(state), values));
-                    CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0, 1, 2}));
-                    CHECK(std::ranges::equal(j_ptr->view(state), std::vector{1, 2, 0}));
-                    CHECK(std::ranges::equal(out_ptr->view(state), std::vector{1, 5, 6}));
+                    CHECK_THAT(i_ptr->view(state), RangeEquals({0, 1, 2}));
+                    CHECK_THAT(j_ptr->view(state), RangeEquals({1, 2, 0}));
+                    CHECK_THAT(out_ptr->view(state), RangeEquals({1, 5, 6}));
                 }
             }
         }
@@ -83,9 +86,9 @@ TEST_CASE("AdvancedIndexingNode") {
 
         THEN("The resulting array has the size/shape we expect") {
             CHECK(B_ptr->dynamic());
-            CHECK(std::ranges::equal(B_ptr->shape(), std::vector{-1}));
+            CHECK_THAT(B_ptr->shape(), RangeEquals({-1}));
             CHECK(B_ptr->size() == Array::DYNAMIC_SIZE);
-            CHECK(std::ranges::equal(B_ptr->strides(), std::vector{sizeof(double)}));
+            CHECK_THAT(B_ptr->strides(), RangeEquals({sizeof(double)}));
             CHECK(B_ptr->ndim() == 1);
 
             CHECK(array_shape_equal(B_ptr, s_ptr));
@@ -102,8 +105,8 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We have the state we expect") {
                 CHECK(std::ranges::equal(A_ptr->view(state), values));
-                CHECK(std::ranges::equal(s_ptr->view(state), std::vector<double>{}));
-                CHECK(std::ranges::equal(B_ptr->view(state), std::vector<double>{}));
+                CHECK_THAT(s_ptr->view(state), RangeEquals(std::vector<double>{}));
+                CHECK_THAT(B_ptr->view(state), RangeEquals(std::vector<double>{}));
             }
 
             THEN("The resulting array has the same size as the SetNode") {
@@ -119,7 +122,7 @@ TEST_CASE("AdvancedIndexingNode") {
                     CHECK(std::ranges::equal(B_ptr->shape(state), s_ptr->shape(state)));
                     CHECK(B_ptr->size(state) == s_ptr->size(state));
 
-                    CHECK(std::ranges::equal(B_ptr->view(state), std::vector{4}));
+                    CHECK_THAT(B_ptr->view(state), RangeEquals({4}));
                 }
 
                 AND_WHEN("We commit") {
@@ -128,7 +131,7 @@ TEST_CASE("AdvancedIndexingNode") {
                     THEN("The values stick, and the diff is cleared") {
                         CHECK(std::ranges::equal(B_ptr->shape(state), s_ptr->shape(state)));
                         CHECK(B_ptr->size(state) == s_ptr->size(state));
-                        CHECK(std::ranges::equal(B_ptr->view(state), std::vector{4}));
+                        CHECK_THAT(B_ptr->view(state), RangeEquals({4}));
 
                         CHECK(B_ptr->size_diff(state) == 0);
                         CHECK(B_ptr->diff(state).size() == 0);
@@ -141,7 +144,7 @@ TEST_CASE("AdvancedIndexingNode") {
                     THEN("We're back to where we started") {
                         CHECK(std::ranges::equal(B_ptr->shape(state), s_ptr->shape(state)));
                         CHECK(B_ptr->size(state) == s_ptr->size(state));
-                        CHECK(std::ranges::equal(B_ptr->view(state), std::vector<double>{}));
+                        CHECK_THAT(B_ptr->view(state), RangeEquals(std::vector<double>{}));
 
                         CHECK(B_ptr->size_diff(state) == 0);
                         CHECK(B_ptr->diff(state).size() == 0);
@@ -158,7 +161,7 @@ TEST_CASE("AdvancedIndexingNode") {
                     CHECK(std::ranges::equal(B_ptr->shape(state), s_ptr->shape(state)));
                     CHECK(B_ptr->size(state) == s_ptr->size(state));
 
-                    CHECK(std::ranges::equal(B_ptr->view(state), std::vector{4, 3}));
+                    CHECK_THAT(B_ptr->view(state), RangeEquals({4, 3}));
 
                     CHECK(B_ptr->size_diff(state) == 2);  // grew by two
                 }
@@ -169,7 +172,7 @@ TEST_CASE("AdvancedIndexingNode") {
                     THEN("The values stick, and the diff is cleared") {
                         CHECK(std::ranges::equal(B_ptr->shape(state), s_ptr->shape(state)));
                         CHECK(B_ptr->size(state) == s_ptr->size(state));
-                        CHECK(std::ranges::equal(B_ptr->view(state), std::vector{4, 3}));
+                        CHECK_THAT(B_ptr->view(state), RangeEquals({4, 3}));
 
                         CHECK(B_ptr->size_diff(state) == 0);
                         CHECK(B_ptr->diff(state).size() == 0);
@@ -183,7 +186,7 @@ TEST_CASE("AdvancedIndexingNode") {
                             CHECK(std::ranges::equal(B_ptr->shape(state), s_ptr->shape(state)));
                             CHECK(B_ptr->size(state) == s_ptr->size(state));
 
-                            CHECK(std::ranges::equal(B_ptr->view(state), std::vector{4}));
+                            CHECK_THAT(B_ptr->view(state), RangeEquals({4}));
 
                             CHECK(B_ptr->size_diff(state) == -1);  // shrank by one
                         }
@@ -194,7 +197,7 @@ TEST_CASE("AdvancedIndexingNode") {
                             THEN("The values stick, and the diff is cleared") {
                                 CHECK(std::ranges::equal(B_ptr->shape(state), s_ptr->shape(state)));
                                 CHECK(B_ptr->size(state) == s_ptr->size(state));
-                                CHECK(std::ranges::equal(B_ptr->view(state), std::vector{4}));
+                                CHECK_THAT(B_ptr->view(state), RangeEquals({4}));
 
                                 CHECK(B_ptr->size_diff(state) == 0);
                                 CHECK(B_ptr->diff(state).size() == 0);
@@ -207,8 +210,7 @@ TEST_CASE("AdvancedIndexingNode") {
                             THEN("We're back to where we started") {
                                 CHECK(std::ranges::equal(B_ptr->shape(state), s_ptr->shape(state)));
                                 CHECK(B_ptr->size(state) == s_ptr->size(state));
-                                CHECK(std::ranges::equal(B_ptr->view(state),
-                                                         std::vector<double>{4, 3}));
+                                CHECK_THAT(B_ptr->view(state), RangeEquals({4, 3}));
 
                                 CHECK(B_ptr->size_diff(state) == 0);
                                 CHECK(B_ptr->diff(state).size() == 0);
@@ -223,7 +225,7 @@ TEST_CASE("AdvancedIndexingNode") {
                     THEN("We're back to where we started") {
                         CHECK(std::ranges::equal(B_ptr->shape(state), s_ptr->shape(state)));
                         CHECK(B_ptr->size(state) == s_ptr->size(state));
-                        CHECK(std::ranges::equal(B_ptr->view(state), std::vector<double>{}));
+                        CHECK_THAT(B_ptr->view(state), RangeEquals(std::vector<double>{}));
 
                         CHECK(B_ptr->size_diff(state) == 0);
                         CHECK(B_ptr->diff(state).size() == 0);
@@ -245,7 +247,7 @@ TEST_CASE("AdvancedIndexingNode") {
         graph.emplace_node<ArrayValidationNode>(B_ptr);
 
         THEN("Then the resulting matrix has the size/shape we expect") {
-            CHECK(std::ranges::equal(B_ptr->shape(), std::vector{3}));
+            CHECK_THAT(B_ptr->shape(), RangeEquals({3}));
             CHECK(B_ptr->size() == 3);
             CHECK(B_ptr->ndim() == 1);
 
@@ -264,9 +266,9 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We have the state we expect") {
                 CHECK(std::ranges::equal(A_ptr->view(state), values));
-                CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0, 1, 2}));
-                CHECK(std::ranges::equal(j_ptr->view(state), std::vector{0, 1, 2}));
-                CHECK(std::ranges::equal(B_ptr->view(state), std::vector{0, 4, 8}));
+                CHECK_THAT(i_ptr->view(state), RangeEquals({0, 1, 2}));
+                CHECK_THAT(j_ptr->view(state), RangeEquals({0, 1, 2}));
+                CHECK_THAT(B_ptr->view(state), RangeEquals({0, 4, 8}));
             }
         }
 
@@ -278,9 +280,9 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We have the state we expect") {
                 CHECK(std::ranges::equal(A_ptr->view(state), values));
-                CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0, 2, 1}));
-                CHECK(std::ranges::equal(j_ptr->view(state), std::vector{2, 1, 0}));
-                CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2, 7, 3}));
+                CHECK_THAT(i_ptr->view(state), RangeEquals({0, 2, 1}));
+                CHECK_THAT(j_ptr->view(state), RangeEquals({2, 1, 0}));
+                CHECK_THAT(B_ptr->view(state), RangeEquals({2, 7, 3}));
             }
 
             AND_WHEN("We mutate one of the decision variables and then propagate") {
@@ -290,9 +292,9 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 THEN("We have the state we expect") {
                     CHECK(std::ranges::equal(A_ptr->view(state), values));
-                    CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0, 1, 2}));
-                    CHECK(std::ranges::equal(j_ptr->view(state), std::vector{2, 1, 0}));
-                    CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2, 4, 6}));
+                    CHECK_THAT(i_ptr->view(state), RangeEquals({0, 1, 2}));
+                    CHECK_THAT(j_ptr->view(state), RangeEquals({2, 1, 0}));
+                    CHECK_THAT(B_ptr->view(state), RangeEquals({2, 4, 6}));
                 }
 
                 AND_WHEN("We commit") {
@@ -300,9 +302,9 @@ TEST_CASE("AdvancedIndexingNode") {
 
                     THEN("We have the updated state still") {
                         CHECK(std::ranges::equal(A_ptr->view(state), values));
-                        CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0, 1, 2}));
-                        CHECK(std::ranges::equal(j_ptr->view(state), std::vector{2, 1, 0}));
-                        CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2, 4, 6}));
+                        CHECK_THAT(i_ptr->view(state), RangeEquals({0, 1, 2}));
+                        CHECK_THAT(j_ptr->view(state), RangeEquals({2, 1, 0}));
+                        CHECK_THAT(B_ptr->view(state), RangeEquals({2, 4, 6}));
                     }
                 }
 
@@ -311,9 +313,9 @@ TEST_CASE("AdvancedIndexingNode") {
 
                     THEN("We have the original state") {
                         CHECK(std::ranges::equal(A_ptr->view(state), values));
-                        CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0, 2, 1}));
-                        CHECK(std::ranges::equal(j_ptr->view(state), std::vector{2, 1, 0}));
-                        CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2, 7, 3}));
+                        CHECK_THAT(i_ptr->view(state), RangeEquals({0, 2, 1}));
+                        CHECK_THAT(j_ptr->view(state), RangeEquals({2, 1, 0}));
+                        CHECK_THAT(B_ptr->view(state), RangeEquals({2, 7, 3}));
                     }
                 }
             }
@@ -358,7 +360,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 graph.propagate(state, graph.descendants(state, {dyn_ptr}));
 
-                CHECK(std::ranges::equal(B_ptr->view(state), std::vector{0}));
+                CHECK_THAT(B_ptr->view(state), RangeEquals({0}));
             }
         }
 
@@ -371,17 +373,17 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We have the state we expect") {
                 CHECK(dyn_ptr->size(state) == 4);
-                CHECK(std::ranges::equal(dyn_ptr->shape(state), std::vector{2, 2}));
+                CHECK_THAT(dyn_ptr->shape(state), RangeEquals({2, 2}));
 
                 CHECK(i_ptr->size(state) == 2);
-                CHECK(std::ranges::equal(i_ptr->shape(state), std::vector{2}));
-                CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0, 2}));
+                CHECK_THAT(i_ptr->shape(state), RangeEquals({2}));
+                CHECK_THAT(i_ptr->view(state), RangeEquals({0, 2}));
 
                 CHECK(j_ptr->size(state) == 2);
-                CHECK(std::ranges::equal(j_ptr->shape(state), std::vector{2}));
-                CHECK(std::ranges::equal(j_ptr->view(state), std::vector{2, 1}));
+                CHECK_THAT(j_ptr->shape(state), RangeEquals({2}));
+                CHECK_THAT(j_ptr->view(state), RangeEquals({2, 1}));
 
-                CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2, 7}));
+                CHECK_THAT(B_ptr->view(state), RangeEquals({2, 7}));
             }
 
             AND_WHEN("We grow the decision variable and then propagate") {
@@ -391,18 +393,18 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 graph.propagate(state, graph.descendants(state, {dyn_ptr}));
 
-                CHECK(std::ranges::equal(dyn_ptr->view(state), std::vector{0, 2, 2, 1, 1, 0}));
-                CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0, 2, 1}));
-                CHECK(std::ranges::equal(j_ptr->view(state), std::vector{2, 1, 0}));
-                CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2, 7, 3}));
+                CHECK_THAT(dyn_ptr->view(state), RangeEquals({0, 2, 2, 1, 1, 0}));
+                CHECK_THAT(i_ptr->view(state), RangeEquals({0, 2, 1}));
+                CHECK_THAT(j_ptr->view(state), RangeEquals({2, 1, 0}));
+                CHECK_THAT(B_ptr->view(state), RangeEquals({2, 7, 3}));
 
                 AND_WHEN("We revert") {
                     graph.revert(state, graph.descendants(state, {dyn_ptr}));
 
-                    CHECK(std::ranges::equal(dyn_ptr->view(state), std::vector{0, 2, 2, 1}));
-                    CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0, 2}));
-                    CHECK(std::ranges::equal(j_ptr->view(state), std::vector{2, 1}));
-                    CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2, 7}));
+                    CHECK_THAT(dyn_ptr->view(state), RangeEquals({0, 2, 2, 1}));
+                    CHECK_THAT(i_ptr->view(state), RangeEquals({0, 2}));
+                    CHECK_THAT(j_ptr->view(state), RangeEquals({2, 1}));
+                    CHECK_THAT(B_ptr->view(state), RangeEquals({2, 7}));
                     CHECK(B_ptr->diff(state).size() == 0);
                 }
             }
@@ -414,14 +416,14 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 graph.propagate(state, graph.descendants(state, {dyn_ptr}));
 
-                CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0}));
-                CHECK(std::ranges::equal(j_ptr->view(state), std::vector{2}));
-                CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2}));
+                CHECK_THAT(i_ptr->view(state), RangeEquals({0}));
+                CHECK_THAT(j_ptr->view(state), RangeEquals({2}));
+                CHECK_THAT(B_ptr->view(state), RangeEquals({2}));
 
                 AND_WHEN("We revert") {
                     graph.revert(state, graph.descendants(state, {dyn_ptr}));
 
-                    CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2, 7}));
+                    CHECK_THAT(B_ptr->view(state), RangeEquals({2, 7}));
                     CHECK(B_ptr->diff(state).size() == 0);
                 }
             }
@@ -434,14 +436,14 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 graph.propagate(state, graph.descendants(state, {dyn_ptr}));
 
-                CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0}));
-                CHECK(std::ranges::equal(j_ptr->view(state), std::vector{1}));
-                CHECK(std::ranges::equal(B_ptr->view(state), std::vector{1}));
+                CHECK_THAT(i_ptr->view(state), RangeEquals({0}));
+                CHECK_THAT(j_ptr->view(state), RangeEquals({1}));
+                CHECK_THAT(B_ptr->view(state), RangeEquals({1}));
 
                 AND_WHEN("We revert") {
                     graph.revert(state, graph.descendants(state, {dyn_ptr}));
 
-                    CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2, 7}));
+                    CHECK_THAT(B_ptr->view(state), RangeEquals({2, 7}));
                     CHECK(B_ptr->diff(state).size() == 0);
                 }
             }
@@ -458,14 +460,14 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 graph.propagate(state, graph.descendants(state, {dyn_ptr}));
 
-                CHECK(std::ranges::equal(i_ptr->view(state), std::vector{0, 2}));
-                CHECK(std::ranges::equal(j_ptr->view(state), std::vector{2, 1}));
-                CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2, 7}));
+                CHECK_THAT(i_ptr->view(state), RangeEquals({0, 2}));
+                CHECK_THAT(j_ptr->view(state), RangeEquals({2, 1}));
+                CHECK_THAT(B_ptr->view(state), RangeEquals({2, 7}));
 
                 AND_WHEN("We revert") {
                     graph.revert(state, graph.descendants(state, {dyn_ptr}));
 
-                    CHECK(std::ranges::equal(B_ptr->view(state), std::vector{2, 7}));
+                    CHECK_THAT(B_ptr->view(state), RangeEquals({2, 7}));
                     CHECK(B_ptr->diff(state).size() == 0);
                 }
             }
@@ -489,7 +491,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->size() == 10);
-                CHECK(std::ranges::equal(adv->shape(), std::vector{2, 5}));
+                CHECK_THAT(adv->shape(), RangeEquals({2, 5}));
             }
 
             THEN("We see the predecessors we expect") {
@@ -502,8 +504,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 THEN("We can read out the state of the nodes") {
                     CHECK(std::ranges::equal(arr_ptr->view(state), values));
-                    CHECK(std::ranges::equal(adv->view(state),
-                                             std::vector{20, 21, 22, 23, 24, 5, 6, 7, 8, 9}));
+                    CHECK_THAT(adv->view(state), RangeEquals({20, 21, 22, 23, 24, 5, 6, 7, 8, 9}));
                 }
             }
         }
@@ -513,7 +514,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->size() == 6);
-                CHECK(std::ranges::equal(adv->shape(), std::vector{2, 3}));
+                CHECK_THAT(adv->shape(), RangeEquals({2, 3}));
             }
 
             THEN("We see the predecessors we expect") {
@@ -526,7 +527,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 THEN("We can read out the state of the nodes") {
                     CHECK(std::ranges::equal(arr_ptr->view(state), values));
-                    CHECK(std::ranges::equal(adv->view(state), std::vector{16, 21, 26, 1, 6, 11}));
+                    CHECK_THAT(adv->view(state), RangeEquals({16, 21, 26, 1, 6, 11}));
                 }
             }
         }
@@ -553,7 +554,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->size() == 8);
-                CHECK(std::ranges::equal(adv->shape(), std::vector{2, 4}));
+                CHECK_THAT(adv->shape(), RangeEquals({2, 4}));
             }
 
             AND_WHEN("We create a state") {
@@ -561,8 +562,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 THEN("We can read out the state of the nodes") {
                     CHECK(std::ranges::equal(arr_ptr->view(state), values));
-                    CHECK(std::ranges::equal(adv->view(state),
-                                             std::vector{84, 85, 86, 87, 28, 29, 30, 31}));
+                    CHECK_THAT(adv->view(state), RangeEquals({84, 85, 86, 87, 28, 29, 30, 31}));
                 }
             }
         }
@@ -573,7 +573,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->size() == 10);
-                CHECK(std::ranges::equal(adv->shape(), std::vector{2, 5}));
+                CHECK_THAT(adv->shape(), RangeEquals({2, 5}));
             }
 
             AND_WHEN("We create a state") {
@@ -581,8 +581,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 THEN("We can read out the state of the nodes") {
                     CHECK(std::ranges::equal(arr_ptr->view(state), values));
-                    CHECK(std::ranges::equal(adv->view(state),
-                                             std::vector{81, 85, 89, 93, 97, 22, 26, 30, 34, 38}));
+                    CHECK_THAT(adv->view(state), RangeEquals({81, 85, 89, 93, 97, 22, 26, 30, 34, 38}));
                 }
             }
         }
@@ -593,7 +592,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->size() == 6);
-                CHECK(std::ranges::equal(adv->shape(), std::vector{2, 3}));
+                CHECK_THAT(adv->shape(), RangeEquals({2, 3}));
             }
 
             AND_WHEN("We create a state") {
@@ -601,8 +600,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 THEN("We can read out the state of the nodes") {
                     CHECK(std::ranges::equal(arr_ptr->view(state), values));
-                    CHECK(std::ranges::equal(adv->view(state),
-                                             std::vector{65, 85, 105, 6, 26, 46}));
+                    CHECK_THAT(adv->view(state), RangeEquals({65, 85, 105, 6, 26, 46}));
                 }
             }
         }
@@ -613,7 +611,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->size() == 30);
-                CHECK(std::ranges::equal(adv->shape(), std::vector{2, 3, 5}));
+                CHECK_THAT(adv->shape(), RangeEquals({2, 3, 5}));
             }
 
             AND_WHEN("We create a state") {
@@ -636,7 +634,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->size() == 24);
-                CHECK(std::ranges::equal(adv->shape(), std::vector{2, 3, 4}));
+                CHECK_THAT(adv->shape(), RangeEquals({2, 3, 4}));
             }
 
             AND_WHEN("We create a state") {
@@ -644,10 +642,9 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 THEN("We can read out the state of the nodes") {
                     CHECK(std::ranges::equal(arr_ptr->view(state), values));
-                    CHECK(std::ranges::equal(
-                            adv->view(state),
-                            std::vector{64, 65, 66, 67, 84, 85, 86, 87, 104, 105, 106, 107,
-                                        8,  9,  10, 11, 28, 29, 30, 31, 48,  49,  50,  51}));
+                    CHECK_THAT(adv->view(state),
+                               RangeEquals({64, 65, 66, 67, 84, 85, 86, 87, 104, 105, 106, 107,
+                                            8,  9,  10, 11, 28, 29, 30, 31, 48,  49,  50,  51}));
                 }
             }
         }
@@ -658,7 +655,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->size() == 16);
-                CHECK(std::ranges::equal(adv->shape(), std::vector{2, 2, 4}));
+                CHECK_THAT(adv->shape(), RangeEquals({2, 2, 4}));
             }
 
             AND_WHEN("We create a state") {
@@ -666,9 +663,8 @@ TEST_CASE("AdvancedIndexingNode") {
 
                 THEN("We can read out the state of the nodes") {
                     CHECK(std::ranges::equal(arr_ptr->view(state), values));
-                    CHECK(std::ranges::equal(adv->view(state),
-                                             std::vector{24, 25, 26, 27, 8, 9, 10, 11, 84, 85, 86,
-                                                         87, 68, 69, 70, 71}));
+                    CHECK_THAT(adv->view(state), RangeEquals({24, 25, 26, 27, 8, 9, 10, 11, 84, 85,
+                                                              86, 87, 68, 69, 70, 71}));
                 }
             }
         }
@@ -694,14 +690,14 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->dynamic());
-                CHECK(std::ranges::equal(adv->shape(), std::vector{-1, 4}));
+                CHECK_THAT(adv->shape(), RangeEquals({-1, 4}));
             }
 
             AND_WHEN("We create a state") {
                 auto state = graph.initialize_state();
 
                 THEN("The state starts empty") {
-                    CHECK(std::ranges::equal(adv->view(state), std::vector<double>{}));
+                    CHECK_THAT(adv->view(state), RangeEquals(std::vector<double>{}));
                 }
 
                 AND_WHEN("We grow the indexing nodes and propagate") {
@@ -714,8 +710,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                     THEN("The state has the expected values and the diff is correct") {
                         CHECK(adv->size(state) == 8);
-                        CHECK(std::ranges::equal(adv->view(state),
-                                                 std::vector{36, 37, 38, 39, 116, 117, 118, 119}));
+                        CHECK_THAT(adv->view(state), RangeEquals({36, 37, 38, 39, 116, 117, 118, 119}));
                     }
 
                     AND_WHEN("We shrink the indexing nodes and propagate") {
@@ -727,8 +722,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                         THEN("The state has the expected values and the diff is correct") {
                             CHECK(adv->size(state) == 4);
-                            CHECK(std::ranges::equal(adv->view(state),
-                                                     std::vector{36, 37, 38, 39}));
+                            CHECK_THAT(adv->view(state), RangeEquals({36, 37, 38, 39}));
                         }
 
                         AND_WHEN("We revert") {
@@ -755,14 +749,14 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->dynamic());
-                CHECK(std::ranges::equal(adv->shape(), std::vector{-1, 3}));
+                CHECK_THAT(adv->shape(), RangeEquals({-1, 3}));
             }
 
             AND_WHEN("We create a state") {
                 auto state = graph.initialize_state();
 
                 THEN("The state starts empty") {
-                    CHECK(std::ranges::equal(adv->view(state), std::vector<double>{}));
+                    CHECK_THAT(adv->view(state), RangeEquals(std::vector<double>{}));
                 }
 
                 AND_WHEN("We grow the indexing nodes and propagate") {
@@ -775,8 +769,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                     THEN("The state has the expected values and the diff is correct") {
                         CHECK(adv->size(state) == 6);
-                        CHECK(std::ranges::equal(adv->view(state),
-                                                 std::vector{7, 27, 47, 71, 91, 111}));
+                        CHECK_THAT(adv->view(state), RangeEquals({7, 27, 47, 71, 91, 111}));
                     }
 
                     AND_WHEN("We shrink the indexing nodes and propagate") {
@@ -788,7 +781,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                         THEN("The state has the expected values and the diff is correct") {
                             CHECK(adv->size(state) == 3);
-                            CHECK(std::ranges::equal(adv->view(state), std::vector{7, 27, 47}));
+                            CHECK_THAT(adv->view(state), RangeEquals({7, 27, 47}));
                         }
 
                         AND_WHEN("We revert") {
@@ -796,8 +789,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                             THEN("The state has returned to the original") {
                                 CHECK(adv->size(state) == 6);
-                                CHECK(std::ranges::equal(adv->view(state),
-                                                         std::vector{7, 27, 47, 71, 91, 111}));
+                                CHECK_THAT(adv->view(state), RangeEquals({7, 27, 47, 71, 91, 111}));
                                 CHECK(adv->diff(state).size() == 0);
                             }
                         }
@@ -837,7 +829,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv_ptr->dynamic());
-                CHECK(std::ranges::equal(adv_ptr->shape(), std::vector{-1, 3}));
+                CHECK_THAT(adv_ptr->shape(), RangeEquals({-1, 3}));
             }
 
             AND_WHEN("We create a state") {
@@ -870,7 +862,7 @@ TEST_CASE("AdvancedIndexingNode") {
                         graph.commit(state, graph.descendants(state, {arr_ptr, dyn_ptr}));
 
                         THEN("The output is as expected") {
-                            CHECK(std::ranges::equal(adv_ptr->view(state), std::vector{0, -1, 40}));
+                            CHECK_THAT(adv_ptr->view(state), RangeEquals({0, -1, 40}));
                             // ArrayValidationNode checks most of the consistency etc
                         }
                     }
@@ -879,7 +871,7 @@ TEST_CASE("AdvancedIndexingNode") {
                         graph.revert(state, graph.descendants(state, {arr_ptr, dyn_ptr}));
 
                         THEN("The output is as expected") {
-                            CHECK(std::ranges::equal(adv_ptr->view(state), std::vector<double>{}));
+                            CHECK_THAT(adv_ptr->view(state), RangeEquals(std::vector<double>{}));
                             // ArrayValidationNode checks most of the consistency etc
                         }
                     }
@@ -895,7 +887,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv_ptr->dynamic());
-                CHECK(std::ranges::equal(adv_ptr->shape(), std::vector{-1, 3, 4}));
+                CHECK_THAT(adv_ptr->shape(), RangeEquals({-1, 3, 4}));
             }
 
             AND_WHEN("We create a state") {
@@ -940,7 +932,7 @@ TEST_CASE("AdvancedIndexingNode") {
                         graph.revert(state, graph.descendants(state, {arr_ptr, dyn_ptr}));
 
                         THEN("The output is as expected") {
-                            CHECK(std::ranges::equal(adv_ptr->view(state), std::vector<double>{}));
+                            CHECK_THAT(adv_ptr->view(state), RangeEquals(std::vector<double>{}));
                             // ArrayValidationNode checks most of the consistency etc
                         }
                     }
@@ -970,7 +962,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->dynamic());
-                CHECK(std::ranges::equal(adv->shape(), std::vector{-1}));
+                CHECK_THAT(adv->shape(), RangeEquals({-1}));
             }
 
             AND_WHEN("We create a state") {
@@ -981,7 +973,7 @@ TEST_CASE("AdvancedIndexingNode") {
                 graph.initialize_state(state);
 
                 THEN("The state starts empty") {
-                    CHECK(std::ranges::equal(adv->view(state), std::vector<double>{}));
+                    CHECK_THAT(adv->view(state), RangeEquals(std::vector<double>{}));
                 }
 
                 AND_WHEN("We grow the indexing nodes and propagate") {
@@ -991,14 +983,14 @@ TEST_CASE("AdvancedIndexingNode") {
                     graph.propagate(state, graph.descendants(state, {arr_ptr, i_ptr}));
 
                     THEN("The state has the expected values") {
-                        CHECK(std::ranges::equal(adv->view(state), std::vector{3, 5, 7, 2}));
+                        CHECK_THAT(adv->view(state), RangeEquals({3, 5, 7, 2}));
                     }
 
                     AND_WHEN("We revert the indexing nodes") {
                         graph.revert(state, graph.descendants(state, {arr_ptr, i_ptr}));
 
                         THEN("The state goes back to empty") {
-                            CHECK(std::ranges::equal(adv->view(state), std::vector<double>{}));
+                            CHECK_THAT(adv->view(state), RangeEquals(std::vector<double>{}));
                         }
                     }
 
@@ -1006,8 +998,7 @@ TEST_CASE("AdvancedIndexingNode") {
                         graph.commit(state, graph.descendants(state, {arr_ptr, i_ptr}));
 
                         THEN("The final state is correct") {
-                            CHECK(std::ranges::equal(adv->view(state),
-                                                     std::vector<double>{3, 5, 7, 2}));
+                            CHECK_THAT(adv->view(state), RangeEquals({3, 5, 7, 2}));
                         }
 
                         AND_WHEN("We mutate and shrink the indexing array") {
@@ -1017,16 +1008,14 @@ TEST_CASE("AdvancedIndexingNode") {
                             graph.propagate(state, graph.descendants(state, {arr_ptr, i_ptr}));
 
                             THEN("The final state is correct") {
-                                CHECK(std::ranges::equal(adv->view(state),
-                                                         std::vector<double>{3, 5, 6}));
+                                CHECK_THAT(adv->view(state), RangeEquals({3, 5, 6}));
                             }
 
                             AND_WHEN("We revert") {
                                 graph.revert(state, graph.descendants(state, {arr_ptr, i_ptr}));
 
                                 THEN("The state goes back to the previous") {
-                                    CHECK(std::ranges::equal(adv->view(state),
-                                                             std::vector<double>{3, 5, 7, 2}));
+                                    CHECK_THAT(adv->view(state), RangeEquals({3, 5, 7, 2}));
                                 }
                             }
                         }
@@ -1041,16 +1030,14 @@ TEST_CASE("AdvancedIndexingNode") {
                             graph.propagate(state, graph.descendants(state, {arr_ptr, i_ptr}));
 
                             THEN("The state has the expected values") {
-                                CHECK(std::ranges::equal(adv->view(state),
-                                                         std::vector{103, 105, 7, 102}));
+                                CHECK_THAT(adv->view(state), RangeEquals({103, 105, 7, 102}));
                             }
 
                             AND_WHEN("We revert") {
                                 graph.revert(state, graph.descendants(state, {arr_ptr, i_ptr}));
 
                                 THEN("The state has the expected values") {
-                                    CHECK(std::ranges::equal(adv->view(state),
-                                                             std::vector{3, 5, 7, 2}));
+                                    CHECK_THAT(adv->view(state), RangeEquals({3, 5, 7, 2}));
                                 }
                             }
                         }
@@ -1069,16 +1056,14 @@ TEST_CASE("AdvancedIndexingNode") {
                             graph.propagate(state, graph.descendants(state, {arr_ptr, i_ptr}));
 
                             THEN("The state has the expected values") {
-                                CHECK(std::ranges::equal(adv->view(state),
-                                                         std::vector{103, 105, 6, 103, 1}));
+                                CHECK_THAT(adv->view(state), RangeEquals({103, 105, 6, 103, 1}));
                             }
 
                             AND_WHEN("We revert") {
                                 graph.revert(state, graph.descendants(state, {arr_ptr, i_ptr}));
 
                                 THEN("The state has the expected values") {
-                                    CHECK(std::ranges::equal(adv->view(state),
-                                                             std::vector{3, 5, 7, 2}));
+                                    CHECK_THAT(adv->view(state), RangeEquals({3, 5, 7, 2}));
                                 }
                             }
                         }
@@ -1104,7 +1089,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->dynamic());
-                CHECK(std::ranges::equal(adv->shape(), std::vector{-1, 3}));
+                CHECK_THAT(adv->shape(), RangeEquals({-1, 3}));
             }
 
             AND_WHEN("We create a state") {
@@ -1115,7 +1100,7 @@ TEST_CASE("AdvancedIndexingNode") {
                 graph.initialize_state(state);
 
                 THEN("The state starts empty") {
-                    CHECK(std::ranges::equal(adv->view(state), std::vector<double>{}));
+                    CHECK_THAT(adv->view(state), RangeEquals(std::vector<double>{}));
                 }
 
                 AND_WHEN("We grow the main array and propagate") {
@@ -1127,8 +1112,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                     THEN("The state has the expected values and the diff is correct") {
                         CHECK(adv->size(state) == 6);
-                        CHECK(std::ranges::equal(adv->view(state),
-                                                 std::vector{24, 8, 46, 84, 68, 106}));
+                        CHECK_THAT(adv->view(state), RangeEquals({24, 8, 46, 84, 68, 106}));
                     }
 
                     AND_WHEN("We mutate the main array") {
@@ -1145,8 +1129,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                         THEN("The state has the expected values and the diff is correct") {
                             CHECK(adv->size(state) == 6);
-                            CHECK(std::ranges::equal(adv->view(state),
-                                                     std::vector{24, -4, 46, -1, -2, 106}));
+                            CHECK_THAT(adv->view(state), RangeEquals({24, -4, 46, -1, -2, 106}));
                         }
                     }
 
@@ -1164,8 +1147,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                         THEN("The state has the expected values and the diff is correct") {
                             CHECK(adv->size(state) == 6);
-                            CHECK(std::ranges::equal(adv->view(state),
-                                                     std::vector{24, -4, 46, -1, -2, 106}));
+                            CHECK_THAT(adv->view(state), RangeEquals({24, -4, 46, -1, -2, 106}));
                         }
                     }
                 }
@@ -1181,7 +1163,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(adv->dynamic());
-                CHECK(std::ranges::equal(adv->shape(), std::vector{-1, 3, 4}));
+                CHECK_THAT(adv->shape(), RangeEquals({-1, 3, 4}));
             }
 
             AND_WHEN("We create a state") {
@@ -1191,7 +1173,7 @@ TEST_CASE("AdvancedIndexingNode") {
                 graph.initialize_state(state);
 
                 THEN("The state starts empty") {
-                    CHECK(std::ranges::equal(adv->view(state), std::vector<double>{}));
+                    CHECK_THAT(adv->view(state), RangeEquals(std::vector<double>{}));
                 }
 
                 AND_WHEN("We grow the main array and propagate") {
@@ -1207,7 +1189,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                     THEN("The state has the expected values and the diff is correct") {
                         CHECK(adv->size(state) == 2 * 3 * 4);
-                        CHECK(std::ranges::equal(adv->shape(state), std::vector{2, 3, 4}));
+                        CHECK_THAT(adv->shape(state), RangeEquals({2, 3, 4}));
                         CHECK(std::ranges::equal(adv->view(state), expected));
                     }
 
@@ -1234,7 +1216,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                         THEN("The state has the expected values and the diff is correct") {
                             CHECK(adv->size(state) == 2 * 3 * 4);
-                            CHECK(std::ranges::equal(adv->shape(state), std::vector{2, 3, 4}));
+                            CHECK_THAT(adv->shape(state), RangeEquals({2, 3, 4}));
                             CHECK(std::ranges::equal(adv->view(state), new_expected));
                         }
                     }
@@ -1251,7 +1233,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                         THEN("The state has the expected values and the diff is correct") {
                             CHECK(adv->size(state) == 2 * 3 * 4);
-                            CHECK(std::ranges::equal(adv->shape(state), std::vector{2, 3, 4}));
+                            CHECK_THAT(adv->shape(state), RangeEquals({2, 3, 4}));
                             CHECK(std::ranges::equal(adv->view(state), new_expected));
                         }
 
@@ -1286,7 +1268,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
                         THEN("The state has the expected values and the diff is correct") {
                             CHECK(adv->size(state) == 2 * 3 * 4);
-                            CHECK(std::ranges::equal(adv->shape(state), std::vector{2, 3, 4}));
+                            CHECK_THAT(adv->shape(state), RangeEquals({2, 3, 4}));
                             CHECK(std::ranges::equal(adv->view(state), new_expected));
                         }
 
@@ -1326,7 +1308,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(!adv->dynamic());
-                CHECK(std::ranges::equal(adv->shape(), std::vector{5, 4}));
+                CHECK_THAT(adv->shape(), RangeEquals({5, 4}));
             }
 
             AND_WHEN("We create a state") {
@@ -1390,7 +1372,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(!adv->dynamic());
-                CHECK(std::ranges::equal(adv->shape(), std::vector{2, 4}));
+                CHECK_THAT(adv->shape(), RangeEquals({2, 4}));
             }
 
             AND_WHEN("We create a state") {
@@ -1450,7 +1432,7 @@ TEST_CASE("AdvancedIndexingNode") {
 
             THEN("We get the shape we expect") {
                 CHECK(!adv->dynamic());
-                CHECK(std::ranges::equal(adv->shape(), std::vector{5}));
+                CHECK_THAT(adv->shape(), RangeEquals({5}));
             }
 
             AND_WHEN("We create a state") {

--- a/tests/cpp/nodes/indexing/test_basic.cpp
+++ b/tests/cpp/nodes/indexing/test_basic.cpp
@@ -14,6 +14,7 @@
 
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators.hpp"
+#include "catch2/matchers/catch_matchers_all.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
@@ -21,6 +22,8 @@
 #include "dwave-optimization/nodes/mathematical.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"
 #include "dwave-optimization/nodes/testing.hpp"
+
+using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
@@ -226,7 +229,7 @@ TEST_CASE("BasicIndexingNode") {
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 1);
                     CHECK(std::ranges::equal(ptr->shape(state), std::vector<ssize_t>()));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{20}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({20}));
                 }
             }
         }
@@ -249,7 +252,7 @@ TEST_CASE("BasicIndexingNode") {
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 1);
                     CHECK(std::ranges::equal(ptr->shape(state), std::vector<ssize_t>()));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{40}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({40}));
                 }
             }
         }
@@ -260,8 +263,8 @@ TEST_CASE("BasicIndexingNode") {
             THEN("The resulting node has the shape we expect") {
                 CHECK(ptr->ndim() == 1);
                 CHECK(ptr->size() == 1);
-                CHECK(std::ranges::equal(ptr->shape(), std::vector{1}));
-                CHECK(std::ranges::equal(ptr->strides(), std::vector{sizeof(double)}));
+                CHECK_THAT(ptr->shape(), RangeEquals({1}));
+                CHECK_THAT(ptr->strides(), RangeEquals({sizeof(double)}));
 
                 CHECK(ptr->contiguous());
             }
@@ -271,8 +274,8 @@ TEST_CASE("BasicIndexingNode") {
 
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 1);
-                    CHECK(std::ranges::equal(ptr->shape(state), std::vector{1}));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{10}));
+                    CHECK_THAT(ptr->shape(state), RangeEquals({1}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({10}));
                 }
             }
         }
@@ -283,8 +286,8 @@ TEST_CASE("BasicIndexingNode") {
             THEN("The resulting node has the shape we expect") {
                 CHECK(ptr->ndim() == 1);
                 CHECK(ptr->size() == 2);
-                CHECK(std::ranges::equal(ptr->shape(), std::vector{2}));
-                CHECK(std::ranges::equal(ptr->strides(), std::vector{sizeof(double)}));
+                CHECK_THAT(ptr->shape(), RangeEquals({2}));
+                CHECK_THAT(ptr->strides(), RangeEquals({sizeof(double)}));
 
                 CHECK(ptr->contiguous());
             }
@@ -294,8 +297,8 @@ TEST_CASE("BasicIndexingNode") {
 
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 2);
-                    CHECK(std::ranges::equal(ptr->shape(state), std::vector{2}));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{10, 40}));
+                    CHECK_THAT(ptr->shape(state), RangeEquals({2}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({10, 40}));
                 }
             }
         }
@@ -323,8 +326,8 @@ TEST_CASE("BasicIndexingNode") {
 
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 1);
-                    CHECK(std::ranges::equal(ptr->shape(state), std::vector<int>{}));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{7}));
+                    CHECK_THAT(ptr->shape(state), RangeEquals(std::vector<ssize_t>{}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({7}));
                 }
             }
         }
@@ -335,9 +338,8 @@ TEST_CASE("BasicIndexingNode") {
             THEN("The resulting node has the shape we expect") {
                 CHECK(ptr->ndim() == 2);
                 CHECK(ptr->size() == 1);
-                CHECK(std::ranges::equal(ptr->shape(), std::vector{1, 1}));
-                CHECK(std::ranges::equal(ptr->strides(),
-                                         std::vector{3 * sizeof(double), sizeof(double)}));
+                CHECK_THAT(ptr->shape(), RangeEquals({1, 1}));
+                CHECK_THAT(ptr->strides(), RangeEquals({3 * sizeof(double), sizeof(double)}));
 
                 CHECK(ptr->contiguous());
             }
@@ -347,8 +349,8 @@ TEST_CASE("BasicIndexingNode") {
 
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 1);
-                    CHECK(std::ranges::equal(ptr->shape(state), std::vector{1, 1}));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{4}));
+                    CHECK_THAT(ptr->shape(state), RangeEquals({1, 1}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({4}));
                 }
             }
         }
@@ -359,9 +361,8 @@ TEST_CASE("BasicIndexingNode") {
             THEN("The resulting node has the shape we expect") {
                 CHECK(ptr->ndim() == 2);
                 CHECK(ptr->size() == 4);
-                CHECK(std::ranges::equal(ptr->shape(), std::vector{2, 2}));
-                CHECK(std::ranges::equal(ptr->strides(),
-                                         std::vector{3 * sizeof(double), sizeof(double)}));
+                CHECK_THAT(ptr->shape(), RangeEquals({2, 2}));
+                CHECK_THAT(ptr->strides(), RangeEquals({3 * sizeof(double), sizeof(double)}));
 
                 CHECK(!ptr->contiguous());
             }
@@ -371,8 +372,8 @@ TEST_CASE("BasicIndexingNode") {
 
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 4);
-                    CHECK(std::ranges::equal(ptr->shape(state), std::vector{2, 2}));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{1, 2, 4, 5}));
+                    CHECK_THAT(ptr->shape(state), RangeEquals({2, 2}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({1, 2, 4, 5}));
                 }
             }
         }
@@ -383,8 +384,8 @@ TEST_CASE("BasicIndexingNode") {
             THEN("The resulting node has the shape we expect") {
                 CHECK(ptr->ndim() == 1);
                 CHECK(ptr->size() == 2);
-                CHECK(std::ranges::equal(ptr->shape(), std::vector{2}));
-                CHECK(std::ranges::equal(ptr->strides(), std::vector{3 * sizeof(double)}));
+                CHECK_THAT(ptr->shape(), RangeEquals({2}));
+                CHECK_THAT(ptr->strides(), RangeEquals({3 * sizeof(double)}));
 
                 CHECK(!ptr->contiguous());
             }
@@ -394,8 +395,8 @@ TEST_CASE("BasicIndexingNode") {
 
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 2);
-                    CHECK(std::ranges::equal(ptr->shape(state), std::vector{2}));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{2, 5}));
+                    CHECK_THAT(ptr->shape(state), RangeEquals({2}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({2, 5}));
                 }
             }
         }
@@ -406,8 +407,8 @@ TEST_CASE("BasicIndexingNode") {
             THEN("The resulting node has the shape we expect") {
                 CHECK(ptr->ndim() == 1);
                 CHECK(ptr->size() == 3);
-                CHECK(std::ranges::equal(ptr->shape(), std::vector{3}));
-                CHECK(std::ranges::equal(ptr->strides(), std::vector{3 * sizeof(double)}));
+                CHECK_THAT(ptr->shape(), RangeEquals({3}));
+                CHECK_THAT(ptr->strides(), RangeEquals({3 * sizeof(double)}));
 
                 CHECK(!ptr->contiguous());
             }
@@ -417,8 +418,8 @@ TEST_CASE("BasicIndexingNode") {
 
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 3);
-                    CHECK(std::ranges::equal(ptr->shape(state), std::vector{3}));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{2, 5, 8}));
+                    CHECK_THAT(ptr->shape(state), RangeEquals({3}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({2, 5, 8}));
                 }
             }
         }
@@ -429,8 +430,8 @@ TEST_CASE("BasicIndexingNode") {
             THEN("The resulting node has the shape we expect") {
                 CHECK(ptr->ndim() == 1);
                 CHECK(ptr->size() == 2);
-                CHECK(std::ranges::equal(ptr->shape(), std::vector{2}));
-                CHECK(std::ranges::equal(ptr->strides(), std::vector{sizeof(double)}));
+                CHECK_THAT(ptr->shape(), RangeEquals({2}));
+                CHECK_THAT(ptr->strides(), RangeEquals({sizeof(double)}));
 
                 CHECK(ptr->contiguous());
             }
@@ -440,8 +441,8 @@ TEST_CASE("BasicIndexingNode") {
 
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 2);
-                    CHECK(std::ranges::equal(ptr->shape(state), std::vector{2}));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{5, 6}));
+                    CHECK_THAT(ptr->shape(state), RangeEquals({2}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({5, 6}));
                 }
             }
         }
@@ -474,7 +475,7 @@ TEST_CASE("BasicIndexingNode") {
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 1);
                     CHECK(std::ranges::equal(ptr->shape(state), ptr->shape()));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{6}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({6}));
                 }
             }
         }
@@ -486,9 +487,8 @@ TEST_CASE("BasicIndexingNode") {
             THEN("The resulting node has the shape we expect") {
                 CHECK(ptr->ndim() == 2);
                 CHECK(ptr->size() == 2);
-                CHECK(std::ranges::equal(ptr->shape(), std::vector{1, 2}));
-                CHECK(std::ranges::equal(ptr->strides(),
-                                         std::vector{4 * sizeof(double), sizeof(double)}));
+                CHECK_THAT(ptr->shape(), RangeEquals({1, 2}));
+                CHECK_THAT(ptr->strides(), RangeEquals({4 * sizeof(double), sizeof(double)}));
             }
 
             AND_WHEN("We create and then read the state") {
@@ -497,7 +497,7 @@ TEST_CASE("BasicIndexingNode") {
                 THEN("It has the values and shape we expect") {
                     CHECK(ptr->size(state) == 2);
                     CHECK(std::ranges::equal(ptr->shape(state), ptr->shape()));
-                    CHECK(std::ranges::equal(ptr->view(state), std::vector{3, 4}));
+                    CHECK_THAT(ptr->view(state), RangeEquals({3, 4}));
                 }
             }
         }
@@ -512,7 +512,7 @@ TEST_CASE("BasicIndexingNode") {
             auto y_ptr = graph.emplace_node<BasicIndexingNode>(x_ptr, Slice());
 
             THEN("y's shape is independent of state") {
-                CHECK(std::ranges::equal(y_ptr->shape(), std::vector{num_items}));
+                CHECK_THAT(y_ptr->shape(), RangeEquals({num_items}));
                 CHECK(y_ptr->size() == num_items);
                 CHECK(y_ptr->ndim() == 1);
             }
@@ -542,7 +542,7 @@ TEST_CASE("BasicIndexingNode") {
             THEN("We get the value we expect") {
                 CHECK(a_ptr->size(state) == 1);
                 CHECK(a_ptr->shape(state).size() == 0);
-                CHECK(std::ranges::equal(a_ptr->view(state), std::vector{30}));
+                CHECK_THAT(a_ptr->view(state), RangeEquals({30}));
             }
         }
     }
@@ -565,7 +565,7 @@ TEST_CASE("BasicIndexingNode") {
             THEN("We get the value we expect") {
                 CHECK(a_ptr->size(state) == 1);
                 CHECK(a_ptr->shape(state).size() == 0);
-                CHECK(std::ranges::equal(a_ptr->view(state), std::vector{40}));
+                CHECK_THAT(a_ptr->view(state), RangeEquals({40}));
             }
         }
     }
@@ -590,7 +590,7 @@ TEST_CASE("BasicIndexingNode") {
                 CHECK(y_ptr->shape(state).size() == 1);
                 CHECK(y_ptr->shape(state)[0] == y_ptr->size());
 
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{0, 1, 2, 3}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({0, 1, 2, 3}));
             }
         }
     }
@@ -615,7 +615,7 @@ TEST_CASE("BasicIndexingNode") {
                 CHECK(y_ptr->shape(state).size() == 1);
                 CHECK(y_ptr->shape(state)[0] == y_ptr->size());
 
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{1, 2, 3, 4}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({1, 2, 3, 4}));
             }
         }
     }
@@ -634,8 +634,8 @@ TEST_CASE("BasicIndexingNode") {
         auto state = graph.initialize_state();
 
         THEN("We get the default states we expect") {
-            CHECK(std::ranges::equal(x_ptr->view(state), std::vector{0, 1, 2, 3, 4}));
-            CHECK(std::ranges::equal(y_ptr->view(state), std::vector{1, 3}));
+            CHECK_THAT(x_ptr->view(state), RangeEquals({0, 1, 2, 3, 4}));
+            CHECK_THAT(y_ptr->view(state), RangeEquals({1, 3}));
         }
 
         WHEN("We do propagation") {
@@ -644,8 +644,8 @@ TEST_CASE("BasicIndexingNode") {
             graph.propagate(state, graph.descendants(state, {x_ptr}));
 
             THEN("The states are as expected") {
-                CHECK(std::ranges::equal(x_ptr->view(state), std::vector{0, 2, 1, 3, 4}));
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{2, 3}));
+                CHECK_THAT(x_ptr->view(state), RangeEquals({0, 2, 1, 3, 4}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({2, 3}));
             }
         }
     }
@@ -658,9 +658,9 @@ TEST_CASE("BasicIndexingNode") {
         graph.emplace_node<ArrayValidationNode>(y_ptr);
 
         THEN("y has the shape and strides we expect") {
-            CHECK(std::ranges::equal(y_ptr->shape(), std::vector{2, 2}));
+            CHECK_THAT(y_ptr->shape(), RangeEquals({2, 2}));
 
-            CHECK(std::ranges::equal(y_ptr->strides(), std::vector{48, 8}));
+            CHECK_THAT(y_ptr->strides(), RangeEquals({48, 8}));
         }
 
         auto state = graph.initialize_state();
@@ -677,9 +677,8 @@ TEST_CASE("BasicIndexingNode") {
             graph.propagate(state, graph.descendants(state, {x_ptr}));
 
             THEN("The states are as expected") {
-                CHECK(std::ranges::equal(x_ptr->view(state),
-                                         std::vector{1, 1, 0, 0, 0, 0, 0, 0, 0}));
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{1, 0, 0, 0}));
+                CHECK_THAT(x_ptr->view(state), RangeEquals({1, 1, 0, 0, 0, 0, 0, 0, 0}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({1, 0, 0, 0}));
             }
         }
     }
@@ -724,7 +723,7 @@ TEST_CASE("BasicIndexingNode") {
                 CHECK(y_ptr->size(state) == x_ptr->size(state) - 1);
                 CHECK(y_ptr->shape(state).size() == 1);
                 CHECK(y_ptr->shape(state)[0] == y_ptr->size(state));
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{1, 2}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({1, 2}));
             }
         }
     }
@@ -777,7 +776,7 @@ TEST_CASE("BasicIndexingNode") {
                 CHECK(y_ptr->size(state) == 1);
                 REQUIRE(y_ptr->shape(state).size() == 1);
                 CHECK(y_ptr->shape(state)[0] == y_ptr->size(state));
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{0}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({0}));
 
                 graph.commit(state, graph.descendants(state, {x_ptr}));
 
@@ -785,7 +784,7 @@ TEST_CASE("BasicIndexingNode") {
 
                 graph.propagate(state, graph.descendants(state, {x_ptr}));
 
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{0, 1}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({0, 1}));
             }
 
             AND_WHEN("We grow the dynamic array past the range") {
@@ -796,7 +795,7 @@ TEST_CASE("BasicIndexingNode") {
                 CHECK(y_ptr->size(state) == 2);
                 REQUIRE(y_ptr->shape(state).size() == 1);
                 CHECK(y_ptr->shape(state)[0] == y_ptr->size(state));
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{0, 1}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({0, 1}));
 
                 graph.commit(state, graph.descendants(state, {x_ptr}));
 
@@ -818,7 +817,7 @@ TEST_CASE("BasicIndexingNode") {
                 // Now shrink
                 x_ptr->shrink(state);
                 graph.propagate(state, graph.descendants(state, {x_ptr}));
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{0}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({0}));
 
                 graph.commit(state, graph.descendants(state, {x_ptr}));
 
@@ -855,7 +854,7 @@ TEST_CASE("BasicIndexingNode") {
                 x_ptr->shrink(state);          // [0, 1, 4, 3][:-2] = [0, 1]
                 graph.propagate(state, graph.descendants(state, {x_ptr}));
 
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{0, 1}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({0, 1}));
             }
 
             AND_WHEN("We shrink and grow the dynamic array") {
@@ -868,7 +867,7 @@ TEST_CASE("BasicIndexingNode") {
 
                 graph.propagate(state, graph.descendants(state, {x_ptr}));
 
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{0}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({0}));
 
                 graph.commit(state, graph.descendants(state, {x_ptr}));
 
@@ -878,7 +877,7 @@ TEST_CASE("BasicIndexingNode") {
 
                 graph.propagate(state, graph.descendants(state, {x_ptr}));
 
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{0}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({0}));
             }
 
             AND_WHEN("We change the shape of the dynamic array, and then revert") {
@@ -930,7 +929,7 @@ TEST_CASE("BasicIndexingNode") {
                 CHECK(y_ptr->size(state) == 1);
                 CHECK(y_ptr->shape(state).size() == 1);
                 CHECK(y_ptr->shape(state)[0] == 1);
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{0}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({0}));
             }
 
             AND_WHEN("We grow the dynamic array up to the range") {
@@ -942,7 +941,7 @@ TEST_CASE("BasicIndexingNode") {
                 CHECK(y_ptr->size(state) == 2);
                 REQUIRE(y_ptr->shape(state).size() == 1);
                 CHECK(y_ptr->shape(state)[0] == 2);
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{0, 1}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({0, 1}));
 
                 graph.commit(state, graph.descendants(state, {x_ptr}));
 
@@ -950,7 +949,7 @@ TEST_CASE("BasicIndexingNode") {
 
                 graph.propagate(state, graph.descendants(state, {x_ptr}));
 
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{1, 2}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({1, 2}));
             }
 
             AND_WHEN("We grow the dynamic array past the range") {
@@ -961,7 +960,7 @@ TEST_CASE("BasicIndexingNode") {
                 CHECK(y_ptr->size(state) == 2);
                 REQUIRE(y_ptr->shape(state).size() == 1);
                 CHECK(y_ptr->shape(state)[0] == y_ptr->size(state));
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{2, 3}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({2, 3}));
 
                 graph.commit(state, graph.descendants(state, {x_ptr}));
 
@@ -983,7 +982,7 @@ TEST_CASE("BasicIndexingNode") {
                 // Now shrink
                 x_ptr->shrink(state);
                 graph.propagate(state, graph.descendants(state, {x_ptr}));
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{1, 2}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({1, 2}));
 
                 graph.commit(state, graph.descendants(state, {x_ptr}));
 
@@ -991,7 +990,7 @@ TEST_CASE("BasicIndexingNode") {
                 x_ptr->shrink(state);
                 x_ptr->shrink(state);
                 graph.propagate(state, graph.descendants(state, {x_ptr}));
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{0}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({0}));
 
                 graph.commit(state, graph.descendants(state, {x_ptr}));
 
@@ -1011,7 +1010,7 @@ TEST_CASE("BasicIndexingNode") {
 
                 graph.propagate(state, graph.descendants(state, {x_ptr}));
 
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{2, 3}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({2, 3}));
             }
 
             AND_WHEN("We change the shape of the dynamic array, and then revert") {

--- a/tests/cpp/nodes/mathematical/test_binaryop.cpp
+++ b/tests/cpp/nodes/mathematical/test_binaryop.cpp
@@ -14,6 +14,7 @@
 
 #include "catch2/catch_template_test_macros.hpp"
 #include "catch2/catch_test_macros.hpp"
+#include "catch2/matchers/catch_matchers_all.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
@@ -21,6 +22,8 @@
 #include "dwave-optimization/nodes/mathematical.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"
 #include "dwave-optimization/nodes/testing.hpp"
+
+using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
@@ -222,8 +225,8 @@ TEST_CASE("BinaryOpNode - LessEqualNode") {
         auto ge_ptr = graph.emplace_node<LessEqualNode>(y_ptr, x_ptr);
 
         THEN("We have the shape we expect") {
-            CHECK(std::ranges::equal(le_ptr->shape(), std::vector{5}));
-            CHECK(std::ranges::equal(ge_ptr->shape(), std::vector{5}));
+            CHECK_THAT(le_ptr->shape(), RangeEquals({5}));
+            CHECK_THAT(ge_ptr->shape(), RangeEquals({5}));
         }
 
         // let's also toss an ArrayValidationNode on there to do most of the
@@ -238,11 +241,11 @@ TEST_CASE("BinaryOpNode - LessEqualNode") {
             graph.initialize_state(state);
 
             THEN("le == x <= y == [false, false, false, true, true]") {
-                CHECK(std::ranges::equal(le_ptr->view(state), std::vector{0, 0, 0, 1, 1}));
+                CHECK_THAT(le_ptr->view(state), RangeEquals({0, 0, 0, 1, 1}));
             }
 
             THEN("ge == y <= x == [true, true, true, true, false]") {
-                CHECK(std::ranges::equal(ge_ptr->view(state), std::vector{1, 1, 1, 1, 0}));
+                CHECK_THAT(ge_ptr->view(state), RangeEquals({1, 1, 1, 1, 0}));
             }
 
             AND_WHEN("We then set x = 2") {
@@ -250,22 +253,22 @@ TEST_CASE("BinaryOpNode - LessEqualNode") {
                 graph.propagate(state, graph.descendants(state, {x_ptr}));
 
                 THEN("le == x <= y == [false, false, true, true, true]") {
-                    CHECK(std::ranges::equal(le_ptr->view(state), std::vector{0, 0, 1, 1, 1}));
+                    CHECK_THAT(le_ptr->view(state), RangeEquals({0, 0, 1, 1, 1}));
                 }
 
                 THEN("ge == y <= x == [true, true, true, false, false]") {
-                    CHECK(std::ranges::equal(ge_ptr->view(state), std::vector{1, 1, 1, 0, 0}));
+                    CHECK_THAT(ge_ptr->view(state), RangeEquals({1, 1, 1, 0, 0}));
                 }
 
                 AND_WHEN("We commit") {
                     graph.commit(state, graph.descendants(state, {x_ptr}));
 
                     THEN("le == x <= y == [false, false, true, true, true]") {
-                        CHECK(std::ranges::equal(le_ptr->view(state), std::vector{0, 0, 1, 1, 1}));
+                        CHECK_THAT(le_ptr->view(state), RangeEquals({0, 0, 1, 1, 1}));
                     }
 
                     THEN("ge == y <= x == [true, true, true, false, false]") {
-                        CHECK(std::ranges::equal(ge_ptr->view(state), std::vector{1, 1, 1, 0, 0}));
+                        CHECK_THAT(ge_ptr->view(state), RangeEquals({1, 1, 1, 0, 0}));
                     }
                 }
 
@@ -273,11 +276,11 @@ TEST_CASE("BinaryOpNode - LessEqualNode") {
                     graph.revert(state, graph.descendants(state, {x_ptr}));
 
                     THEN("le == x <= y == [false, false, false, true, true]") {
-                        CHECK(std::ranges::equal(le_ptr->view(state), std::vector{0, 0, 0, 1, 1}));
+                        CHECK_THAT(le_ptr->view(state), RangeEquals({0, 0, 0, 1, 1}));
                     }
 
                     THEN("ge == y <= x == [true, true, true, true, false]") {
-                        CHECK(std::ranges::equal(ge_ptr->view(state), std::vector{1, 1, 1, 1, 0}));
+                        CHECK_THAT(ge_ptr->view(state), RangeEquals({1, 1, 1, 1, 0}));
                     }
                 }
             }
@@ -291,8 +294,8 @@ TEST_CASE("BinaryOpNode - LessEqualNode") {
         auto ge_ptr = graph.emplace_node<LessEqualNode>(y_ptr, x_ptr);
 
         THEN("We have the shape we expect") {
-            CHECK(std::ranges::equal(le_ptr->shape(), std::vector{-1}));
-            CHECK(std::ranges::equal(ge_ptr->shape(), std::vector{-1}));
+            CHECK_THAT(le_ptr->shape(), RangeEquals({-1}));
+            CHECK_THAT(ge_ptr->shape(), RangeEquals({-1}));
 
             // derives its size from the dynamic node
             CHECK(le_ptr->sizeinfo() == SizeInfo(y_ptr));
@@ -313,11 +316,11 @@ TEST_CASE("BinaryOpNode - LessEqualNode") {
             graph.initialize_state(state);
 
             THEN("le == x <= y == [true, false, true]") {
-                CHECK(std::ranges::equal(le_ptr->view(state), std::vector{1, 0, 1}));
+                CHECK_THAT(le_ptr->view(state), RangeEquals({1, 0, 1}));
             }
 
             THEN("ge == y <= x == [false, true, true]") {
-                CHECK(std::ranges::equal(ge_ptr->view(state), std::vector{0, 1, 1}));
+                CHECK_THAT(ge_ptr->view(state), RangeEquals({0, 1, 1}));
             }
 
             AND_WHEN("We mutate y to [4, 3, 0, 1]") {
@@ -329,25 +332,25 @@ TEST_CASE("BinaryOpNode - LessEqualNode") {
 
                 // the 1 is actually an implementation detail but let's make that
                 // assumption for the purpose of these tests
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{4, 3, 0, 1}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({4, 3, 0, 1}));
 
                 THEN("le == x <= y == [true, true, false, false]") {
-                    CHECK(std::ranges::equal(le_ptr->view(state), std::vector{1, 1, 0, 0}));
+                    CHECK_THAT(le_ptr->view(state), RangeEquals({1, 1, 0, 0}));
                 }
 
                 THEN("ge == y <= x == [false, true, true, true]") {
-                    CHECK(std::ranges::equal(ge_ptr->view(state), std::vector{0, 1, 1, 1}));
+                    CHECK_THAT(ge_ptr->view(state), RangeEquals({0, 1, 1, 1}));
                 }
 
                 AND_WHEN("We commit") {
                     graph.commit(state, graph.descendants(state, {y_ptr}));
 
                     THEN("le == x <= y == [true, true, false, false]") {
-                        CHECK(std::ranges::equal(le_ptr->view(state), std::vector{1, 1, 0, 0}));
+                        CHECK_THAT(le_ptr->view(state), RangeEquals({1, 1, 0, 0}));
                     }
 
                     THEN("ge == y <= x == [false, true, true, true]") {
-                        CHECK(std::ranges::equal(ge_ptr->view(state), std::vector{0, 1, 1, 1}));
+                        CHECK_THAT(ge_ptr->view(state), RangeEquals({0, 1, 1, 1}));
                     }
                 }
 
@@ -355,11 +358,11 @@ TEST_CASE("BinaryOpNode - LessEqualNode") {
                     graph.revert(state, graph.descendants(state, {y_ptr}));
 
                     THEN("le == x <= y == [true, false, true]") {
-                        CHECK(std::ranges::equal(le_ptr->view(state), std::vector{1, 0, 1}));
+                        CHECK_THAT(le_ptr->view(state), RangeEquals({1, 0, 1}));
                     }
 
                     THEN("ge == y <= x == [false, true, true]") {
-                        CHECK(std::ranges::equal(ge_ptr->view(state), std::vector{0, 1, 1}));
+                        CHECK_THAT(ge_ptr->view(state), RangeEquals({0, 1, 1}));
                     }
                 }
             }

--- a/tests/cpp/nodes/mathematical/test_reduce.cpp
+++ b/tests/cpp/nodes/mathematical/test_reduce.cpp
@@ -15,6 +15,7 @@
 #include "catch2/catch_template_test_macros.hpp"
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/generators/catch_generators.hpp"
+#include "catch2/matchers/catch_matchers_all.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
@@ -22,6 +23,8 @@
 #include "dwave-optimization/nodes/mathematical.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"
 #include "dwave-optimization/nodes/testing.hpp"
+
+using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
@@ -120,11 +123,11 @@ TEST_CASE("PartialReduceNode - PartialProdNode") {
                 /// Check with
                 /// A = np.arange(8).reshape((2, 2, 2))
                 /// np.prod(A, axis=0)
-                CHECK(std::ranges::equal(r_ptr_0->view(state), std::vector{0, 5, 12, 21}));
+                CHECK_THAT(r_ptr_0->view(state), RangeEquals({0, 5, 12, 21}));
                 /// np.prod(A, axis=1)
-                CHECK(std::ranges::equal(r_ptr_1->view(state), std::vector{0, 3, 24, 35}));
+                CHECK_THAT(r_ptr_1->view(state), RangeEquals({0, 3, 24, 35}));
                 /// np.prod(A, axis=2)
-                CHECK(std::ranges::equal(r_ptr_2->view(state), std::vector{0, 6, 20, 42}));
+                CHECK_THAT(r_ptr_2->view(state), RangeEquals({0, 6, 20, 42}));
             }
         }
     }
@@ -165,11 +168,11 @@ TEST_CASE("PartialReduceNode - PartialSumNode") {
                 /// Check with
                 /// A = np.arange(8).reshape((2, 2, 2))
                 /// np.sum(A, axis=0)
-                CHECK(std::ranges::equal(r_ptr_0->view(state), std::vector{4, 6, 8, 10}));
+                CHECK_THAT(r_ptr_0->view(state), RangeEquals({4, 6, 8, 10}));
                 /// np.sum(A, axis=1)
-                CHECK(std::ranges::equal(r_ptr_1->view(state), std::vector{2, 4, 10, 12}));
+                CHECK_THAT(r_ptr_1->view(state), RangeEquals({2, 4, 10, 12}));
                 /// np.sum(A, axis=2)
-                CHECK(std::ranges::equal(r_ptr_2->view(state), std::vector{1, 5, 9, 13}));
+                CHECK_THAT(r_ptr_2->view(state), RangeEquals({1, 5, 9, 13}));
             }
         }
     }
@@ -216,11 +219,9 @@ TEST_CASE("PartialReduceNode - PartialSumNode") {
                     r_ptr_2->propagate(state);
 
                     THEN("The partial reductions are updated correctly") {
-                        CHECK(std::ranges::equal(r_ptr_0->view(state),
-                                                 std::vector{0, 0, 0, 0, 1, 0}));
-                        CHECK(std::ranges::equal(r_ptr_1->view(state), std::vector{1, 0, 0, 0}));
-                        CHECK(std::ranges::equal(r_ptr_2->view(state),
-                                                 std::vector{0, 0, 1, 0, 0, 0}));
+                        CHECK_THAT(r_ptr_0->view(state), RangeEquals({0, 0, 0, 0, 1, 0}));
+                        CHECK_THAT(r_ptr_1->view(state), RangeEquals({1, 0, 0, 0}));
+                        CHECK_THAT(r_ptr_2->view(state), RangeEquals({0, 0, 1, 0, 0, 0}));
                     }
 
                     AND_WHEN("We commit") {
@@ -230,12 +231,9 @@ TEST_CASE("PartialReduceNode - PartialSumNode") {
                         r_ptr_2->commit(state);
 
                         THEN("The values are maintained") {
-                            CHECK(std::ranges::equal(r_ptr_0->view(state),
-                                                     std::vector{0, 0, 0, 0, 1, 0}));
-                            CHECK(std::ranges::equal(r_ptr_1->view(state),
-                                                     std::vector{1, 0, 0, 0}));
-                            CHECK(std::ranges::equal(r_ptr_2->view(state),
-                                                     std::vector{0, 0, 1, 0, 0, 0}));
+                            CHECK_THAT(r_ptr_0->view(state), RangeEquals({0, 0, 0, 0, 1, 0}));
+                            CHECK_THAT(r_ptr_1->view(state), RangeEquals({1, 0, 0, 0}));
+                            CHECK_THAT(r_ptr_2->view(state), RangeEquals({0, 0, 1, 0, 0, 0}));
                         }
                     }
 
@@ -291,9 +289,9 @@ TEST_CASE("PartialReduceNode - PartialSumNode") {
                 /// A = np.arange(8).reshape((2, 2, 2))
                 /// B = A[:, 1, :]
                 /// np.sum(B, axis=0)
-                CHECK(std::ranges::equal(r_ptr_0->view(state), std::vector{8, 10}));
+                CHECK_THAT(r_ptr_0->view(state), RangeEquals({8, 10}));
                 /// np.sum(B, axis=1)
-                CHECK(std::ranges::equal(r_ptr_1->view(state), std::vector{5, 13}));
+                CHECK_THAT(r_ptr_1->view(state), RangeEquals({5, 13}));
             }
         }
     }
@@ -486,8 +484,8 @@ TEST_CASE("ReduceNode - AllNode/AnyNode") {
             graph.initialize_state(state);
 
             THEN("y is false and z is false") {
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{false}));
-                CHECK(std::ranges::equal(z_ptr->view(state), std::vector{false}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({false}));
+                CHECK_THAT(z_ptr->view(state), RangeEquals({false}));
             }
 
             AND_WHEN("x is updated to [0, 0, 1, 0, 0]") {
@@ -495,8 +493,8 @@ TEST_CASE("ReduceNode - AllNode/AnyNode") {
                 graph.propagate(state, {x_ptr, y_ptr, z_ptr});
 
                 THEN("y is false and z is true") {
-                    CHECK(std::ranges::equal(y_ptr->view(state), std::vector{false}));
-                    CHECK(std::ranges::equal(z_ptr->view(state), std::vector{true}));
+                    CHECK_THAT(y_ptr->view(state), RangeEquals({false}));
+                    CHECK_THAT(z_ptr->view(state), RangeEquals({true}));
                 }
 
                 graph.commit(state, {x_ptr, y_ptr, z_ptr});
@@ -506,8 +504,8 @@ TEST_CASE("ReduceNode - AllNode/AnyNode") {
                     graph.propagate(state, {x_ptr, y_ptr, z_ptr});
 
                     THEN("y is false and z is false") {
-                        CHECK(std::ranges::equal(y_ptr->view(state), std::vector{false}));
-                        CHECK(std::ranges::equal(z_ptr->view(state), std::vector{false}));
+                        CHECK_THAT(y_ptr->view(state), RangeEquals({false}));
+                        CHECK_THAT(z_ptr->view(state), RangeEquals({false}));
                     }
                 }
             }
@@ -519,8 +517,8 @@ TEST_CASE("ReduceNode - AllNode/AnyNode") {
             graph.initialize_state(state);
 
             THEN("y is false and z is true") {
-                CHECK(std::ranges::equal(y_ptr->view(state), std::vector{false}));
-                CHECK(std::ranges::equal(z_ptr->view(state), std::vector{true}));
+                CHECK_THAT(y_ptr->view(state), RangeEquals({false}));
+                CHECK_THAT(z_ptr->view(state), RangeEquals({true}));
             }
         }
     }
@@ -543,8 +541,8 @@ TEST_CASE("ReduceNode - AllNode/AnyNode") {
         auto state = graph.initialize_state();
 
         THEN("y and not z") {
-            CHECK(std::ranges::equal(y_ptr->view(state), std::vector{true}));
-            CHECK(std::ranges::equal(z_ptr->view(state), std::vector{false}));
+            CHECK_THAT(y_ptr->view(state), RangeEquals({true}));
+            CHECK_THAT(z_ptr->view(state), RangeEquals({false}));
         }
     }
 }

--- a/tests/cpp/nodes/mathematical/test_unaryop.cpp
+++ b/tests/cpp/nodes/mathematical/test_unaryop.cpp
@@ -14,6 +14,7 @@
 
 #include "catch2/catch_template_test_macros.hpp"
 #include "catch2/catch_test_macros.hpp"
+#include "catch2/matchers/catch_matchers_all.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
@@ -21,6 +22,8 @@
 #include "dwave-optimization/nodes/mathematical.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"
 #include "dwave-optimization/nodes/testing.hpp"
+
+using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
@@ -77,7 +80,7 @@ TEMPLATE_TEST_CASE("UnaryOpNode", "", functional::abs<double>, functional::logic
 
             THEN("The output has the value and shape we expect") {
                 CHECK(p_ptr->size(state) == 0);
-                CHECK(std::ranges::equal(p_ptr->view(state), std::vector<double>{}));
+                CHECK_THAT(p_ptr->view(state), RangeEquals(std::vector<double>{}));
             }
 
             AND_WHEN("We grow the array and then propagate") {
@@ -92,7 +95,7 @@ TEMPLATE_TEST_CASE("UnaryOpNode", "", functional::abs<double>, functional::logic
                 THEN("The output is what we expect") {
                     REQUIRE(p_ptr->size(state) == 1);
                     double val = func(a_ptr->view(state).front());
-                    CHECK(std::ranges::equal(p_ptr->view(state), std::vector{val}));
+                    CHECK_THAT(p_ptr->view(state), RangeEquals({val}));
                 }
 
                 AND_WHEN("We commit") {
@@ -102,7 +105,7 @@ TEMPLATE_TEST_CASE("UnaryOpNode", "", functional::abs<double>, functional::logic
                     THEN("The output is what we expect") {
                         REQUIRE(p_ptr->size(state) == 1);
                         double val = func(a_ptr->view(state).front());
-                        CHECK(std::ranges::equal(p_ptr->view(state), std::vector{val}));
+                        CHECK_THAT(p_ptr->view(state), RangeEquals({val}));
                     }
                 }
 
@@ -112,7 +115,7 @@ TEMPLATE_TEST_CASE("UnaryOpNode", "", functional::abs<double>, functional::logic
 
                     THEN("The output is what we expect") {
                         CHECK(p_ptr->size(state) == 0);
-                        CHECK(std::ranges::equal(p_ptr->view(state), std::vector<double>{}));
+                        CHECK_THAT(p_ptr->view(state), RangeEquals(std::vector<double>{}));
                     }
                 }
             }
@@ -264,8 +267,8 @@ TEST_CASE("UnaryOpNode - LogicalNode") {
 
         THEN("The negation has the state we expect") {
             auto state = graph.initialize_state();
-            CHECK(std::ranges::equal(logical_ptr->view(state),
-                                     std::vector{true, true, false, true, true, true, true}));
+            CHECK_THAT(logical_ptr->view(state),
+                       RangeEquals({true, true, false, true, true, true, true}));
         }
     }
 }
@@ -302,8 +305,8 @@ TEST_CASE("UnaryOpNode - NotNode") {
 
         THEN("The negation has the state we expect") {
             auto state = graph.initialize_state();
-            CHECK(std::ranges::equal(nc_ptr->view(state),
-                                     std::vector{false, false, true, false, false, false, false}));
+            CHECK_THAT(nc_ptr->view(state),
+                       RangeEquals({false, false, true, false, false, false, false}));
         }
     }
 }
@@ -357,8 +360,8 @@ TEST_CASE("UnaryOpNode - RintNode") {
         auto state = graph.initialize_state();
 
         THEN("We get the value we expect") {
-            CHECK(std::ranges::equal(a0_ptr->view(state), std::vector{0}));
-            CHECK(std::ranges::equal(a3_ptr->view(state), std::vector{30}));
+            CHECK_THAT(a0_ptr->view(state), RangeEquals({0}));
+            CHECK_THAT(a3_ptr->view(state), RangeEquals({30}));
         }
     }
 }

--- a/tests/cpp/nodes/test_constants.cpp
+++ b/tests/cpp/nodes/test_constants.cpp
@@ -13,8 +13,11 @@
 //    limitations under the License.
 
 #include "catch2/catch_test_macros.hpp"
+#include "catch2/matchers/catch_matchers_all.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
+
+using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
@@ -27,9 +30,9 @@ TEST_CASE("ConstantNode") {
         THEN("It defaults to an empty 1d array") {
             CHECK(ptr->ndim() == 1);
             CHECK(ptr->size() == 0);
-            CHECK(std::ranges::equal(ptr->data(), std::vector<double>()));
-            CHECK(std::ranges::equal(ptr->shape(), std::vector{0}));
-            CHECK(std::ranges::equal(ptr->strides(), std::vector{sizeof(double)}));
+            CHECK_THAT(ptr->data(), RangeEquals(std::vector<double>()));
+            CHECK_THAT(ptr->shape(), RangeEquals({0}));
+            CHECK_THAT(ptr->strides(), RangeEquals({sizeof(double)}));
         }
 
         THEN("min/max/integral are all well-defined") {
@@ -47,8 +50,8 @@ TEST_CASE("ConstantNode") {
             CHECK(ptr->ndim() == 1);
             CHECK(ptr->size() == 4);
             CHECK(std::ranges::equal(ptr->data(), values));
-            CHECK(std::ranges::equal(ptr->shape(), std::vector{4}));
-            CHECK(std::ranges::equal(ptr->strides(), std::vector{sizeof(double)}));
+            CHECK_THAT(ptr->shape(), RangeEquals({4}));
+            CHECK_THAT(ptr->strides(), RangeEquals({sizeof(double)}));
         }
 
         THEN("min/max/integral all match the vector") {
@@ -61,7 +64,7 @@ TEST_CASE("ConstantNode") {
             values[2] = -105;
 
             THEN("The ConstantNode is not affected because it's a copy") {
-                CHECK(std::ranges::equal(ptr->data(), std::vector{30, 10, 40, 20}));
+                CHECK_THAT(ptr->data(), RangeEquals({30, 10, 40, 20}));
             }
         }
     }
@@ -73,17 +76,16 @@ TEST_CASE("ConstantNode") {
         THEN("It acts as a 2d array") {
             CHECK(ptr->ndim() == 2);
             CHECK(ptr->size() == 4);  // shrunk to fit
-            CHECK(std::ranges::equal(ptr->data(), std::vector{30, 10, 40, 20}));
-            CHECK(std::ranges::equal(ptr->shape(), std::vector{2, 2}));
-            CHECK(std::ranges::equal(ptr->strides(),
-                                     std::vector<int>{2 * sizeof(double), sizeof(double)}));
+            CHECK_THAT(ptr->data(), RangeEquals({30, 10, 40, 20}));
+            CHECK_THAT(ptr->shape(), RangeEquals({2, 2}));
+            CHECK_THAT(ptr->strides(), RangeEquals({2 * sizeof(double), sizeof(double)}));
         }
 
         WHEN("We mutate the original vector") {
             values[2] = -105;
 
             THEN("The ConstantNode is not affected because it's a copy") {
-                CHECK(std::ranges::equal(ptr->data(), std::vector{30, 10, 40, 20}));
+                CHECK_THAT(ptr->data(), RangeEquals({30, 10, 40, 20}));
             }
         }
     }
@@ -94,9 +96,9 @@ TEST_CASE("ConstantNode") {
         THEN("It acts as a single value") {
             CHECK(ptr->ndim() == 0);
             CHECK(ptr->size() == 1);
-            CHECK(std::ranges::equal(ptr->data(), std::vector{6.5}));
-            CHECK(std::ranges::equal(ptr->shape(), std::vector<int>{}));
-            CHECK(std::ranges::equal(ptr->strides(), std::vector<int>{}));
+            CHECK_THAT(ptr->data(), RangeEquals({6.5}));
+            CHECK_THAT(ptr->shape(), RangeEquals(std::vector<int>{}));
+            CHECK_THAT(ptr->strides(), RangeEquals(std::vector<int>{}));
         }
 
         THEN("min/max/integral all match the value") {
@@ -114,17 +116,16 @@ TEST_CASE("ConstantNode") {
         THEN("It acts as a 2d array") {
             CHECK(ptr->ndim() == 2);
             CHECK(ptr->size() == 4);  // shrunk to fit
-            CHECK(std::ranges::equal(ptr->data(), std::vector{30, 10, 40, 20}));
-            CHECK(std::ranges::equal(ptr->shape(), std::vector{2, 2}));
-            CHECK(std::ranges::equal(ptr->strides(),
-                                     std::vector<int>{2 * sizeof(double), sizeof(double)}));
+            CHECK_THAT(ptr->data(), RangeEquals({30, 10, 40, 20}));
+            CHECK_THAT(ptr->shape(), RangeEquals({2, 2}));
+            CHECK_THAT(ptr->strides(), RangeEquals({2 * sizeof(double), sizeof(double)}));
         }
 
         WHEN("We mutate the original vector") {
             values[2] = -105;
 
             THEN("The ConstantNode is mutated accordingly") {
-                CHECK(std::ranges::equal(ptr->data(), std::vector{30, 10, -105, 20}));
+                CHECK_THAT(ptr->data(), RangeEquals({30, 10, -105, 20}));
             }
         }
     }

--- a/tests/cpp/nodes/test_flow.cpp
+++ b/tests/cpp/nodes/test_flow.cpp
@@ -13,11 +13,14 @@
 //    limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
 #include <dwave-optimization/graph.hpp>
 #include <dwave-optimization/nodes/collections.hpp>
 #include <dwave-optimization/nodes/flow.hpp>
 #include <dwave-optimization/nodes/numbers.hpp>
 #include <dwave-optimization/nodes/testing.hpp>
+
+using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
@@ -213,7 +216,7 @@ TEST_CASE("WhereNode") {
         graph.initialize_state(state);
 
         THEN("`where` has the expected output") {
-            CHECK(std::ranges::equal(where_ptr->view(state), std::vector{1, 2, 1, 4}));
+            CHECK_THAT(where_ptr->view(state), RangeEquals({1, 2, 1, 4}));
         }
 
         WHEN("We update `condition`") {
@@ -222,7 +225,7 @@ TEST_CASE("WhereNode") {
             graph.propose(state, {condition_ptr});
 
             THEN("`where` has the expected output") {
-                CHECK(std::ranges::equal(where_ptr->view(state), std::vector{1, 2, 1, 1}));
+                CHECK_THAT(where_ptr->view(state), RangeEquals({1, 2, 1, 1}));
             }
         }
 
@@ -240,7 +243,7 @@ TEST_CASE("WhereNode") {
                 // condition = [4, 1, 0, 2]
                 // x = [4, 3, 3, 4]
                 // y = [3, 2, 2, 1]
-                CHECK(std::ranges::equal(where_ptr->view(state), std::vector{4, 3, 2, 4}));
+                CHECK_THAT(where_ptr->view(state), RangeEquals({4, 3, 2, 4}));
             }
         }
     }

--- a/tests/cpp/nodes/test_numbers.cpp
+++ b/tests/cpp/nodes/test_numbers.cpp
@@ -13,8 +13,11 @@
 //    limitations under the License.
 
 #include "catch2/catch_test_macros.hpp"
+#include "catch2/matchers/catch_matchers_all.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"
+
+using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
@@ -27,8 +30,8 @@ TEST_CASE("BinaryNode") {
         THEN("The shape is fixed") {
             CHECK(ptr->ndim() == 1);
             CHECK(ptr->size() == 10);
-            CHECK(std::ranges::equal(ptr->shape(), std::vector{10}));
-            CHECK(std::ranges::equal(ptr->strides(), std::vector{sizeof(double)}));
+            CHECK_THAT(ptr->shape(), RangeEquals({10}));
+            CHECK_THAT(ptr->strides(), RangeEquals({sizeof(double)}));
         }
 
         WHEN("We create a state using the default value") {
@@ -36,9 +39,8 @@ TEST_CASE("BinaryNode") {
 
             THEN("All elements are zero") {
                 CHECK(ptr->size(state) == 10);
-                CHECK(std::ranges::equal(ptr->shape(state), std::vector{10}));
-                CHECK(std::ranges::equal(ptr->view(state),
-                                         std::vector{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+                CHECK_THAT(ptr->shape(state), RangeEquals({10}));
+                CHECK_THAT(ptr->view(state), RangeEquals({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
             }
         }
 
@@ -62,10 +64,10 @@ TEST_CASE("BinaryNode") {
             graph.initialize_state(state);
 
             THEN("The passed in values are not modified") {
-                CHECK(std::ranges::equal(vec_d, std::vector{0, 1, 0, 1, 0, 1, 0, 1, 0, 1}));
+                CHECK_THAT(vec_d, RangeEquals({0, 1, 0, 1, 0, 1, 0, 1, 0, 1}));
             }
 
-            THEN("We can read the state") { CHECK(std::ranges::equal(ptr->view(state), vec_d)); }
+            THEN("We can read the state") { CHECK_THAT(ptr->view(state), RangeEquals(vec_d)); }
 
             WHEN("We flip the states") {
                 for (int i = 0; i < ptr->size(); i++) {
@@ -74,7 +76,7 @@ TEST_CASE("BinaryNode") {
                 }
 
                 THEN("Elments are flipped properly") {
-                    CHECK(std::ranges::equal(ptr->view(state), vec_d));
+                    CHECK_THAT(ptr->view(state), RangeEquals(vec_d));
                 }
             }
 
@@ -138,9 +140,8 @@ TEST_CASE("BinaryNode") {
         THEN("The shape is fixed") {
             CHECK(ptr->ndim() == 2);
             CHECK(ptr->size() == 25);
-            CHECK(std::ranges::equal(ptr->shape(), std::vector{5, 5}));
-            CHECK(std::ranges::equal(ptr->strides(),
-                                     std::vector<int>{5 * sizeof(double), sizeof(double)}));
+            CHECK_THAT(ptr->shape(), RangeEquals({5, 5}));
+            CHECK_THAT(ptr->strides(), RangeEquals({5 * sizeof(double), sizeof(double)}));
         }
 
         WHEN("We create a state using the default value") {
@@ -148,10 +149,9 @@ TEST_CASE("BinaryNode") {
 
             THEN("All elements are zero") {
                 CHECK(ptr->size(state) == 25);
-                CHECK(std::ranges::equal(ptr->shape(state), std::vector{5, 5}));
-                CHECK(std::ranges::equal(ptr->view(state),
-                                         std::vector{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+                CHECK_THAT(ptr->shape(state), RangeEquals({5, 5}));
+                CHECK_THAT(ptr->view(state), RangeEquals({0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
             }
         }
 
@@ -176,8 +176,8 @@ TEST_CASE("BinaryNode") {
             graph.initialize_state(state);
 
             THEN("The passed in values are not modified") {
-                CHECK(std::ranges::equal(vec_d, std::vector{0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0,
-                                                            1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}));
+                CHECK_THAT(vec_d, RangeEquals({0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0,
+                                               1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}));
             }
 
             THEN("We can read the state") { CHECK(std::ranges::equal(ptr->view(state), vec_d)); }
@@ -314,8 +314,8 @@ TEST_CASE("IntegerNode") {
         THEN("The shape is fixed") {
             CHECK(ptr->ndim() == 1);
             CHECK(ptr->size() == 10);
-            CHECK(std::ranges::equal(ptr->shape(), std::vector{10}));
-            CHECK(std::ranges::equal(ptr->strides(), std::vector{sizeof(double)}));
+            CHECK_THAT(ptr->shape(), RangeEquals({10}));
+            CHECK_THAT(ptr->strides(), RangeEquals({sizeof(double)}));
         }
 
         WHEN("We create a state using the default value") {
@@ -323,9 +323,8 @@ TEST_CASE("IntegerNode") {
 
             THEN("All elements are zero") {
                 CHECK(ptr->size(state) == 10);
-                CHECK(std::ranges::equal(ptr->shape(state), std::vector{10}));
-                CHECK(std::ranges::equal(ptr->view(state),
-                                         std::vector{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+                CHECK_THAT(ptr->shape(state), RangeEquals({10}));
+                CHECK_THAT(ptr->view(state), RangeEquals({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
             }
         }
 
@@ -350,7 +349,7 @@ TEST_CASE("IntegerNode") {
             graph.initialize_state(state);
 
             THEN("The passed in values are not modified") {
-                CHECK(std::ranges::equal(vec_d, std::vector{-4, -4, -2, -2, 0, 0, 2, 2, 4, 4}));
+                CHECK_THAT(vec_d, RangeEquals({-4, -4, -2, -2, 0, 0, 2, 2, 4, 4}));
             }
 
             THEN("We can read the state") { CHECK(std::ranges::equal(ptr->view(state), vec_d)); }

--- a/tests/cpp/nodes/test_quadratic_model.cpp
+++ b/tests/cpp/nodes/test_quadratic_model.cpp
@@ -13,10 +13,13 @@
 //    limitations under the License.
 
 #include "catch2/catch_test_macros.hpp"
+#include "catch2/matchers/catch_matchers_all.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"
 #include "dwave-optimization/nodes/quadratic_model.hpp"
+
+using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
@@ -120,7 +123,7 @@ TEST_CASE("QuadraticModelNode") {
             graph.initialize_state(state);
 
             THEN("We can read the state of the quadratic model node") {
-                CHECK(std::ranges::equal(qnode_ptr->view(state), std::vector<double>{16}));
+                CHECK_THAT(qnode_ptr->view(state), RangeEquals({16}));
             }
 
             WHEN("We update the elements of the binary node and propagate") {
@@ -133,7 +136,7 @@ TEST_CASE("QuadraticModelNode") {
                 qnode_ptr->propagate(state);
 
                 THEN("The state of the quadratic node is changed accordingly") {
-                    CHECK(std::ranges::equal(qnode_ptr->view(state), std::vector<double>{70}));
+                    CHECK_THAT(qnode_ptr->view(state), RangeEquals({70}));
                 }
 
                 WHEN("We commit previous changes and stack more changes") {
@@ -147,7 +150,7 @@ TEST_CASE("QuadraticModelNode") {
                     qnode_ptr->propagate(state);
 
                     THEN("The state of the quadratic node is changed accordingly") {
-                        CHECK(std::ranges::equal(qnode_ptr->view(state), std::vector<double>{0}));
+                        CHECK_THAT(qnode_ptr->view(state), RangeEquals({0}));
                     }
                 }
             }
@@ -170,7 +173,7 @@ TEST_CASE("QuadraticModelNode") {
                 }
 
                 THEN("The state of the quadratic node is changed accordingly") {
-                    CHECK(std::ranges::equal(qnode_ptr->view(state), std::vector<double>{70}));
+                    CHECK_THAT(qnode_ptr->view(state), RangeEquals({70}));
                 }
             }
         }
@@ -186,7 +189,7 @@ TEST_CASE("QuadraticModelNode") {
             graph.initialize_state(state);
 
             THEN("We can read the state of the quadratic model node") {
-                CHECK(std::ranges::equal(qnode_ptr->view(state), std::vector<double>{430}));
+                CHECK_THAT(qnode_ptr->view(state), RangeEquals({430}));
             }
 
             WHEN("We update the elements of the list node and propagate") {
@@ -199,7 +202,7 @@ TEST_CASE("QuadraticModelNode") {
                 qnode_ptr->propagate(state);
 
                 THEN("The state of the quadratic node is changed accordingly") {
-                    CHECK(std::ranges::equal(qnode_ptr->view(state), std::vector<double>{290}));
+                    CHECK_THAT(qnode_ptr->view(state), RangeEquals({290}));
                 }
 
                 WHEN("We commit previous changes and stack more changes") {
@@ -214,7 +217,7 @@ TEST_CASE("QuadraticModelNode") {
                     qnode_ptr->propagate(state);
 
                     THEN("The state of the quadratic node is changed accordingly") {
-                        CHECK(std::ranges::equal(qnode_ptr->view(state), std::vector<double>{430}));
+                        CHECK_THAT(qnode_ptr->view(state), RangeEquals({430}));
                     }
                 }
             }
@@ -243,7 +246,7 @@ TEST_CASE("QuadraticModelNode") {
                 }
 
                 THEN("The state of the quadratic node is changed accordingly") {
-                    CHECK(std::ranges::equal(qnode_ptr->view(state), std::vector<double>{430}));
+                    CHECK_THAT(qnode_ptr->view(state), RangeEquals({430}));
                 }
             }
         }

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -20,6 +20,8 @@
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/state.hpp"
 
+using Catch::Matchers::RangeEquals;
+
 namespace dwave::optimization {
 
 TEST_CASE("Array::View") {
@@ -168,7 +170,7 @@ TEST_CASE("ArrayIterator and ConstArrayIterator") {
             }
 
             THEN("The vector is edited") {
-                CHECK(std::ranges::equal(values, std::vector{-5, 1, -5, 3, -5, 5, -5, 7, -5}));
+                CHECK_THAT(values, RangeEquals({-5, 1, -5, 3, -5, 5, -5, 7, -5}));
             }
         }
 
@@ -270,7 +272,7 @@ TEST_CASE("ArrayIterator and ConstArrayIterator") {
             auto copy = std::vector<double>();
             copy.assign(std::reverse_iterator(ConstArrayIterator(values.data()) + 6),
                         std::reverse_iterator(ConstArrayIterator(values.data())));
-            CHECK(std::ranges::equal(copy, std::vector<double>{5, 4, 3, 2, 1, 0}));
+            CHECK_THAT(copy, RangeEquals({5, 4, 3, 2, 1, 0}));
         }
     }
 }

--- a/tests/cpp/test_utils.cpp
+++ b/tests/cpp/test_utils.cpp
@@ -13,8 +13,11 @@
 //    limitations under the License.
 
 #include "catch2/catch_test_macros.hpp"
+#include "catch2/matchers/catch_matchers_all.hpp"
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/utils.hpp"
+
+using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
@@ -159,8 +162,7 @@ TEST_CASE("Test deduplicate_diff") {
         WHEN("We call deduplicate_diff") {
             deduplicate_diff(updates);
             THEN("deduplicate_diff() sorts them and removes noops") {
-                CHECK(std::ranges::equal(updates,
-                                         std::vector<Update>{Update(2, 1, 0), Update(3, 0, 1)}));
+                CHECK_THAT(updates, RangeEquals({Update(2, 1, 0), Update(3, 0, 1)}));
             }
         }
     }


### PR DESCRIPTION
The upshot is that the newer `Catch2`s let you do
```c++
CHECK_THAT(lhs, RangeEquals({0, 1, 2}));
```
rather than
```c++
CHECK(std::ranges::equal(lhs, std::vector{0, 1, 2}));
```
this is a bit more succinct, and it actually gives a useful error message when they don't match!

```../tests/cpp/nodes/mathematical/test_binaryop.cpp:228: FAILED:
  CHECK_THAT( le_ptr->shape(), RangeEquals({5, 7}) )
with expansion:
  { 5 } elements are { 5, 7 }
```

This PR has no functional changes, but IMO makes for much cleaner test code.

I am also sure I missed a few, but not trying to be 100% complete.