### PR TITLE
Include <cstdint> on all files that use std::int*_t

### DIFF
--- a/dwave/optimization/include/dwave-optimization/array.hpp
+++ b/dwave/optimization/include/dwave-optimization/array.hpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <limits>

--- a/dwave/optimization/src/nodes/manipulation.cpp
+++ b/dwave/optimization/src/nodes/manipulation.cpp
@@ -12,6 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+#include <cstdint>
 #include <tuple>
 #include <unordered_set>
 

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -12,6 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+#include <cstdint>
 #include <sstream>
 
 #include "catch2/catch_template_test_macros.hpp"


### PR DESCRIPTION
Otherwise compilation fails on some compilers that seem not to include cstdint implicitly