### PR TITLE
Add Node::deterministic_state() method

### DIFF
--- a/dwave/optimization/_model.pyx
+++ b/dwave/optimization/_model.pyx
@@ -760,6 +760,12 @@ cdef class Symbol:
         self.node_ptr = node_ptr
         self.expired_ptr = node_ptr.expired_ptr()
 
+    def _deterministic_state(self):
+        """Return ``True`` if the symbol's state is uniquely determined by its
+        predecessors.
+        """
+        return self.node_ptr.deterministic_state()
+
     def equals(self, other):
         """Compare whether two symbols are identical.
 

--- a/dwave/optimization/include/dwave-optimization/graph.hpp
+++ b/dwave/optimization/include/dwave-optimization/graph.hpp
@@ -194,6 +194,10 @@ class Node {
 
     virtual void initialize_state(State& state) const;
 
+    /// Return true if the node's state is deterministic - that is it's uniquely
+    /// derived from its predecessors. Defaults to `true`, except for decisions.
+    virtual bool deterministic_state() const { return true; }
+
     // The current topological index. Will be negative if unsorted.
     ssize_t topological_index() const { return topological_index_; }
 
@@ -329,6 +333,9 @@ NodeType* Graph::emplace_node(Args&&... args) {
 class ArrayNode : public Array, public virtual Node {};
 class DecisionNode : public Decision, public virtual Node {
  public:
+    /// Decision nodes by definition do not have a deterministic state.
+    bool deterministic_state() const final { return false; }
+
     // Decisions don't have predecessors so no one should be calling update().
     // Always throws a logic_error.
     [[noreturn]] void update(State& state, int index) const override;

--- a/dwave/optimization/libcpp/graph.pxd
+++ b/dwave/optimization/libcpp/graph.pxd
@@ -24,6 +24,7 @@ cdef extern from "dwave-optimization/graph.hpp" namespace "dwave::optimization" 
     cdef cppclass Node:
         struct SuccessorView:
             Node* ptr
+        bool deterministic_state() const
         shared_ptr[bool] expired_ptr() const
         const vector[Node*]& predecessors() const
         const vector[SuccessorView]& successors() const

--- a/releasenotes/notes/deterministic-node-method-a74d4c8a8e5f8300.yaml
+++ b/releasenotes/notes/deterministic-node-method-a74d4c8a8e5f8300.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add virtual ``Node::deterministic_state()`` C++ method. This method allows
+    nodes to communicate whether or not their state is uniquely derived from its
+    predecessors.

--- a/tests/cpp/nodes/mathematical/test_binaryop.cpp
+++ b/tests/cpp/nodes/mathematical/test_binaryop.cpp
@@ -53,6 +53,10 @@ TEMPLATE_TEST_CASE("BinaryOpNode", "",
             CHECK(static_cast<Array*>(p_ptr->operands()[0]) == static_cast<Array*>(a_ptr));
         }
 
+        THEN("The state is deterministic") {
+            CHECK(p_ptr->deterministic_state());
+        }
+
         THEN("The shape is also a scalar") {
             CHECK(p_ptr->ndim() == 0);
             CHECK(p_ptr->size() == 1);

--- a/tests/cpp/nodes/test_collections.cpp
+++ b/tests/cpp/nodes/test_collections.cpp
@@ -38,6 +38,10 @@ TEST_CASE("DisjointBitSetsNode") {
             CHECK(ptr->num_disjoint_sets() == 3);
         }
 
+        THEN("The state is not deterministic") {
+            CHECK(!ptr->deterministic_state());
+        }
+
         WHEN("We add three array output successors") {
             std::vector<DisjointBitSetNode*> sets;
             for (int i = 0; i < 3; ++i) {
@@ -178,6 +182,10 @@ TEST_CASE("DisjointListsNode") {
         const ssize_t primary_set_size = 5;
         const ssize_t num_disjoint_lists = 3;
         auto ptr = graph.emplace_node<DisjointListsNode>(primary_set_size, num_disjoint_lists);
+
+        THEN("The state is not deterministic") {
+            CHECK(!ptr->deterministic_state());
+        }
 
         THEN("We already know a lot about the size etc") {
             CHECK(ptr->primary_set_size() == 5);
@@ -326,6 +334,10 @@ TEST_CASE("ListNode") {
         const int num_elements = 5;
         auto ptr = graph.emplace_node<ListNode>(num_elements);
 
+        THEN("The state is not deterministic") {
+            CHECK(!ptr->deterministic_state());
+        }
+
         THEN("We already know a lot about the size etc") {
             CHECK(ptr->size() == 5);
             CHECK_THAT(ptr->shape(), RangeEquals({5}));
@@ -394,6 +406,10 @@ TEST_CASE("SetNode") {
         auto ptr = graph.emplace_node<SetNode>(num_elements);
 
         graph.emplace_node<ArrayValidationNode>(ptr);
+
+        THEN("The state is not deterministic") {
+            CHECK(!ptr->deterministic_state());
+        }
 
         THEN("The shape is dynamic") {
             CHECK(ptr->ndim() == 1);

--- a/tests/cpp/nodes/test_numbers.cpp
+++ b/tests/cpp/nodes/test_numbers.cpp
@@ -27,6 +27,10 @@ TEST_CASE("BinaryNode") {
     GIVEN("A Binary Node representing an 1d array of 10 elements") {
         auto ptr = graph.emplace_node<BinaryNode>(std::initializer_list<ssize_t>{10});
 
+        THEN("The state is not deterministic") {
+            CHECK(!ptr->deterministic_state());
+        }
+
         THEN("The shape is fixed") {
             CHECK(ptr->ndim() == 1);
             CHECK(ptr->size() == 10);
@@ -253,6 +257,10 @@ TEST_CASE("IntegerNode") {
 
     GIVEN("Double precision numbers, which may fall outside integer range or are not integral") {
         IntegerNode inode({1});
+
+        THEN("The state is not deterministic") {
+            CHECK(!inode.deterministic_state());
+        }
 
         THEN("The function to check valid integers works") {
             CHECK(inode.max() == 2000000000);

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -103,6 +103,10 @@ class BinaryOpTests(SymbolTests):
         # if the op is different for symbols, allow the override
         return self.op(lhs, rhs)
 
+    def test_deterministic(self):
+        x = next(self.generate_symbols())
+        self.assertTrue(x._deterministic_state())
+
     def test_numpy_equivalence(self):
         lhs_array = np.arange(10)
         rhs_array = np.arange(1, 11)


### PR DESCRIPTION
We want to be able to support intermediate nodes with non-deterministic states while serializing. See https://github.com/dwavesystems/dwave-optimization/pull/241.