### PR TITLE
Tidy serialization code and tests

### DIFF
--- a/dwave/optimization/_model.pyi
+++ b/dwave/optimization/_model.pyi
@@ -28,6 +28,10 @@ _ShapeLike: typing.TypeAlias = typing.Union[int, collections.abc.Sequence[int]]
 _GraphSubclass = typing.TypeVar("_GraphSubclass", bound="_Graph")
 
 
+DEFAULT_SERIALIZATION_VERSION: tuple[int, int]
+KNOWN_SERIALIZATION_VERSIONS: tuple[tuple[int, int], ...]
+
+
 class _Graph:
     def __init__(self, *args, **kwargs) -> typing.NoReturn: ...
 
@@ -48,6 +52,7 @@ class _Graph:
         *,
         max_num_states: int = 0,
         only_decision: bool = False,
+        version: typing.Optional[tuple[int, int]] = None
         ): ...
 
     def is_locked(self) -> bool: ...

--- a/dwave/optimization/_model.pyx
+++ b/dwave/optimization/_model.pyx
@@ -166,14 +166,14 @@ cdef class _Graph:
         read_prefix = file.read(len(prefix))
         if read_prefix != prefix:
             raise ValueError("Unknown file type. Expected magic string "
-                             f"{prefix!r} but recieved {read_prefix!r} "
+                             f"{prefix!r} but received {read_prefix!r} "
                              "instead")
 
         version = tuple(file.read(2))
 
         if version not in KNOWN_SERIALIZATION_VERSIONS:
             raise ValueError("Unknown serialization format. Expected one of "
-                             f"{KNOWN_SERIALIZATION_VERSIONS} but recieved {version} "
+                             f"{KNOWN_SERIALIZATION_VERSIONS} but received {version} "
                              "instead. Upgrading your dwave-optimization version may help.")
 
         if check_header:
@@ -288,6 +288,8 @@ cdef class _Graph:
             only_decision:
                 If ``True``, only decision variables are serialized.
                 If ``False``, all symbols are serialized.
+            version:
+                A 2-tuple indicating which serialization version to use.
 
         See also:
             :meth:`.from_file`, :meth:`.to_file`
@@ -317,7 +319,7 @@ cdef class _Graph:
             version = DEFAULT_SERIALIZATION_VERSION
         elif version not in KNOWN_SERIALIZATION_VERSIONS:
             raise ValueError("Unknown serialization format. Expected one of "
-                             f"{KNOWN_SERIALIZATION_VERSIONS} but recieved {version} "
+                             f"{KNOWN_SERIALIZATION_VERSIONS} but received {version} "
                              "instead. Upgrading your dwave-optimization version may help.")
 
         model_info = self._header_data(

--- a/dwave/optimization/model.py
+++ b/dwave/optimization/model.py
@@ -412,7 +412,15 @@ class Model(_Graph):
             :meth:`.into_file`, :meth:`.from_file`
         """
         file = tempfile.TemporaryFile(mode="w+b")
-        self.into_file(file, **kwargs)
+
+        # into_file can raise an exception, in which case we close off the
+        # tempfile before returning
+        try:
+            self.into_file(file, **kwargs)
+        except Exception:
+            file.close()
+            raise
+
         file.seek(0)
         return file
 

--- a/dwave/optimization/states.pyi
+++ b/dwave/optimization/states.pyi
@@ -37,6 +37,7 @@ class States:
     def into_file(
         self,
         file: typing.Union[typing.BinaryIO, collections.abc.ByteString, str],
+        version: typing.Optional[tuple[int, int]] = None,
         ): ...
 
     def _reset_intermediate_states(self): ...

--- a/dwave/optimization/states.pyx
+++ b/dwave/optimization/states.pyx
@@ -210,6 +210,8 @@ cdef class States:
                 File pointer to an existing writeable, seekable file-like
                 object encoding a model. Strings are interpreted as a file
                 name.
+            version:
+                A 2-tuple indicating which serialization version to use.
 
         TODO: describe the format
         """

--- a/dwave/optimization/states.pyx
+++ b/dwave/optimization/states.pyx
@@ -200,7 +200,9 @@ cdef class States:
             self._states[i].resize(model.num_nodes())
             model._graph.initialize_state(self._states[i])
 
-    def into_file(self, file):
+    def into_file(self, file, *,
+                  version = None,
+                  ):
         """Serialize the states into an existing  file.
 
         Args:
@@ -212,7 +214,12 @@ cdef class States:
         TODO: describe the format
         """
         self.resolve()
-        return self._model().into_file(file, only_decision=True, max_num_states=self.size())
+        return self._model().into_file(
+            file,
+            only_decision=True,
+            max_num_states=self.size(),
+            version=version,
+            )
 
 
     cdef _Graph _model(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -470,7 +470,7 @@ class TestModelSerialization(unittest.TestCase):
         for n0, n1 in zip(model.iter_symbols(), new.iter_symbols()):
             self.assertIs(type(n0), type(n1))
 
-    def test_invalid_version(self):
+    def test_invalid_version_from_file(self):
         from dwave.optimization._model import DEFAULT_SERIALIZATION_VERSION
 
         model = Model()
@@ -490,6 +490,16 @@ class TestModelSerialization(unittest.TestCase):
             # one being thrown
             with self.assertRaisesRegex(ValueError, "Unknown serialization format"):
                 Model.from_file(f)
+
+    def test_invalid_version_into_file(self):
+        model = Model()
+        with io.BytesIO() as f:
+            with self.assertRaisesRegex(ValueError, "Unknown serialization format"):
+                model.into_file(f, version=(255, 255))
+
+        with self.assertRaisesRegex(ValueError, "Unknown serialization format"):
+            with model.to_file(version=(255, 255)) as f:
+                pass
 
     def test_max_num_states(self):
         model = Model()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -12,6 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+import io
 import operator
 import os.path
 import tempfile
@@ -345,96 +346,6 @@ class TestModel(unittest.TestCase):
             self.assertEqual(num_removed, 1)
             self.assertEqual(model.num_symbols(), 9)
 
-    def test_serialization(self):
-        # Create a simple model
-        model = Model()
-        x = model.list(5)
-        W = model.constant(np.arange(25).reshape((5, 5)))
-        model.minimize(W[x, :][:, x].sum())
-
-        # Serialize, then deserialize the model
-        with model.to_file() as f:
-            new = Model.from_file(f)
-
-        new.lock()
-        new.states.resize(3)
-        a, *_ = new.iter_symbols()
-        a.set_state(0, [2, 4, 3, 1, 0])
-        # don't set state 1
-        a.state(2)  # default initialize
-
-        # Attach the new states to the original model
-        with new.states.to_file() as f:
-            model.states.from_file(f)
-
-        self.assertEqual(model.states.size(), 3)
-        np.testing.assert_array_equal(x.state(0), [2, 4, 3, 1, 0])
-        self.assertFalse(a.has_state(1))
-        np.testing.assert_array_equal(a.state(2), range(5))
-
-    def test_serialization_by_filename(self):
-        model = Model()
-        c = model.constant([0, 1, 2, 3, 4])
-        x = model.list(5)
-        model.minimize(c[x].sum())
-
-        with tempfile.TemporaryDirectory() as dirname:
-            fname = os.path.join(dirname, "temp.nl")
-
-            model.into_file(fname)
-
-            new = Model.from_file(fname)
-
-        # todo: use a model equality test function once we have it
-        for n0, n1 in zip(model.iter_symbols(), new.iter_symbols()):
-            self.assertIs(type(n0), type(n1))
-
-    def test_serialization_max_num_states(self):
-        model = Model()
-        model.states.resize(4)
-
-        with self.subTest("large max_num_states"):
-            with model.to_file(max_num_states=100) as f:
-                new = Model.from_file(f)
-            self.assertEqual(new.states.size(), 4)
-
-        with self.subTest("small max_num_states"):
-            with model.to_file(max_num_states=2) as f:
-                new = Model.from_file(f)
-            self.assertEqual(new.states.size(), 2)
-
-    def test_serialization_only_decision(self):
-        model = Model()
-        a = model.list(5)
-        model.constant(100)
-        b = model.list(6)
-        model.constant(14)
-
-        with model.to_file(only_decision="truthy") as f:
-            new = Model.from_file(f)
-
-        self.assertEqual(new.num_nodes(), 2)
-        x, y = new.iter_symbols()
-        self.assertEqual(x.shape(), a.shape())
-        self.assertEqual(y.shape(), b.shape())
-
-    def test_serialization_partially_initialized_states(self):
-        model = Model()
-        x = model.list(10)
-        model.states.resize(3)
-        x.set_state(0, list(reversed(range(10))))
-        # don't set state 1
-        x.state(2)  # default initialize
-
-        with model.to_file(max_num_states=model.states.size()) as f:
-            new = Model.from_file(f)
-
-        a, = new.iter_symbols()
-        self.assertEqual(new.states.size(), 3)
-        np.testing.assert_array_equal(a.state(0), x.state(0))
-        self.assertFalse(a.has_state(1))
-        np.testing.assert_array_equal(a.state(2), x.state(2))
-
     def test_state_size(self):
         self.assertEqual(Model().state_size(), 0)
 
@@ -512,6 +423,119 @@ class TestModel(unittest.TestCase):
         self.assertEqual(len(G.nodes), 6)
         self.assertEqual(len(G.edges), 6)
         self.assertIn("constraint(s)", G.nodes)
+
+
+class TestModelSerialization(unittest.TestCase):
+    def test(self):
+        # Create a simple model
+        model = Model()
+        x = model.list(5)
+        W = model.constant(np.arange(25).reshape((5, 5)))
+        model.minimize(W[x, :][:, x].sum())
+
+        # Serialize, then deserialize the model
+        with model.to_file() as f:
+            new = Model.from_file(f)
+
+        new.lock()
+        new.states.resize(3)
+        a, *_ = new.iter_symbols()
+        a.set_state(0, [2, 4, 3, 1, 0])
+        # don't set state 1
+        a.state(2)  # default initialize
+
+        # Attach the new states to the original model
+        with new.states.to_file() as f:
+            model.states.from_file(f)
+
+        self.assertEqual(model.states.size(), 3)
+        np.testing.assert_array_equal(x.state(0), [2, 4, 3, 1, 0])
+        self.assertFalse(a.has_state(1))
+        np.testing.assert_array_equal(a.state(2), range(5))
+
+    def test_by_filename(self):
+        model = Model()
+        c = model.constant([0, 1, 2, 3, 4])
+        x = model.list(5)
+        model.minimize(c[x].sum())
+
+        with tempfile.TemporaryDirectory() as dirname:
+            fname = os.path.join(dirname, "temp.nl")
+
+            model.into_file(fname)
+
+            new = Model.from_file(fname)
+
+        # todo: use a model equality test function once we have it
+        for n0, n1 in zip(model.iter_symbols(), new.iter_symbols()):
+            self.assertIs(type(n0), type(n1))
+
+    def test_invalid_version(self):
+        from dwave.optimization._model import DEFAULT_SERIALIZATION_VERSION
+
+        model = Model()
+        with io.BytesIO() as f:
+            model.into_file(f)
+
+            # check that the version is in the right place in the header and edit it
+            f.seek(4)
+            self.assertEqual(tuple(f.read(2)), DEFAULT_SERIALIZATION_VERSION)
+
+            # now overwrite it and check that we fail
+            f.seek(4)
+            f.write(b"\xff\xff")
+
+            f.seek(0)
+            # the actual message is longer, but this is sufficient to test it's the
+            # one being thrown
+            with self.assertRaisesRegex(ValueError, "Unknown serialization format"):
+                Model.from_file(f)
+
+    def test_max_num_states(self):
+        model = Model()
+        model.states.resize(4)
+
+        with self.subTest("large max_num_states"):
+            with model.to_file(max_num_states=100) as f:
+                new = Model.from_file(f)
+            self.assertEqual(new.states.size(), 4)
+
+        with self.subTest("small max_num_states"):
+            with model.to_file(max_num_states=2) as f:
+                new = Model.from_file(f)
+            self.assertEqual(new.states.size(), 2)
+
+    def test_only_decision(self):
+        model = Model()
+        a = model.list(5)
+        model.constant(100)
+        b = model.list(6)
+        model.constant(14)
+
+        with model.to_file(only_decision="truthy") as f:
+            new = Model.from_file(f)
+
+        self.assertEqual(new.num_nodes(), 2)
+        x, y = new.iter_symbols()
+        self.assertEqual(x.shape(), a.shape())
+        self.assertEqual(y.shape(), b.shape())
+
+    def test_partially_initialized_states(self):
+        model = Model()
+        x = model.list(10)
+        model.states.resize(3)
+        x.set_state(0, list(reversed(range(10))))
+        # don't set state 1
+        x.state(2)  # default initialize
+
+        with model.to_file(max_num_states=model.states.size()) as f:
+            new = Model.from_file(f)
+
+        a, = new.iter_symbols()
+        self.assertEqual(new.states.size(), 3)
+        np.testing.assert_array_equal(a.state(0), x.state(0))
+        self.assertFalse(a.has_state(1))
+        np.testing.assert_array_equal(a.state(2), x.state(2))
 
 
 class TestSymbol(unittest.TestCase):

--- a/tests/test_states.py
+++ b/tests/test_states.py
@@ -137,7 +137,9 @@ class TestStates(unittest.TestCase):
         model.states.resize(10)
         self.assertEqual(model.states.size(), 10)
 
-    def test_serialization(self):
+
+class TestStatesSerialization(unittest.TestCase):
+    def test(self):
         model = Model()
         x = model.list(10)
         model.states.resize(3)
@@ -158,7 +160,7 @@ class TestStates(unittest.TestCase):
         self.assertFalse(a.has_state(1))
         np.testing.assert_array_equal(a.state(2), x.state(2))
 
-    def test_serialization_bad(self):
+    def test_bad(self):
         model = Model()
         x = model.list(10)
         model.states.resize(1)


### PR DESCRIPTION
The first of a series of serialization PRs to support v1. This one is mostly focused on tidying the existing code to make later PRs easier to review.

The only functional change is the addition of a `version` keyword argument for `to_file()`. I also did some test reorganization which will help the followup PRs.

I'll add a release note once the `version` keyword argument actually does something.

See also https://github.com/dwavesystems/dwave-optimization/issues/223