### PR TITLE
Add default state support to `ScalarOutputMixin`

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/lp.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/lp.hpp
@@ -26,18 +26,9 @@ namespace dwave::optimization {
 class LinearProgramNodeBase;
 
 /// A logical node that propagates whether or not its predecessor LinearProgram is feasible.
-class LinearProgramFeasibleNode : public ScalarOutputMixin<ArrayNode> {
+class LinearProgramFeasibleNode : public ScalarOutputMixin<ArrayNode, true> {
  public:
     explicit LinearProgramFeasibleNode(LinearProgramNodeBase* lp_ptr);
-
-    /// @copydoc Array::buff()
-    double const* buff(const State& state) const override;
-
-    /// @copydoc Node::commit()
-    void commit(State& state) const override;
-
-    /// @copydoc Array::diff()
-    std::span<const Update> diff(const State& state) const override;
 
     /// @copydoc Node::initialize_state()
     void initialize_state(State& state) const override;
@@ -51,9 +42,6 @@ class LinearProgramFeasibleNode : public ScalarOutputMixin<ArrayNode> {
 
     /// @copydoc Node::propagate()
     void propagate(State& state) const override;
-
-    /// @copydoc Node::revert()
-    void revert(State& state) const override;
 
  private:
     const LinearProgramNodeBase* lp_ptr_;
@@ -178,27 +166,15 @@ class LinearProgramNode : public LinearProgramNodeBase {
 
 /// A scalar node that propagates the objective value of the solution found by the
 /// LinearProgramNode. Note that the output is undefined if the solution is not feasible.
-class LinearProgramObjectiveValueNode : public ScalarOutputMixin<ArrayNode> {
+class LinearProgramObjectiveValueNode : public ScalarOutputMixin<ArrayNode, true> {
  public:
     explicit LinearProgramObjectiveValueNode(LinearProgramNodeBase* lp_ptr);
-
-    /// @copydoc Array::buff()
-    double const* buff(const State& state) const override;
-
-    /// @copydoc Node::commit()
-    void commit(State& state) const override;
-
-    /// @copydoc Array::diff()
-    std::span<const Update> diff(const State& state) const override;
 
     /// @copydoc Node::initialize_state()
     void initialize_state(State& state) const override;
 
     /// @copydoc Node::propagate()
     void propagate(State& state) const override;
-
-    /// @copydoc Node::revert()
-    void revert(State& state) const override;
 
  private:
     const LinearProgramNodeBase* lp_ptr_;

--- a/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
@@ -198,15 +198,9 @@ class ReshapeNode : public ArrayOutputMixin<ArrayNode> {
     const Array* array_ptr_;
 };
 
-class SizeNode : public ScalarOutputMixin<ArrayNode> {
+class SizeNode : public ScalarOutputMixin<ArrayNode, true> {
  public:
     explicit SizeNode(ArrayNode* node_ptr);
-
-    double const* buff(const State& state) const override;
-
-    void commit(State& state) const override;
-
-    std::span<const Update> diff(const State&) const override;
 
     void initialize_state(State& state) const override;
 
@@ -218,8 +212,6 @@ class SizeNode : public ScalarOutputMixin<ArrayNode> {
             optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
 
     void propagate(State& state) const override;
-
-    void revert(State& state) const override;
 
  private:
     // we could dynamically cast each time, but it's easier to just keep separate

--- a/dwave/optimization/src/nodes/_state.hpp
+++ b/dwave/optimization/src/nodes/_state.hpp
@@ -224,20 +224,4 @@ class ArrayNodeStateData: public ArrayStateData, public NodeStateData {
     }
 };
 
-
-class ScalarNodeStateData : public NodeStateData {
- public:
-    explicit ScalarNodeStateData(double value) : update(0, value, value) {}
-
-    const double* buff() const { return &update.value; }
-    void commit() { update.old = update.value; }
-    std::span<const Update> diff() const {
-        return std::span<const Update>(&update, update.old != update.value);
-    }
-    void revert() { update.value = update.old; }
-    void set(double value) { update.value = value; }
-
-    Update update;
-};
-
 }  // namespace dwave::optimization

--- a/dwave/optimization/src/nodes/manipulation.cpp
+++ b/dwave/optimization/src/nodes/manipulation.cpp
@@ -577,26 +577,10 @@ std::pair<double, double> ReshapeNode::minmax(
 
 void ReshapeNode::revert(State& state) const {}  // stateless node
 
-class SizeNodeData : public ScalarNodeStateData {
- public:
-    explicit SizeNodeData(std::integral auto value) : ScalarNodeStateData(value) {}
-    void set(std::integral auto value) { ScalarNodeStateData::set(value); }
-};
-
 SizeNode::SizeNode(ArrayNode* node_ptr) : array_ptr_(node_ptr) { this->add_predecessor(node_ptr); }
 
-double const* SizeNode::buff(const State& state) const {
-    return data_ptr<SizeNodeData>(state)->buff();
-}
-
-void SizeNode::commit(State& state) const { return data_ptr<SizeNodeData>(state)->commit(); }
-
-std::span<const Update> SizeNode::diff(const State& state) const {
-    return data_ptr<SizeNodeData>(state)->diff();
-}
-
 void SizeNode::initialize_state(State& state) const {
-    emplace_data_ptr<SizeNodeData>(state, array_ptr_->size(state));
+    emplace_state(state, array_ptr_->size(state));
 }
 
 std::pair<double, double> SizeNode::minmax(
@@ -612,10 +596,6 @@ std::pair<double, double> SizeNode::minmax(
     });
 }
 
-void SizeNode::propagate(State& state) const {
-    return data_ptr<SizeNodeData>(state)->set(array_ptr_->size(state));
-}
-
-void SizeNode::revert(State& state) const { return data_ptr<SizeNodeData>(state)->revert(); }
+void SizeNode::propagate(State& state) const { set_state(state, array_ptr_->size(state)); }
 
 }  // namespace dwave::optimization


### PR DESCRIPTION
Removes a fair amount of code duplication.

Could be replicated for `ArrayOutputMixin`, but IMO we should play with this one for a while first.

One thing that this is highlighting for me is that we have a circular dependency between `array.hpp` and `graph.hpp`. We've gotten around it for now by messing with templates and the like, but probably there are nicer things we could do in the future.