### PR TITLE
Add simple propagation overloads

### DIFF
--- a/dwave/optimization/include/dwave-optimization/graph.hpp
+++ b/dwave/optimization/include/dwave-optimization/graph.hpp
@@ -95,14 +95,23 @@ class Graph {
     // the sources.
     static std::vector<const Node*> descendants(State& state, std::vector<const Node*> sources);
 
+    /// Call propagate on every `Node` in the `Graph`.
+    void propagate(State& state) const;
+
     // Call the propagate method on each node in changed. Note this does not call propagate on
     // the descendents of changed.
     void propagate(State& state, std::span<const Node*> changed) const;
     void propagate(State& state, std::vector<const Node*>&& changed) const;
 
+    /// Call commit on every `Node` in the `Graph`.
+    void commit(State& state) const;
+
     // Commit the changes on each changed node.
     void commit(State& state, std::span<const Node*> changed) const;
     void commit(State& state, std::vector<const Node*>&& changed) const;
+
+    /// Call revert on every `Node` in the `Graph`.
+    void revert(State& state) const;
 
     // Revert the changes on each changed node.
     void revert(State& state, std::span<const Node*> changed) const;

--- a/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
@@ -140,6 +140,9 @@ class IntegerNode : public NumberNode {
 /// A contiguous block of binary numbers.
 class BinaryNode : public IntegerNode {
  public:
+    /// A single binary scalar variable
+    BinaryNode() : BinaryNode({}) {}
+
     explicit BinaryNode(std::initializer_list<ssize_t> shape) : IntegerNode(shape, 0, 1) {}
     explicit BinaryNode(std::span<const ssize_t> shape) : IntegerNode(shape, 0, 1) {}
 

--- a/dwave/optimization/src/graph.cpp
+++ b/dwave/optimization/src/graph.cpp
@@ -227,6 +227,10 @@ std::vector<const Node*> Graph::descendants(State& state, std::vector<const Node
     return sources;
 }
 
+void Graph::propagate(State& state) const {
+    std::ranges::for_each(nodes(), [&state](const auto& ptr) { ptr->propagate(state); });
+}
+
 void Graph::propagate(State& state, std::span<const Node*> queue_to_update) const {
     for (const Node* node_ptr : queue_to_update) {
         node_ptr->propagate(state);
@@ -239,6 +243,10 @@ void Graph::propagate(State& state, std::span<const Node*> queue_to_update) cons
 
 void Graph::propagate(State& state, std::vector<const Node*>&& changed) const {
     return propagate(state, std::span(changed));
+}
+
+void Graph::commit(State& state) const {
+    std::ranges::for_each(nodes(), [&state](const auto& ptr) { ptr->commit(state); });
 }
 
 void Graph::commit(State& state, std::span<const Node*> changed) const {
@@ -257,6 +265,10 @@ void Graph::commit(State& state, std::span<const Node*> changed) const {
 
 void Graph::commit(State& state, std::vector<const Node*>&& changed) const {
     commit(state, std::span(changed));
+}
+
+void Graph::revert(State& state) const {
+    std::ranges::for_each(nodes(), [&state](const auto& ptr) { ptr->revert(state); });
 }
 
 void Graph::revert(State& state, std::span<const Node*> changed) const {

--- a/releasenotes/notes/simple-propagation-b352e157e95dd8d6.yaml
+++ b/releasenotes/notes/simple-propagation-b352e157e95dd8d6.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add overloads to C++ methods ``Graph::commit()``, ``Graph::propagate()``,
+    and ``Graph::revert()`` that commit, propagate, or revert respectively
+    all nodes in the graph.
+  - Add a default constructor for C++ ``BinaryNode``.


### PR DESCRIPTION
I have not touched the existing methods, though probably at some point we should switch them over to using `std::ranges::for_each(...)` as well.