### PR TITLE
Remove symbol construction boilerplate from many symbols

### DIFF
--- a/dwave/optimization/_model.pyx
+++ b/dwave/optimization/_model.pyx
@@ -1891,6 +1891,3 @@ cdef class ArraySymbol(Symbol):
             return dwave.optimization.symbols.PartialSum(self, axis)
 
         return dwave.optimization.symbols.Sum(self)
-
-cdef class A:
-    pass

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -839,7 +839,7 @@ cdef class BSpline(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppBSplineNode * ptr = dynamic_cast_ptr[cppBSplineNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a BSpline")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
         cdef BSpline m = BSpline.__new__(BSpline)
         m.ptr = ptr
         m.initialize_arraynode(symbol.model, ptr)
@@ -917,7 +917,7 @@ cdef class Concatenate(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppConcatenateNode* ptr = dynamic_cast_ptr[cppConcatenateNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Concatenate")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef Concatenate m = Concatenate.__new__(Concatenate)
         m.ptr = ptr
@@ -1049,7 +1049,7 @@ cdef class Constant(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppConstantNode* ptr = dynamic_cast_ptr[cppConstantNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Constant")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef Constant constant = Constant.__new__(Constant)
         constant.ptr = ptr
@@ -1184,7 +1184,7 @@ cdef class DisjointBitSets(Symbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppDisjointBitSetsNode* ptr = dynamic_cast_ptr[cppDisjointBitSetsNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a DisjointBitSets")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef DisjointBitSets x = DisjointBitSets.__new__(DisjointBitSets)
         x.ptr = ptr
@@ -1363,7 +1363,7 @@ cdef class DisjointBitSet(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppDisjointBitSetNode* ptr = dynamic_cast_ptr[cppDisjointBitSetNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a DisjointBitSet")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
         cdef DisjointBitSet x = DisjointBitSet.__new__(DisjointBitSet)
         x.ptr = ptr
         x.initialize_arraynode(symbol.model, ptr)
@@ -1455,7 +1455,7 @@ cdef class DisjointLists(Symbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppDisjointListsNode* ptr = dynamic_cast_ptr[cppDisjointListsNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a DisjointLists")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
         cdef DisjointLists x = DisjointLists.__new__(DisjointLists)
         x.ptr = ptr
         x.initialize_node(symbol.model, ptr)
@@ -1630,7 +1630,7 @@ cdef class DisjointList(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppDisjointListNode* ptr = dynamic_cast_ptr[cppDisjointListNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a DisjointList")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
         cdef DisjointList x = DisjointList.__new__(DisjointList)
         x.ptr = ptr
         x.initialize_arraynode(symbol.model, ptr)
@@ -1723,7 +1723,7 @@ cdef class Divide(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppDivideNode* ptr = dynamic_cast_ptr[cppDivideNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Divide")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
         cdef Divide x = Divide.__new__(Divide)
         x.ptr = ptr
         x.initialize_arraynode(symbol.model, ptr)
@@ -1840,7 +1840,7 @@ cdef class Input(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppInputNode* ptr = dynamic_cast_ptr[cppInputNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Input")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef Input inp = Input.__new__(Input)
         inp.ptr = ptr
@@ -1909,7 +1909,7 @@ cdef class IntegerVariable(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppIntegerNode* ptr = dynamic_cast_ptr[cppIntegerNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a IntegerVariable")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef IntegerVariable x = IntegerVariable.__new__(IntegerVariable)
         x.ptr = ptr
@@ -2057,7 +2057,7 @@ cdef class LinearProgram(Symbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppLinearProgramNode* ptr = dynamic_cast_ptr[cppLinearProgramNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a LinearProgram")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
         cdef LinearProgram x = LinearProgram.__new__(LinearProgram)
         x.ptr = ptr
         x.initialize_node(symbol.model, ptr)
@@ -2276,7 +2276,7 @@ cdef class ListVariable(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppListNode* ptr = dynamic_cast_ptr[cppListNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a ListVariable")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef ListVariable x = ListVariable.__new__(ListVariable)
         x.ptr = ptr
@@ -3078,7 +3078,7 @@ cdef class QuadraticModel(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppQuadraticModelNode* ptr = dynamic_cast_ptr[cppQuadraticModelNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a QuadraticModel")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef QuadraticModel qm = QuadraticModel.__new__(QuadraticModel)
         qm.ptr = ptr
@@ -3194,7 +3194,7 @@ cdef class Reshape(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppReshapeNode* ptr = dynamic_cast_ptr[cppReshapeNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Reshape")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef Reshape m = Reshape.__new__(Reshape)
         m.ptr = ptr
@@ -3246,7 +3246,7 @@ cdef class SetVariable(ArraySymbol):
     def _from_symbol(cls, Symbol symbol):
         cdef cppSetNode* ptr = dynamic_cast_ptr[cppSetNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a SetVariable")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef SetVariable x = SetVariable.__new__(SetVariable)
         x.ptr = ptr

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -182,8 +182,6 @@ __all__ = [
     ]
 
 
-
-
 cdef class Absolute(ArraySymbol):
     """Absolute value element-wise on a symbol.
 
@@ -193,20 +191,8 @@ cdef class Absolute(ArraySymbol):
     def __init__(self, ArraySymbol x):
         cdef _Graph model = x.model
 
-        self.ptr = model._graph.emplace_node[cppAbsoluteNode](x.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppAbsoluteNode* ptr = dynamic_cast_ptr[cppAbsoluteNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Absolute")
-        cdef Absolute x = Absolute.__new__(Absolute)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppAbsoluteNode* ptr
+        cdef cppAbsoluteNode* ptr = model._graph.emplace_node[cppAbsoluteNode](x.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Absolute, typeid(cppAbsoluteNode))
 
@@ -231,20 +217,8 @@ cdef class Add(ArraySymbol):
 
         cdef _Graph model = lhs.model
 
-        self.ptr = model._graph.emplace_node[cppAddNode](lhs.array_ptr, rhs.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppAddNode* ptr = dynamic_cast_ptr[cppAddNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Add")
-        cdef Add x = Add.__new__(Add)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppAddNode* ptr
+        cdef cppAddNode* ptr = model._graph.emplace_node[cppAddNode](lhs.array_ptr, rhs.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Add, typeid(cppAddNode))
 
@@ -264,20 +238,8 @@ cdef class All(ArraySymbol):
     """
     def __init__(self, ArraySymbol array):
         cdef _Graph model = array.model
-        self.ptr = model._graph.emplace_node[cppAllNode](array.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppAllNode* ptr = dynamic_cast_ptr[cppAllNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a All")
-        cdef All s = All.__new__(All)
-        s.ptr = ptr
-        s.initialize_arraynode(symbol.model, ptr)
-        return s
-
-    cdef cppAllNode* ptr
+        cdef cppAllNode* ptr = model._graph.emplace_node[cppAllNode](array.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(All, typeid(cppAllNode))
 
@@ -294,20 +256,8 @@ cdef class And(ArraySymbol):
 
         cdef _Graph model = lhs.model
 
-        self.ptr = model._graph.emplace_node[cppAndNode](lhs.array_ptr, rhs.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppAndNode* ptr = dynamic_cast_ptr[cppAndNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a And")
-        cdef And x = And.__new__(And)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppAndNode* ptr
+        cdef cppAndNode* ptr = model._graph.emplace_node[cppAndNode](lhs.array_ptr, rhs.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(And, typeid(cppAndNode))
 
@@ -335,20 +285,8 @@ cdef class Any(ArraySymbol):
     """
     def __init__(self, ArraySymbol array):
         cdef _Graph model = array.model
-        self.ptr = model._graph.emplace_node[cppAnyNode](array.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppAnyNode* ptr = dynamic_cast_ptr[cppAnyNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Any")
-        cdef Any s = Any.__new__(Any)
-        s.ptr = ptr
-        s.initialize_arraynode(symbol.model, ptr)
-        return s
-
-    cdef cppAnyNode* ptr
+        cdef cppAnyNode* ptr = model._graph.emplace_node[cppAnyNode](array.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Any, typeid(cppAnyNode))
 
@@ -357,22 +295,8 @@ cdef class _ArrayValidation(Symbol):
     def __init__(self, ArraySymbol array_node):
         cdef _Graph model = array_node.model
 
-        self.ptr = model._graph.emplace_node[cppArrayValidationNode](array_node.array_ptr)
-
-        self.initialize_node(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppArrayValidationNode* ptr = dynamic_cast_ptr[cppArrayValidationNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a _ArrayValidation")
-
-        cdef _ArrayValidation m = _ArrayValidation.__new__(_ArrayValidation)
-        m.ptr = ptr
-        m.initialize_node(symbol.model, ptr)
-        return m
-
-    cdef cppArrayValidationNode* ptr
+        cdef cppArrayValidationNode* ptr = model._graph.emplace_node[cppArrayValidationNode](array_node.array_ptr)
+        self.initialize_node(model, ptr)
 
 _register(_ArrayValidation, typeid(cppArrayValidationNode))
 
@@ -443,12 +367,12 @@ cdef class ARange(ArraySymbol):
         else:
             raise RuntimeError  # shouldn't be possible
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppARangeNode* ptr = dynamic_cast_ptr[cppARangeNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct an ARange")
-        cdef ARange sym = ARange.__new__(ARange)
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+        cdef ARange sym = cls.__new__(cls)
         sym.ptr = ptr
         sym.initialize_arraynode(symbol.model, ptr)
         return sym
@@ -584,11 +508,11 @@ cdef class AdvancedIndexing(ArraySymbol):
 
         return super().__getitem__(index)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppAdvancedIndexingNode* ptr = dynamic_cast_ptr[cppAdvancedIndexingNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a AdvancedIndexing")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef AdvancedIndexing sym = AdvancedIndexing.__new__(AdvancedIndexing)
         sym.ptr = ptr
@@ -683,11 +607,11 @@ cdef class BasicIndexing(ArraySymbol):
 
         return cppSlice(start, stop, step)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppBasicIndexingNode* ptr = dynamic_cast_ptr[cppBasicIndexingNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a BasicIndexing")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef BasicIndexing sym = BasicIndexing.__new__(BasicIndexing)
         sym.ptr = ptr
@@ -762,11 +686,11 @@ cdef class BinaryVariable(ArraySymbol):
 
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppBinaryNode* ptr = dynamic_cast_ptr[cppBinaryNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a BinaryVariable")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
 
         cdef BinaryVariable x = BinaryVariable.__new__(BinaryVariable)
         x.ptr = ptr
@@ -911,8 +835,8 @@ cdef class BSpline(ArraySymbol):
         self.ptr = model._graph.emplace_node[cppBSplineNode](x.array_ptr, val_k, vec_t, vec_c)
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppBSplineNode * ptr = dynamic_cast_ptr[cppBSplineNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a BSpline")
@@ -989,8 +913,8 @@ cdef class Concatenate(ArraySymbol):
         self.ptr = model._graph.emplace_node[cppConcatenateNode](cppinputs, axis)
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppConcatenateNode* ptr = dynamic_cast_ptr[cppConcatenateNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a Concatenate")
@@ -1121,8 +1045,8 @@ cdef class Constant(ArraySymbol):
         # The size check is redundant, but worth checking in order to avoid segfaults
         return self.ptr.size() == 1 and self.ptr.ndim() == 0
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppConstantNode* ptr = dynamic_cast_ptr[cppConstantNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a Constant")
@@ -1228,24 +1152,8 @@ cdef class Copy(ArraySymbol):
     def __init__(self, ArraySymbol node):
         cdef _Graph model = node.model
 
-        self.ptr = model._graph.emplace_node[cppCopyNode](
-            node.array_ptr,
-            )
-
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppCopyNode* ptr = dynamic_cast_ptr[cppCopyNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Copy")
-
-        cdef Copy m = Copy.__new__(Copy)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
-
-    cdef cppCopyNode* ptr
+        cdef cppCopyNode* ptr = model._graph.emplace_node[cppCopyNode](node.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Copy, typeid(cppCopyNode))
 
@@ -1272,8 +1180,8 @@ cdef class DisjointBitSets(Symbol):
 
         self.initialize_node(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppDisjointBitSetsNode* ptr = dynamic_cast_ptr[cppDisjointBitSetsNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a DisjointBitSets")
@@ -1451,8 +1359,8 @@ cdef class DisjointBitSet(ArraySymbol):
 
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppDisjointBitSetNode* ptr = dynamic_cast_ptr[cppDisjointBitSetNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a DisjointBitSet")
@@ -1543,8 +1451,8 @@ cdef class DisjointLists(Symbol):
 
         self.initialize_node(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppDisjointListsNode* ptr = dynamic_cast_ptr[cppDisjointListsNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a DisjointLists")
@@ -1718,8 +1626,8 @@ cdef class DisjointList(ArraySymbol):
 
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppDisjointListNode* ptr = dynamic_cast_ptr[cppDisjointListNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a DisjointList")
@@ -1811,8 +1719,8 @@ cdef class Divide(ArraySymbol):
         self.ptr = model._graph.emplace_node[cppDivideNode](lhs.array_ptr, rhs.array_ptr)
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppDivideNode* ptr = dynamic_cast_ptr[cppDivideNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a Divide")
@@ -1846,22 +1754,11 @@ cdef class Equal(ArraySymbol):
 
         cdef _Graph model = lhs.model
 
-        self.ptr = model._graph.emplace_node[cppEqualNode](lhs.array_ptr, rhs.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppEqualNode* ptr = dynamic_cast_ptr[cppEqualNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Equal")
-        cdef Equal x = Equal.__new__(Equal)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppEqualNode* ptr
+        cdef cppEqualNode* ptr = model._graph.emplace_node[cppEqualNode](lhs.array_ptr, rhs.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Equal, typeid(cppEqualNode))
+
 
 cdef class Exp(ArraySymbol):
     """Takes the values of a symbol and returns the corresponding base-e exponential.
@@ -1874,23 +1771,11 @@ cdef class Exp(ArraySymbol):
     def __init__(self, ArraySymbol x):
         cdef _Graph model = x.model
 
-        self.ptr = model._graph.emplace_node[cppExpNode](x.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppExpNode* ptr = dynamic_cast_ptr[cppExpNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Exp")
-
-        cdef Exp x = Exp.__new__(Exp)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppExpNode* ptr
+        cdef cppExpNode* ptr = model._graph.emplace_node[cppExpNode](x.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Exp, typeid(cppExpNode))
+
 
 cdef class Expit(ArraySymbol):
     """Takes the values of a symbol and returns the corresponding logistic sigmoid (expit).
@@ -1903,23 +1788,11 @@ cdef class Expit(ArraySymbol):
     def __init__(self, ArraySymbol x):
         cdef _Graph model = x.model
 
-        self.ptr = model._graph.emplace_node[cppExpitNode](x.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppExpitNode* ptr = dynamic_cast_ptr[cppExpitNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Expit")
-
-        cdef Expit x = Expit.__new__(Expit)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppExpitNode* ptr
+        cdef cppExpitNode* ptr = model._graph.emplace_node[cppExpitNode](x.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Expit, typeid(cppExpitNode))
+
 
 cdef class Input(ArraySymbol):
     """An input symbol. Functions as a "placeholder" in a model."""
@@ -1963,8 +1836,8 @@ cdef class Input(ArraySymbol):
             <span[const double]>as_span(arr)
         )
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppInputNode* ptr = dynamic_cast_ptr[cppInputNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a Input")
@@ -2032,8 +1905,8 @@ cdef class IntegerVariable(ArraySymbol):
 
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppIntegerNode* ptr = dynamic_cast_ptr[cppIntegerNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a IntegerVariable")
@@ -2128,20 +2001,8 @@ cdef class LessEqual(ArraySymbol):
 
         cdef _Graph model = lhs.model
 
-        self.ptr = model._graph.emplace_node[cppLessEqualNode](lhs.array_ptr, rhs.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppLessEqualNode* ptr = dynamic_cast_ptr[cppLessEqualNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a LessEqual")
-        cdef LessEqual x = LessEqual.__new__(LessEqual)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppLessEqualNode* ptr
+        cdef cppLessEqualNode* ptr = model._graph.emplace_node[cppLessEqualNode](lhs.array_ptr, rhs.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(LessEqual, typeid(cppLessEqualNode))
 
@@ -2192,8 +2053,8 @@ cdef class LinearProgram(Symbol):
             raise ValueError("all symbols must share the same underlying model")
         return x.array_ptr
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppLinearProgramNode* ptr = dynamic_cast_ptr[cppLinearProgramNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a LinearProgram")
@@ -2343,20 +2204,8 @@ cdef class LinearProgramFeasible(ArraySymbol):
         if not base_ptr:
             raise TypeError("Provided symbol must be derived from the LP base class")
 
-        self.ptr = model._graph.emplace_node[cppLinearProgramFeasibleNode](base_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppLinearProgramFeasibleNode* ptr = dynamic_cast_ptr[cppLinearProgramFeasibleNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a LinearProgramFeasible")
-        cdef LinearProgramFeasible x = LinearProgramFeasible.__new__(LinearProgramFeasible)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppLinearProgramFeasibleNode* ptr
+        cdef cppLinearProgramFeasibleNode* ptr = model._graph.emplace_node[cppLinearProgramFeasibleNode](base_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(LinearProgramFeasible, typeid(cppLinearProgramFeasibleNode))
 
@@ -2377,21 +2226,8 @@ cdef class LinearProgramObjectiveValue(ArraySymbol):
         if not base_ptr:
             raise TypeError("Provided symbol must be derived from the LP base class")
 
-        self.ptr = model._graph.emplace_node[cppLinearProgramObjectiveValueNode](base_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppLinearProgramObjectiveValueNode* ptr = dynamic_cast_ptr[cppLinearProgramObjectiveValueNode](
-            symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a LinearProgramObjectiveValue")
-        cdef LinearProgramObjectiveValue x = LinearProgramObjectiveValue.__new__(LinearProgramObjectiveValue)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppLinearProgramObjectiveValueNode* ptr
+        cdef cppLinearProgramObjectiveValueNode* ptr = model._graph.emplace_node[cppLinearProgramObjectiveValueNode](base_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(LinearProgramObjectiveValue, typeid(cppLinearProgramObjectiveValueNode))
 
@@ -2412,21 +2248,8 @@ cdef class LinearProgramSolution(ArraySymbol):
         if not base_ptr:
             raise TypeError("Provided symbol must be derived from the LP base class")
 
-        self.ptr = model._graph.emplace_node[cppLinearProgramSolutionNode](base_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppLinearProgramSolutionNode* ptr = dynamic_cast_ptr[cppLinearProgramSolutionNode](
-            symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a LinearProgramSolution")
-        cdef LinearProgramSolution x = LinearProgramSolution.__new__(LinearProgramSolution)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppLinearProgramSolutionNode* ptr
+        cdef cppLinearProgramSolutionNode* ptr = model._graph.emplace_node[cppLinearProgramSolutionNode](base_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(LinearProgramSolution, typeid(cppLinearProgramSolutionNode))
 
@@ -2449,8 +2272,8 @@ cdef class ListVariable(ArraySymbol):
 
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppListNode* ptr = dynamic_cast_ptr[cppListNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a ListVariable")
@@ -2526,21 +2349,8 @@ cdef class Log(ArraySymbol):
     def __init__(self, ArraySymbol x):
         cdef _Graph model = x.model
 
-        self.ptr = model._graph.emplace_node[cppLogNode](x.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppLogNode* ptr = dynamic_cast_ptr[cppLogNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Log")
-
-        cdef Log x = Log.__new__(Log)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppLogNode* ptr
+        cdef cppLogNode* ptr = model._graph.emplace_node[cppLogNode](x.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Log, typeid(cppLogNode))
 
@@ -2554,20 +2364,8 @@ cdef class Logical(ArraySymbol):
     def __init__(self, ArraySymbol x):
         cdef _Graph model = x.model
 
-        self.ptr = model._graph.emplace_node[cppLogicalNode](x.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppLogicalNode* ptr = dynamic_cast_ptr[cppLogicalNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Logical")
-        cdef Logical x = Logical.__new__(Logical)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppLogicalNode* ptr
+        cdef cppLogicalNode* ptr = model._graph.emplace_node[cppLogicalNode](x.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Logical, typeid(cppLogicalNode))
 
@@ -2589,21 +2387,8 @@ cdef class Max(ArraySymbol):
     def __init__(self, ArraySymbol node):
         cdef _Graph model = node.model
 
-        self.ptr = model._graph.emplace_node[cppMaxNode](node.array_ptr)
-
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppMaxNode* ptr = dynamic_cast_ptr[cppMaxNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Max")
-        cdef Max m = Max.__new__(Max)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
-
-    cdef cppMaxNode* ptr
+        cdef cppMaxNode* ptr = model._graph.emplace_node[cppMaxNode](node.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Max, typeid(cppMaxNode))
 
@@ -2631,21 +2416,8 @@ cdef class Maximum(ArraySymbol):
 
         cdef _Graph model = lhs.model
 
-        self.ptr = model._graph.emplace_node[cppMaximumNode](lhs.array_ptr, rhs.array_ptr)
-
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppMaximumNode* ptr = dynamic_cast_ptr[cppMaximumNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Maximum")
-        cdef Maximum m = Maximum.__new__(Maximum)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
-
-    cdef cppMaximumNode* ptr
+        cdef cppMaximumNode* ptr = model._graph.emplace_node[cppMaximumNode](lhs.array_ptr, rhs.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Maximum, typeid(cppMaximumNode))
 
@@ -2667,21 +2439,8 @@ cdef class Min(ArraySymbol):
     def __init__(self, ArraySymbol node):
         cdef _Graph model = node.model
 
-        self.ptr = model._graph.emplace_node[cppMinNode](node.array_ptr)
-
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppMinNode* ptr = dynamic_cast_ptr[cppMinNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Min")
-        cdef Min m = Min.__new__(Min)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
-
-    cdef cppMinNode* ptr
+        cdef cppMinNode* ptr = model._graph.emplace_node[cppMinNode](node.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Min, typeid(cppMinNode))
 
@@ -2709,21 +2468,8 @@ cdef class Minimum(ArraySymbol):
 
         cdef _Graph model = lhs.model
 
-        self.ptr = model._graph.emplace_node[cppMinimumNode](lhs.array_ptr, rhs.array_ptr)
-
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppMinimumNode* ptr = dynamic_cast_ptr[cppMinimumNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Minimum")
-        cdef Minimum m = Minimum.__new__(Minimum)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
-
-    cdef cppMinimumNode* ptr
+        cdef cppMinimumNode* ptr = model._graph.emplace_node[cppMinimumNode](lhs.array_ptr, rhs.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Minimum, typeid(cppMinimumNode))
 
@@ -2748,20 +2494,8 @@ cdef class Modulus(ArraySymbol):
 
         cdef _Graph model = lhs.model
 
-        self.ptr = model._graph.emplace_node[cppModulusNode](lhs.array_ptr, rhs.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppModulusNode* ptr = dynamic_cast_ptr[cppModulusNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Modulus")
-        cdef Modulus m = Modulus.__new__(Modulus)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
-
-    cdef cppModulusNode* ptr
+        cdef cppModulusNode* ptr = model._graph.emplace_node[cppModulusNode](lhs.array_ptr, rhs.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Modulus, typeid(cppModulusNode))
 
@@ -2786,20 +2520,8 @@ cdef class Multiply(ArraySymbol):
 
         cdef _Graph model = lhs.model
 
-        self.ptr = model._graph.emplace_node[cppMultiplyNode](lhs.array_ptr, rhs.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppMultiplyNode* ptr = dynamic_cast_ptr[cppMultiplyNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Multiply")
-        cdef Multiply x = Multiply.__new__(Multiply)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppMultiplyNode* ptr
+        cdef cppMultiplyNode* ptr = model._graph.emplace_node[cppMultiplyNode](lhs.array_ptr, rhs.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Multiply, typeid(cppMultiplyNode))
 
@@ -2838,11 +2560,11 @@ cdef class NaryAdd(ArraySymbol):
         self.ptr = model._graph.emplace_node[cppNaryAddNode](cppinputs)
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppNaryAddNode* ptr = dynamic_cast_ptr[cppNaryAddNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a NaryAdd")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
         cdef NaryAdd x = NaryAdd.__new__(NaryAdd)
         x.ptr = ptr
         x.initialize_arraynode(symbol.model, ptr)
@@ -2892,20 +2614,8 @@ cdef class NaryMaximum(ArraySymbol):
             array = <ArraySymbol?>node
             cppinputs.push_back(array.array_ptr)
 
-        self.ptr = model._graph.emplace_node[cppNaryMaximumNode](cppinputs)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppNaryMaximumNode* ptr = dynamic_cast_ptr[cppNaryMaximumNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a NaryMaximum")
-        cdef NaryMaximum x = NaryMaximum.__new__(NaryMaximum)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppNaryMaximumNode* ptr
+        cdef cppNaryMaximumNode* ptr = model._graph.emplace_node[cppNaryMaximumNode](cppinputs)
+        self.initialize_arraynode(model, ptr)
 
 _register(NaryMaximum, typeid(cppNaryMaximumNode))
 
@@ -2942,20 +2652,8 @@ cdef class NaryMinimum(ArraySymbol):
             array = <ArraySymbol?>node
             cppinputs.push_back(array.array_ptr)
 
-        self.ptr = model._graph.emplace_node[cppNaryMinimumNode](cppinputs)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppNaryMinimumNode* ptr = dynamic_cast_ptr[cppNaryMinimumNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a NaryMinimum")
-        cdef NaryMinimum x = NaryMinimum.__new__(NaryMinimum)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppNaryMinimumNode* ptr
+        cdef cppNaryMinimumNode* ptr = model._graph.emplace_node[cppNaryMinimumNode](cppinputs)
+        self.initialize_arraynode(model, ptr)
 
 _register(NaryMinimum, typeid(cppNaryMinimumNode))
 
@@ -2994,11 +2692,11 @@ cdef class NaryMultiply(ArraySymbol):
         self.ptr = model._graph.emplace_node[cppNaryMultiplyNode](cppinputs)
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppNaryMultiplyNode* ptr = dynamic_cast_ptr[cppNaryMultiplyNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a NaryMultiply")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
         cdef NaryMultiply x = NaryMultiply.__new__(NaryMultiply)
         x.ptr = ptr
         x.initialize_arraynode(symbol.model, ptr)
@@ -3032,20 +2730,8 @@ cdef class Negative(ArraySymbol):
     def __init__(self, ArraySymbol x):
         cdef _Graph model = x.model
 
-        self.ptr = model._graph.emplace_node[cppNegativeNode](x.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppNegativeNode* ptr = dynamic_cast_ptr[cppNegativeNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Negative")
-        cdef Negative x = Negative.__new__(Negative)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppNegativeNode* ptr
+        cdef cppNegativeNode* ptr = model._graph.emplace_node[cppNegativeNode](x.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Negative, typeid(cppNegativeNode))
 
@@ -3059,20 +2745,8 @@ cdef class Not(ArraySymbol):
     def __init__(self, ArraySymbol x):
         cdef _Graph model = x.model
 
-        self.ptr = model._graph.emplace_node[cppNotNode](x.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppNotNode* ptr = dynamic_cast_ptr[cppNotNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Not")
-        cdef Not x = Not.__new__(Not)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppNotNode* ptr
+        cdef cppNotNode* ptr = model._graph.emplace_node[cppNotNode](x.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Not, typeid(cppNotNode))
 
@@ -3089,20 +2763,8 @@ cdef class Or(ArraySymbol):
 
         cdef _Graph model = lhs.model
 
-        self.ptr = model._graph.emplace_node[cppOrNode](lhs.array_ptr, rhs.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppOrNode* ptr = dynamic_cast_ptr[cppOrNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Or")
-        cdef Or x = Or.__new__(Or)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppOrNode* ptr
+        cdef cppOrNode* ptr = model._graph.emplace_node[cppOrNode](lhs.array_ptr, rhs.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Or, typeid(cppOrNode))
 
@@ -3124,11 +2786,11 @@ cdef class PartialProd(ArraySymbol):
         axes = self.ptr.axes()
         return tuple(axes[i] for i in range(axes.size()))
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppPartialProdNode* ptr = dynamic_cast_ptr[cppPartialProdNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Partial Sum")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
         cdef PartialProd ps = PartialProd.__new__(PartialProd)
         ps.ptr = ptr
         ps.initialize_arraynode(symbol.model, ptr)
@@ -3174,11 +2836,11 @@ cdef class PartialSum(ArraySymbol):
         axes = self.ptr.axes()
         return tuple(axes[i] for i in range(axes.size()))
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppPartialSumNode* ptr = dynamic_cast_ptr[cppPartialSumNode](symbol.node_ptr)
         if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Partial Sum")
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
         cdef PartialSum ps = PartialSum.__new__(PartialSum)
         ps.ptr = ptr
         ps.initialize_arraynode(symbol.model, ptr)
@@ -3222,20 +2884,9 @@ cdef class Permutation(ArraySymbol):
         if array.model is not x.model:
             raise ValueError("array and x do not share the same underlying model")
 
-        self.ptr = array.model._graph.emplace_node[cppPermutationNode](array.array_ptr, x.array_ptr)
-        self.initialize_arraynode(array.model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppPermutationNode* ptr = dynamic_cast_ptr[cppPermutationNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Permutation")
-        cdef Permutation p = Permutation.__new__(Permutation)
-        p.ptr = ptr
-        p.initialize_arraynode(symbol.model, ptr)
-        return p
-
-    cdef cppPermutationNode* ptr
+        cdef cppPermutationNode* ptr = array.model._graph.emplace_node[cppPermutationNode](
+            array.array_ptr, x.array_ptr)
+        self.initialize_arraynode(array.model, ptr)
 
 _register(Permutation, typeid(cppPermutationNode))
 
@@ -3257,22 +2908,8 @@ cdef class Prod(ArraySymbol):
     def __init__(self, ArraySymbol node):
         cdef _Graph model = node.model
 
-        self.ptr = model._graph.emplace_node[cppProdNode](node.array_ptr)
-
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppProdNode* ptr = dynamic_cast_ptr[cppProdNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Prod")
-
-        cdef Prod m = Prod.__new__(Prod)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
-
-    cdef cppProdNode* ptr
+        cdef cppProdNode* ptr = model._graph.emplace_node[cppProdNode](node.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Prod, typeid(cppProdNode))
 
@@ -3293,22 +2930,9 @@ cdef class Put(ArraySymbol):
                 "array, indices, and values do not all share the same underlying model"
             )
 
-        self.ptr = model._graph.emplace_node[cppPutNode](array.array_ptr, indices.array_ptr, values.array_ptr)
-
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppPutNode* ptr = dynamic_cast_ptr[cppPutNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Put")
-
-        cdef Put m = Put.__new__(Put)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
-
-    cdef cppPutNode* ptr
+        cdef cppPutNode* ptr = model._graph.emplace_node[cppPutNode](
+            array.array_ptr, indices.array_ptr, values.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Put, typeid(cppPutNode))
 
@@ -3450,8 +3074,8 @@ cdef class QuadraticModel(ArraySymbol):
 
         self._init_from_coords(x, (data, coords), ldata)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppQuadraticModelNode* ptr = dynamic_cast_ptr[cppQuadraticModelNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a QuadraticModel")
@@ -3566,8 +3190,8 @@ cdef class Reshape(ArraySymbol):
 
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppReshapeNode* ptr = dynamic_cast_ptr[cppReshapeNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a Reshape")
@@ -3618,8 +3242,8 @@ cdef class SetVariable(ArraySymbol):
         self.ptr = model._graph.emplace_node[cppSetNode](n, min_size, max_size)
         self.initialize_arraynode(model, self.ptr)
 
-    @staticmethod
-    def _from_symbol(Symbol symbol):
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
         cdef cppSetNode* ptr = dynamic_cast_ptr[cppSetNode](symbol.node_ptr)
         if not ptr:
             raise TypeError("given symbol cannot be used to construct a SetVariable")
@@ -3696,22 +3320,8 @@ cdef class Size(ArraySymbol):
     def __init__(self, ArraySymbol array):
         cdef _Graph model = array.model
 
-        self.ptr = model._graph.emplace_node[cppSizeNode](array.array_ptr)
-        self.initialize_arraynode(array.model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppSizeNode* ptr = dynamic_cast_ptr[cppSizeNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Size")
-
-        cdef Size x = Size.__new__(Size)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    # An observing pointer to the C++ SizeNode
-    cdef cppSizeNode* ptr
+        cdef cppSizeNode* ptr = model._graph.emplace_node[cppSizeNode](array.array_ptr)
+        self.initialize_arraynode(array.model, ptr)
 
 _register(Size, typeid(cppSizeNode))
 
@@ -3734,21 +3344,8 @@ cdef class Rint(ArraySymbol):
     def __init__(self, ArraySymbol x):
         cdef _Graph model = x.model
 
-        self.ptr = model._graph.emplace_node[cppRintNode](x.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppRintNode* ptr = dynamic_cast_ptr[cppRintNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Rint")
-
-        cdef Rint x = Rint.__new__(Rint)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppRintNode* ptr
+        cdef cppRintNode* ptr = model._graph.emplace_node[cppRintNode](x.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Rint, typeid(cppRintNode))
 
@@ -3770,21 +3367,8 @@ cdef class Square(ArraySymbol):
     def __init__(self, ArraySymbol x):
         cdef _Graph model = x.model
 
-        self.ptr = model._graph.emplace_node[cppSquareNode](x.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppSquareNode* ptr = dynamic_cast_ptr[cppSquareNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Square")
-
-        cdef Square x = Square.__new__(Square)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppSquareNode* ptr
+        cdef cppSquareNode* ptr = model._graph.emplace_node[cppSquareNode](x.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Square, typeid(cppSquareNode))
 
@@ -3807,21 +3391,8 @@ cdef class SquareRoot(ArraySymbol):
     def __init__(self, ArraySymbol x):
         cdef _Graph model = x.model
 
-        self.ptr = model._graph.emplace_node[cppSquareRootNode](x.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppSquareRootNode* ptr = dynamic_cast_ptr[cppSquareRootNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a SquareRoot")
-
-        cdef SquareRoot x = SquareRoot.__new__(SquareRoot)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppSquareRootNode* ptr
+        cdef cppSquareRootNode* ptr = model._graph.emplace_node[cppSquareRootNode](x.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(SquareRoot, typeid(cppSquareRootNode))
 
@@ -3846,20 +3417,8 @@ cdef class Subtract(ArraySymbol):
 
         cdef _Graph model = lhs.model
 
-        self.ptr = model._graph.emplace_node[cppSubtractNode](lhs.array_ptr, rhs.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppSubtractNode* ptr = dynamic_cast_ptr[cppSubtractNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Subtract")
-        cdef Subtract x = Subtract.__new__(Subtract)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppSubtractNode* ptr
+        cdef cppSubtractNode* ptr = model._graph.emplace_node[cppSubtractNode](lhs.array_ptr, rhs.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Subtract, typeid(cppSubtractNode))
 
@@ -3880,20 +3439,8 @@ cdef class Sum(ArraySymbol):
     """
     def __init__(self, ArraySymbol array):
         cdef _Graph model = array.model
-        self.ptr = model._graph.emplace_node[cppSumNode](array.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppSumNode* ptr = dynamic_cast_ptr[cppSumNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Sum")
-        cdef Sum s = Sum.__new__(Sum)
-        s.ptr = ptr
-        s.initialize_arraynode(symbol.model, ptr)
-        return s
-
-    cdef cppSumNode* ptr
+        cdef cppSumNode* ptr = model._graph.emplace_node[cppSumNode](array.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Sum, typeid(cppSumNode))
 
@@ -3912,21 +3459,9 @@ cdef class Where(ArraySymbol):
         if condition.model is not y.model:
             raise ValueError("condition and y do not share the same underlying model")
 
-        self.ptr = model._graph.emplace_node[cppWhereNode](
+        cdef cppWhereNode* ptr = model._graph.emplace_node[cppWhereNode](
             condition.array_ptr, x.array_ptr, y.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppWhereNode* ptr = dynamic_cast_ptr[cppWhereNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Sum")
-        cdef Where sym = Where.__new__(Where)
-        sym.ptr = ptr
-        sym.initialize_arraynode(symbol.model, ptr)
-        return sym
-
-    cdef cppWhereNode* ptr
+        self.initialize_arraynode(model, ptr)
 
 _register(Where, typeid(cppWhereNode))
 
@@ -3945,19 +3480,7 @@ cdef class Xor(ArraySymbol):
 
         cdef _Graph model = lhs.model
 
-        self.ptr = model._graph.emplace_node[cppXorNode](lhs.array_ptr, rhs.array_ptr)
-        self.initialize_arraynode(model, self.ptr)
-
-    @staticmethod
-    def _from_symbol(Symbol symbol):
-        cdef cppXorNode* ptr = dynamic_cast_ptr[cppXorNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError("given symbol cannot be used to construct a Xor")
-        cdef Xor x = Xor.__new__(Xor)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
-
-    cdef cppXorNode* ptr
+        cdef cppXorNode* ptr = model._graph.emplace_node[cppXorNode](lhs.array_ptr, rhs.array_ptr)
+        self.initialize_arraynode(model, ptr)
 
 _register(Xor, typeid(cppXorNode))


### PR DESCRIPTION
Many symbols don't actually need to hold a pointer of their specific type. We can remove a lot of boilerplate from such symbols.