### PR TITLE
Fix ConcatenateNode propagation

### DIFF
--- a/dwave/optimization/src/nodes/manipulation.cpp
+++ b/dwave/optimization/src/nodes/manipulation.cpp
@@ -158,7 +158,7 @@ void ConcatenateNode::propagate(State& state) const {
             auto update_it = view_it + diff.index;
             ssize_t buffer_index = &*update_it - ptr->buffer.data();
             assert(*update_it == diff.old);
-            ptr->updates.emplace_back(buffer_index, *view_it, diff.value);
+            ptr->updates.emplace_back(buffer_index, *update_it, diff.value);
             *update_it = diff.value;
         }
     }

--- a/releasenotes/notes/fix-ConcatenateNode-updates-f5eef8f7efda3879.yaml
+++ b/releasenotes/notes/fix-ConcatenateNode-updates-f5eef8f7efda3879.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix ``ConcatenateNode`` propagation.
+    Previously in some cases it would record the wrong update index.


### PR DESCRIPTION
Previously it would incorrectly indicate the changed value was from the beginning of each subsection.