### PR TITLE
Add input checking tests for LinearProgram symbol

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/lp.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/lp.hpp
@@ -87,6 +87,13 @@ class LinearProgramNodeBase : public Node {
     virtual std::pair<double, double> variables_minmax() const = 0;
 
     virtual std::span<const ssize_t> variables_shape() const = 0;
+
+ protected:
+    /// Enforce the rules on the input node(s).
+    static void check_input_arguments(const ArrayNode* c_ptr, const ArrayNode* b_lb_ptr,
+                                      const ArrayNode* A_ptr, const ArrayNode* b_ub_ptr,
+                                      const ArrayNode* A_eq_ptr, const ArrayNode* b_eq_ptr,
+                                      const ArrayNode* lb_ptr, const ArrayNode* ub_ptr);
 };
 
 /// Node that solves a given LP defined by its predecessors, and outputs the optimal solution
@@ -97,12 +104,14 @@ class LinearProgramNodeBase : public Node {
 ///         callback=None, options=None, x0=None, integrality=None)
 class LinearProgramNode : public LinearProgramNodeBase {
  public:
-    // Parameter names are chosen to match scipy.optimize.lingprog()
-    LinearProgramNode(ArrayNode* c_ptr,                                            // required
-                      ArrayNode* b_lb_ptr, ArrayNode* A_ptr, ArrayNode* b_ub_ptr,  // can be nullptr
-                      ArrayNode* A_eq_ptr, ArrayNode* b_eq_ptr,  // nullptr or must match size
+    /// Construct a LinearProgramNode
+    ///
+    /// Note: parameter names are chosen to match scipy.optimize.lingprog()
+    LinearProgramNode(ArrayNode* c_ptr,
+                      ArrayNode* b_lb_ptr, ArrayNode* A_ptr, ArrayNode* b_ub_ptr,
+                      ArrayNode* A_eq_ptr, ArrayNode* b_eq_ptr,
                       ArrayNode* lb_ptr,
-                      ArrayNode* ub_ptr);  // can be nullptr, both have size 1, or size n
+                      ArrayNode* ub_ptr);
 
     /// @copydoc Node::commit()
     void commit(State& state) const override;

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -1482,6 +1482,34 @@ class TestLinearProgram(utils.SymbolTests):
         yield obj
         yield sol
 
+    def test_inputs_valid(self):
+        from dwave.optimization.symbols import (
+            LinearProgram,
+            LinearProgramFeasible,
+            LinearProgramObjectiveValue,
+            LinearProgramSolution,
+        )
+
+        for name, kwargs in utils.iter_valid_lp_kwargs():
+            with self.subTest(name):
+                lp = LinearProgram(**kwargs)
+                feas = LinearProgramFeasible(lp)
+                res = LinearProgramObjectiveValue(lp)
+                sol = LinearProgramSolution(lp)
+
+                # smoke test that we can access the state in various ways without errors
+                lp.model.states.resize(1)
+                with lp.model.lock():
+                    lp.state()
+                    feas.state()
+                    res.state()
+                    sol.state()
+
+    def test_inputs_invalid(self):
+        for name, kwargs, msg in utils.iter_invalid_lp_kwargs():
+            with self.subTest(name), self.assertRaisesRegex(ValueError, msg):
+                dwave.optimization.symbols.LinearProgram(**kwargs)
+
     def test_unconstrained(self):
         model = Model()
         model.states.resize(1)


### PR DESCRIPTION
Add an input checker to the C++ `LinearProgramNodeBase` class. Also handle the scalar bounds case that was neither disallowed nor supported in the code.