### PR TITLE
Add a meson build option to enable/disable/auto tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -99,9 +99,8 @@ py.extension_module(
 
 install_subdir('dwave', install_dir: py.get_install_dir(pure: false))
 
-# meson doesn't disable building tests by default, so we explicitly don't
-# build them when building for release
-# see https://github.com/mesonbuild/meson/issues/2518
-if get_option('buildtype') != 'release'
+# meson doesn't disable tests by default, so we let the user decide via the build-tests
+# option. If set to 'auto', then we build the tests for non-release builds.
+if get_option('build-tests').enabled() or (get_option('build-tests').auto() and get_option('buildtype') != 'release')
     subdir('tests/cpp/')
 endif

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,10 @@
+option(
+    'build-tests',
+    type: 'feature',
+    value: 'auto',
+    description:
+        'Whether to build the C++ tests.' +
+        'When set to enabled, the tests are always built.' +
+        'When set to disabled, the tests are never built.' +
+        'When set to auto (default), the tests are built when buildtype != release.',
+)


### PR DESCRIPTION
Tests can be disabled with
```bash
meson setup build -Dbuild-tests=disabled
```
by default the tests are built when the `buildtype` is not `release`.