### PR TITLE
Add `Array::minmax()` method

### DIFF
--- a/dwave/optimization/include/dwave-optimization/array.hpp
+++ b/dwave/optimization/include/dwave-optimization/array.hpp
@@ -895,6 +895,7 @@ class Array {
     // If the ``cache.has_value()`` returns ``false``, then the cache is ignored
     // entirely.
     template <class T, class Func>
+    requires (std::same_as<std::invoke_result_t<Func>, T>)
     T memoize(optional_cache_type<T> cache, Func&& func) const {
         // If there is no cache, then just evaluate the function
         if (!cache.has_value()) return func();

--- a/dwave/optimization/include/dwave-optimization/array.hpp
+++ b/dwave/optimization/include/dwave-optimization/array.hpp
@@ -689,6 +689,12 @@ class Array {
     /// A std::random_access_iterator over the values in the array.
     using const_iterator = ArrayIteratorImpl_<true>;
 
+    template<class T>
+    using cache_type = std::unordered_map<const Array*, T>;
+
+    template<class T>
+    using optional_cache_type = std::optional<std::reference_wrapper<cache_type<T>>>;
+
     /// Container-like access to the Array's values as a flat array.
     ///
     /// Satisfies the requirements for std::ranges::random_access_range and
@@ -825,10 +831,14 @@ class Array {
     virtual SizeInfo sizeinfo() const { return dynamic() ? SizeInfo(this) : SizeInfo(size()); }
 
     /// The minimum value that elements in the array may take.
-    virtual double min() const { return std::numeric_limits<double>::lowest(); }
+    double min() const { return minmax().first; }
 
     /// The maximum value that elements in the array may take.
-    virtual double max() const { return std::numeric_limits<double>::max(); }
+    double max() const { return minmax().second; }
+
+    /// The smallest and largest values that elements in the array may take.
+    virtual std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const;
 
     /// Whether the values in the array can be interpreted as integers.
     virtual bool integral() const { return false; }
@@ -878,6 +888,34 @@ class Array {
         }
 
         return true;
+    }
+
+    // Return a cached value if available, and otherwise return the value returned
+    // by ``func()``.
+    // If the ``cache.has_value()`` returns ``false``, then the cache is ignored
+    // entirely.
+    template <class T, class Func>
+    T memoize(optional_cache_type<T> cache, Func&& func) const {
+        // If there is no cache, then just evaluate the function
+        if (!cache.has_value()) return func();
+
+        cache_type<T>& cache_ = cache->get();
+
+        // Otherwise, check if we've already cached a value and return it if so
+        if (auto it = cache_.find(this); it != cache_.end()) {
+            return it->second;
+        }
+
+        // Finally, if we have a cache but we haven't already cached anything, call
+        // the function and cache the output.
+        auto [it, _] = cache_.emplace(this, func());
+        return it->second;
+    }
+    template <class T>
+    T memoize(optional_cache_type<T> cache, T value) const {
+        if (!cache.has_value()) return value;
+        auto [it, _] = cache->get().emplace(this, value);
+        return it->second;
     }
 
     // Determine the size by the shape. For a node with a fixed size, it is simply

--- a/dwave/optimization/include/dwave-optimization/nodes/collections.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/collections.hpp
@@ -40,8 +40,10 @@ class CollectionNode : public ArrayOutputMixin<ArrayNode>, public DecisionNode {
 
     bool integral() const override { return true; }
 
-    double min() const noexcept override { return 0; }
-    double max() const noexcept override { return max_value_ - 1; }
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override {
+        return {0, max_value_ - 1};
+    }
 
     using ArrayOutputMixin::size;  // for size()
     ssize_t size(const State& state) const override;
@@ -158,8 +160,10 @@ class DisjointBitSetNode : public ArrayOutputMixin<ArrayNode> {
 
     bool integral() const override { return true; };
 
-    double min() const noexcept override { return 0; };
-    double max() const noexcept override { return 1; };
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override {
+        return {0, 1};
+    }
 
     // Overloads required by the Node ABC *************************************
 
@@ -233,8 +237,10 @@ class DisjointListNode : public ArrayOutputMixin<ArrayNode> {
 
     bool integral() const override { return true; }
 
-    double min() const noexcept override { return 0; }
-    double max() const noexcept override { return primary_set_size_ - 1; }
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override {
+        return {0, primary_set_size_ - 1};
+    }
 
     using ArrayOutputMixin::size;  // for size()
     ssize_t size(const State& state) const override;

--- a/dwave/optimization/include/dwave-optimization/nodes/collections.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/collections.hpp
@@ -40,10 +40,9 @@ class CollectionNode : public ArrayOutputMixin<ArrayNode>, public DecisionNode {
 
     bool integral() const override { return true; }
 
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
-            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override {
-        return {0, max_value_ - 1};
-    }
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     using ArrayOutputMixin::size;  // for size()
     ssize_t size(const State& state) const override;
@@ -160,10 +159,9 @@ class DisjointBitSetNode : public ArrayOutputMixin<ArrayNode> {
 
     bool integral() const override { return true; };
 
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
-            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override {
-        return {0, 1};
-    }
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     // Overloads required by the Node ABC *************************************
 
@@ -237,10 +235,9 @@ class DisjointListNode : public ArrayOutputMixin<ArrayNode> {
 
     bool integral() const override { return true; }
 
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
-            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override {
-        return {0, primary_set_size_ - 1};
-    }
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     using ArrayOutputMixin::size;  // for size()
     ssize_t size(const State& state) const override;

--- a/dwave/optimization/include/dwave-optimization/nodes/constants.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/constants.hpp
@@ -93,8 +93,8 @@ class ConstantNode : public ArrayOutputMixin<ArrayNode> {
     // Returns ``0.0`` for an empty array.
     // Note that this is an O(size) function call, whereas for most other nodes it
     // is O(1).
-    double max() const override;
-    double min() const override;
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     // Overloads required by the Node ABC *************************************
 

--- a/dwave/optimization/include/dwave-optimization/nodes/flow.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/flow.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <span>
+#include <utility>
 
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/graph.hpp"
@@ -35,8 +36,10 @@ class WhereNode : public ArrayOutputMixin<ArrayNode> {
     std::span<const Update> diff(const State& state) const override;
     void initialize_state(State& state) const override;
     bool integral() const override;
-    double max() const override;
-    double min() const override;
+
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
+
     void propagate(State& state) const override;
     void revert(State& state) const override;
     using Array::shape;

--- a/dwave/optimization/include/dwave-optimization/nodes/flow.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/flow.hpp
@@ -37,6 +37,7 @@ class WhereNode : public ArrayOutputMixin<ArrayNode> {
     void initialize_state(State& state) const override;
     bool integral() const override;
 
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
             optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 

--- a/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
@@ -71,8 +71,8 @@ class AdvancedIndexingNode : public ArrayNode {
 
     // Information about the values are all inherited from the array
     bool integral() const override { return array_ptr_->integral(); }
-    double min() const override { return array_ptr_->min(); }
-    double max() const override { return array_ptr_->max(); }
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     // Node overloads
     void commit(State& state) const override;
@@ -176,8 +176,8 @@ class BasicIndexingNode : public ArrayNode {
 
     // Information about the values are all inherited from the array
     bool integral() const override { return array_ptr_->integral(); }
-    double min() const override { return array_ptr_->min(); }
-    double max() const override { return array_ptr_->max(); }
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     double const* buff(const State& state) const override;
 

--- a/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
@@ -71,6 +71,8 @@ class AdvancedIndexingNode : public ArrayNode {
 
     // Information about the values are all inherited from the array
     bool integral() const override { return array_ptr_->integral(); }
+
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
             optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
@@ -176,6 +178,8 @@ class BasicIndexingNode : public ArrayNode {
 
     // Information about the values are all inherited from the array
     bool integral() const override { return array_ptr_->integral(); }
+
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
             optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 

--- a/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
@@ -36,8 +36,11 @@ class ConcatenateNode : public ArrayOutputMixin<ArrayNode> {
     std::span<const Update> diff(const State& state) const override;
     void initialize_state(State& state) const override;
     bool integral() const override;
-    double max() const override;
-    double min() const override;
+
+    /// @copydoc Array::minmax()
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
+
     void propagate(State& state) const override;
     void revert(State& state) const override;
 
@@ -69,11 +72,9 @@ class CopyNode : public ArrayOutputMixin<ArrayNode> {
     /// @copydoc Array::integral()
     bool integral() const override;
 
-    /// @copydoc Array::max()
-    double max() const override;
-
-    /// @copydoc Array::min()
-    double min() const override;
+    /// @copydoc Array::minmax()
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     /// @copydoc Node::propagate()
     void propagate(State& state) const override;
@@ -138,11 +139,9 @@ class PutNode : public ArrayOutputMixin<ArrayNode> {
     /// Return the number of indices currently "covering" each element in the array.
     std::span<const ssize_t> mask(const State& state) const;
 
-    /// @copydoc Array::max()
-    double max() const override;
-
-    /// @copydoc Array::min()
-    double min() const override;
+    /// @copydoc Array::minmax()
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     /// @copydoc Node::propagate()
     void propagate(State& state) const override;
@@ -186,11 +185,9 @@ class ReshapeNode : public ArrayOutputMixin<ArrayNode> {
     /// @copydoc Array::integral()
     bool integral() const override;
 
-    /// @copydoc Array::max()
-    double max() const override;
-
-    /// @copydoc Array::min()
-    double min() const override;
+    /// @copydoc Array::minmax()
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     /// @copydoc Node::revert()
     void revert(State& state) const override;
@@ -216,9 +213,9 @@ class SizeNode : public ScalarOutputMixin<ArrayNode> {
     // SizeNode's value is always a non-negative integer.
     bool integral() const override { return true; }
 
-    double max() const override;
-
-    double min() const override;
+    /// @copydoc Array::minmax()
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     void propagate(State& state) const override;
 

--- a/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <functional>
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include "dwave-optimization/array.hpp"
@@ -108,8 +109,9 @@ class BinaryOpNode : public ArrayOutputMixin<ArrayNode> {
     double const* buff(const State& state) const override;
     std::span<const Update> diff(const State& state) const override;
     bool integral() const override;
-    double max() const override;
-    double min() const override;
+
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     using ArrayOutputMixin::shape;
     std::span<const ssize_t> shape(const State& state) const override;
@@ -176,8 +178,9 @@ class NaryOpNode : public ArrayOutputMixin<ArrayNode> {
     double const* buff(const State& state) const override;
     std::span<const Update> diff(const State& state) const override;
     bool integral() const override;
-    double max() const override;
-    double min() const override;
+
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     void commit(State& state) const override;
     void revert(State& state) const override;
@@ -229,8 +232,9 @@ class PartialReduceNode : public ArrayOutputMixin<ArrayNode> {
     void initialize_state(State& state) const override;
 
     bool integral() const override;
-    double max() const override;
-    double min() const override;
+
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     // The predecessor of the reduction, as an Array*.
     std::span<Array* const> operands() {
@@ -295,8 +299,9 @@ class ReduceNode : public ScalarOutputMixin<ArrayNode> {
     double const* buff(const State& state) const override;
     std::span<const Update> diff(const State& state) const override;
     bool integral() const override;
-    double max() const override;
-    double min() const override;
+
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     void commit(State& state) const override;
     void revert(State& state) const override;
@@ -344,8 +349,10 @@ class UnaryOpNode : public ArrayOutputMixin<ArrayNode> {
     double const* buff(const State& state) const override;
     std::span<const Update> diff(const State& state) const override;
     bool integral() const override;
-    double max() const override;
-    double min() const override;
+
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
+
     using ArrayOutputMixin::shape;
     std::span<const ssize_t> shape(const State& state) const override;
     using ArrayOutputMixin::size;

--- a/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/mathematical.hpp
@@ -110,6 +110,7 @@ class BinaryOpNode : public ArrayOutputMixin<ArrayNode> {
     std::span<const Update> diff(const State& state) const override;
     bool integral() const override;
 
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
             optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
@@ -179,6 +180,7 @@ class NaryOpNode : public ArrayOutputMixin<ArrayNode> {
     std::span<const Update> diff(const State& state) const override;
     bool integral() const override;
 
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
             optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
@@ -233,6 +235,7 @@ class PartialReduceNode : public ArrayOutputMixin<ArrayNode> {
 
     bool integral() const override;
 
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
             optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
@@ -300,6 +303,7 @@ class ReduceNode : public ScalarOutputMixin<ArrayNode> {
     std::span<const Update> diff(const State& state) const override;
     bool integral() const override;
 
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
             optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
@@ -350,6 +354,7 @@ class UnaryOpNode : public ArrayOutputMixin<ArrayNode> {
     std::span<const Update> diff(const State& state) const override;
     bool integral() const override;
 
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
             optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 

--- a/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
@@ -39,8 +39,9 @@ class NumberNode : public ArrayOutputMixin<ArrayNode>, public DecisionNode {
     void commit(State&) const noexcept override;
     void revert(State&) const noexcept override;
 
-    double min() const override;
-    double max() const override;
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
+
     double lower_bound() const;
     double upper_bound() const;
 

--- a/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
@@ -39,6 +39,7 @@ class NumberNode : public ArrayOutputMixin<ArrayNode>, public DecisionNode {
     void commit(State&) const noexcept override;
     void revert(State&) const noexcept override;
 
+    /// @copydoc Array::minmax()
     std::pair<double, double> minmax(
             optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 

--- a/dwave/optimization/include/dwave-optimization/nodes/testing.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/testing.hpp
@@ -68,8 +68,9 @@ class DynamicArrayTestingNode : public ArrayOutputMixin<ArrayNode>, public Decis
     // lie about min/max/integral for now. We lie in such a way as to create
     // maximum compatibility. In the future we might want to set these values
     // at construction time.
-    double max() const override;
-    double min() const override;
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
+
     bool integral() const override;
     SizeInfo sizeinfo() const override;
 

--- a/dwave/optimization/src/array.cpp
+++ b/dwave/optimization/src/array.cpp
@@ -66,6 +66,11 @@ ssize_t Array::View::size() const {
     return array_ptr_->size(*state_ptr_);
 }
 
+std::pair<double, double> Array::minmax(
+            optional_cache_type<std::pair<double, double>> cache) const {
+    return {std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max()};
+}
+
 SizeInfo::SizeInfo(const Array* array_ptr, std::optional<ssize_t> min, std::optional<ssize_t> max)
         : array_ptr(array_ptr), multiplier(1), offset(0), min(min), max(max) {
     assert(array_ptr->dynamic());

--- a/dwave/optimization/src/nodes/collections.cpp
+++ b/dwave/optimization/src/nodes/collections.cpp
@@ -179,6 +179,11 @@ void CollectionNode::initialize_state(State& state, std::vector<double> contents
     emplace_data_ptr<CollectionStateData>(state, std::move(contents), set.size());
 }
 
+std::pair<double, double> CollectionNode::minmax(
+        optional_cache_type<std::pair<double, double>> cache) const {
+    return {0, max_value_ - 1};
+}
+
 void CollectionNode::revert(State& state) const { data_ptr<CollectionStateData>(state)->revert(); }
 
 std::span<const ssize_t> CollectionNode::shape(const State& state) const {
@@ -353,6 +358,11 @@ std::span<const Update> DisjointBitSetNode::diff(const State& state) const {
     int index = disjoint_bit_sets_node->topological_index();
     DisjointBitSetsNodeData* pred_data = static_cast<DisjointBitSetsNodeData*>(state[index].get());
     return pred_data->diffs[set_index_];
+}
+
+std::pair<double, double> DisjointBitSetNode::minmax(
+        optional_cache_type<std::pair<double, double>> cache) const {
+    return {0, 1};
 }
 
 struct DisjointListStateData : NodeStateData {
@@ -664,6 +674,11 @@ std::span<const Update> DisjointListNode::diff(const State& state) const {
     int index = disjoint_list_node_ptr->topological_index();
     DisjointListStateData* data = static_cast<DisjointListStateData*>(state[index].get());
     return data->all_list_updates[list_index_];
+}
+
+std::pair<double, double> DisjointListNode::minmax(
+        optional_cache_type<std::pair<double, double>> cache) const {
+    return {0, primary_set_size_ - 1};
 }
 
 ssize_t DisjointListNode::size(const State& state) const {

--- a/dwave/optimization/src/nodes/constants.cpp
+++ b/dwave/optimization/src/nodes/constants.cpp
@@ -58,18 +58,22 @@ bool ConstantNode::integral() const {
     return buffer_stats_->integral;
 }
 
-double ConstantNode::max() const {
+std::pair<double, double> ConstantNode::minmax(
+        optional_cache_type<std::pair<double, double>>) const {
+    // The ConstantNode does it's own min/max caching, so we just ignore the
+    // cached passed in and fall back to that.
+
     auto values = this->data();  // all of the values in the array
 
     // If we're empty we return 0.
     // We don't want undefined behavior because there are use cases e.g.
     // indexing by an empty array.
     // So 0 seems like a reasonable default.
-    if (values.empty()) return 0.0;
+    if (values.empty()) return {0.0, 0.0};
 
     // If we're a scalar (or a size-1 array) we can just calculate it in O(1) so let's
     // not bother caching.
-    if (values.size() == 1) return values[0];
+    if (values.size() == 1) return {values[0], values[0]};
 
     // Construct the cache if it's not already there.
     // This only ever happens once, so we do one check outside the mutex for
@@ -80,34 +84,7 @@ double ConstantNode::max() const {
         if (!buffer_stats_) buffer_stats_.emplace(values);
     }
 
-    // Return the cached value
-    return buffer_stats_->max;
-}
-
-double ConstantNode::min() const {
-    auto values = this->data();  // all of the values in the array
-
-    // If we're empty we return 0.
-    // We don't want undefined behavior because there are use cases e.g.
-    // indexing by an empty array.
-    // So 0 seems like a reasonable default.
-    if (values.empty()) return 0.0;
-
-    // If we're a scalar (or a size-1 array) we can just calculate it in O(1) so let's
-    // not bother caching.
-    if (values.size() == 1) return values[0];
-
-    // Construct the cache if it's not already there.
-    // This only ever happens once, so we do one check outside the mutex for
-    // speed, and then another within is to make sure someone else hasn't
-    // already constructed it. Subsequent reads are safe
-    if (!buffer_stats_) {
-        std::lock_guard<std::mutex> guard(buffer_stats_mutex);
-        if (!buffer_stats_) buffer_stats_.emplace(values);
-    }
-
-    // Return the cached value
-    return buffer_stats_->min;
+    return {buffer_stats_->min, buffer_stats_->max};
 }
 
 void ConstantNode::update(State& state, int index) const {

--- a/dwave/optimization/src/nodes/flow.cpp
+++ b/dwave/optimization/src/nodes/flow.cpp
@@ -170,9 +170,13 @@ void WhereNode::initialize_state(State& state) const {
 
 bool WhereNode::integral() const { return x_ptr_->integral() && y_ptr_->integral(); }
 
-double WhereNode::max() const { return std::max(x_ptr_->max(), y_ptr_->max()); }
-
-double WhereNode::min() const { return std::min(x_ptr_->min(), y_ptr_->min()); }
+std::pair<double, double> WhereNode::minmax(
+        optional_cache_type<std::pair<double, double>> cache) const {
+    return memoize(cache, [&]() {
+        const auto [x_min, x_max] = x_ptr_->minmax(cache);
+        const auto [y_min, y_max] = y_ptr_->minmax(cache);
+        return std::make_pair(std::min(x_min, y_min), std::max(x_max, y_max));});
+}
 
 // Given a list of updates on a single `conditional`, did we end up flipping?
 bool _flipped(std::span<const Update> diff) {

--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -631,6 +631,11 @@ void AdvancedIndexingNode::revert(State& state) const {
     data_ptr<AdvancedIndexingNodeData>(state)->revert();
 }
 
+std::pair<double, double> AdvancedIndexingNode::minmax(
+        optional_cache_type<std::pair<double, double>> cache) const {
+    return memoize(cache, [&]() { return array_ptr_->minmax(cache); });
+}
+
 ssize_t AdvancedIndexingNode::size(const State& state) const {
     return dynamic() ? data_ptr<AdvancedIndexingNodeData>(state)->data.size() : this->size();
 }
@@ -1200,6 +1205,11 @@ ssize_t get_smallest_size_during_diff(ssize_t initial_size, const std::span<cons
     }
 
     return minimum_size;
+}
+
+std::pair<double, double> BasicIndexingNode::minmax(
+        optional_cache_type<std::pair<double, double>> cache) const {
+    return memoize(cache, [&]() { return array_ptr_->minmax(cache); });
 }
 
 void BasicIndexingNode::propagate(State& state) const {

--- a/dwave/optimization/src/nodes/numbers.cpp
+++ b/dwave/optimization/src/nodes/numbers.cpp
@@ -37,10 +37,12 @@ void NumberNode::revert(State& state) const noexcept {
 }
 
 double NumberNode::lower_bound() const { return lower_bound_; }
-double NumberNode::min() const { return lower_bound_; }
-
 double NumberNode::upper_bound() const { return upper_bound_; }
-double NumberNode::max() const { return upper_bound_; }
+
+std::pair<double, double> NumberNode::minmax(
+        optional_cache_type<std::pair<double, double>>) const {
+    return {lower_bound_, upper_bound_};
+}
 
 void NumberNode::initialize_state(State& state, std::vector<double>&& number_data) const {
     if (number_data.size() != static_cast<size_t>(this->size())) {

--- a/dwave/optimization/src/nodes/testing.cpp
+++ b/dwave/optimization/src/nodes/testing.cpp
@@ -325,9 +325,11 @@ ssize_t DynamicArrayTestingNode::size_diff(const State& state) const {
     return node_data->current_data.size() - node_data->old_data.size();
 }
 
-double DynamicArrayTestingNode::max() const { return max_.value_or(Array::max()); }
-
-double DynamicArrayTestingNode::min() const { return min_.value_or(Array::min()); }
+std::pair<double, double> DynamicArrayTestingNode::minmax(
+        optional_cache_type<std::pair<double, double>> cache) const {
+    const auto [low, high] = Array::minmax();
+    return {min_.value_or(low), max_.value_or(high)};
+}
 
 bool DynamicArrayTestingNode::integral() const { return integral_; }
 

--- a/releasenotes/notes/Array.minmax-6de0b413d2c77b4c.yaml
+++ b/releasenotes/notes/Array.minmax-6de0b413d2c77b4c.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Add C++ ``Array::minmax()`` method that accepts a ``cache`` argument.
+    This method can avoid a potentially expensive depth first search through
+    the node graph.
+    See `#182 <https://github.com/dwavesystems/dwave-optimization/issues/182>`_.
+upgrade:
+  - |
+    The C++ ``Array::min()`` and ``Array::max()`` methods are no longer ``virtual``,
+    but instead call the more general ``Array::minmax()`` method. Subclasses of
+    ``Array`` should ``override`` the ``Array::minmax()`` method instead.

--- a/tests/cpp/nodes/mathematical/test_binaryop.cpp
+++ b/tests/cpp/nodes/mathematical/test_binaryop.cpp
@@ -383,6 +383,17 @@ TEST_CASE("BinaryOpNode - MultiplyNode") {
             CHECK(y_ptr->max() == 15);
             CHECK(y_ptr->min() == -15);
             CHECK(y_ptr->integral());
+
+            // check that the cache is populated with minmax
+            Array::cache_type<std::pair<double, double>> cache;
+            y_ptr->minmax(cache);
+            // the output of a node depends on the inputs, so it shows
+            // up in cache
+            CHECK(cache.contains(y_ptr));
+            // mutating the cache should also mutate the output
+            cache[y_ptr].first = -1000;
+            CHECK(y_ptr->minmax(cache).first == -1000);
+            CHECK(y_ptr->minmax().first == -15);  // ignores the cache
         }
     }
 

--- a/tests/cpp/nodes/mathematical/test_naryop.cpp
+++ b/tests/cpp/nodes/mathematical/test_naryop.cpp
@@ -202,6 +202,17 @@ TEST_CASE("NaryOpNode - NaryMaximumNode") {
             CHECK(x_ptr->max() == 5);
             CHECK(x_ptr->min() == 2);
             CHECK(x_ptr->integral());
+
+            // check that the cache is populated with minmax
+            Array::cache_type<std::pair<double, double>> cache;
+            x_ptr->minmax(cache);
+            // the output of a node depends on the inputs, so it shows
+            // up in cache
+            CHECK(cache.contains(x_ptr));
+            // mutating the cache should also mutate the output
+            cache[x_ptr].first = -1000;
+            CHECK(x_ptr->minmax(cache).first == -1000);
+            CHECK(x_ptr->minmax().first == 2);  // ignores the cache
         }
     }
 }

--- a/tests/cpp/nodes/mathematical/test_reduce.cpp
+++ b/tests/cpp/nodes/mathematical/test_reduce.cpp
@@ -683,6 +683,17 @@ TEST_CASE("ReduceNode - MaxNode") {
             CHECK(y_ptr->min() == -5);
             CHECK(y_ptr->max() == 2);
             CHECK(y_ptr->integral());
+
+            // check that the cache is populated with minmax
+            Array::cache_type<std::pair<double, double>> cache;
+            y_ptr->minmax(cache);
+            // the output of a node depends on the inputs, so it shows
+            // up in cache
+            CHECK(cache.contains(y_ptr));
+            // mutating the cache should also mutate the output
+            cache[y_ptr].first = -1000;
+            CHECK(y_ptr->minmax(cache).first == -1000);
+            CHECK(y_ptr->minmax().first == -5);  // ignores the cache
         }
     }
 


### PR DESCRIPTION
Changes the ways that C++ ``Array`` subclasses propagate their minimum and maximum possible values. Nodes now should implement a single ``::minmax()`` method. That method is then called from ``Array::min()`` and ``Array::max()``.

The ``::minmax()`` function also optionally accepts a ``cache`` argument. It can be passed in using the `cache_type` type alias. E.g.,
```c++
Array::cache_type<std::pair<double, double>> cache;
const auto [low, high] = node_ptr->minmax(cache);
```


Closes https://github.com/dwavesystems/dwave-optimization/issues/182