### PR TITLE
Fix bug in basic indexing propagation

### DIFF
--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -1450,7 +1450,7 @@ void BasicIndexingNode::propagate(State& state) const {
         // distance between pointers in the parent array. Relies on parent
         // being contiguous
         assert(array_ptr_->contiguous());
-        const ssize_t stop = &*this->end(state) - &*this->begin(state);
+        const ssize_t stop = &*this->end(state) - &*array_ptr_->begin(state);
 
         // A few sanity checks...
         assert(start >= 0);

--- a/releasenotes/notes/fix-basic-indexing-static-size-or-simple-domain-propagation-442b3563091f54f7.yaml
+++ b/releasenotes/notes/fix-basic-indexing-static-size-or-simple-domain-propagation-442b3563091f54f7.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix bug in basic indexing propagation that may have caused some updates
+    from the predecessor array to not get propagated when the start of the
+    indexing operation was offset from the start of the predecessor array.
+    This would happen only when the predecessor array is statically sized or
+    the start and stop of the domain are both positive.


### PR DESCRIPTION
During basic indexing propagation when the predecessor array is statically sized or both the start and stop are positive, we do a basic translation of indices of the updates and otherwise pass them through. We also calculate the start and stop of the "domain" of the basic indexing operation in terms of indices on the predecessor array, and then exclude updates that are outside of this domain. The stop of this domain was calculated by subtracting the pointers returned by `end()` and `begin()`. However, if the start of the domain is not zero, this stop index will not be correct, and thus some updates may get excluded that should not be. Fixed by subtracting the predecessor array's `begin()` from the basic indexing node's `end()` to get the true stop index.