### PR TITLE
Remove some erroneous asserts

### DIFF
--- a/dwave/optimization/src/nodes/mathematical.cpp
+++ b/dwave/optimization/src/nodes/mathematical.cpp
@@ -251,8 +251,6 @@ std::pair<double, double> BinaryOpNode<BinaryOp>::minmax(
     if constexpr (std::same_as<BinaryOp, std::divides<double>> ||
                   std::same_as<BinaryOp, std::multiplies<double>>) {
         // The constructor should prevent us from getting here, but just in case...
-        assert((!std::same_as<BinaryOp, std::divides<double>> || lhs_low != 0));
-        assert((!std::same_as<BinaryOp, std::divides<double>> || lhs_high != 0));
         assert((!std::same_as<BinaryOp, std::divides<double>> || rhs_low != 0));
         assert((!std::same_as<BinaryOp, std::divides<double>> || rhs_high != 0));
 

--- a/tests/cpp/nodes/mathematical/test_binaryop.cpp
+++ b/tests/cpp/nodes/mathematical/test_binaryop.cpp
@@ -427,6 +427,19 @@ TEST_CASE("BinaryOpNode - DivideNode") {
         }
     }
 
+    GIVEN("a = 0, x = IntegerNode(1, 5), y = a / x") {
+        auto a_ptr = graph.emplace_node<ConstantNode>(0);
+        auto x_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{}, 1, 5);
+
+        auto y_ptr = graph.emplace_node<DivideNode>(a_ptr, x_ptr);
+
+        THEN("y's max/min/integral are as expected") {
+            CHECK(y_ptr->max() == 0);
+            CHECK(y_ptr->min() == 0);
+            CHECK_FALSE(y_ptr->integral());
+        }
+    }
+
     GIVEN("x = IntegerNode(-5, 5), a = -3, y = x / a") {
         auto x_ptr = graph.emplace_node<IntegerNode>(std::vector<ssize_t>{}, -5, 5);
         auto a_ptr = graph.emplace_node<ConstantNode>(-3);


### PR DESCRIPTION
We do not need the lhs of a divide operation to be nonzero. Added a test to trigger the case.

No release note because the `asserts` are not turned on in release versions of the solver.