### PR TITLE
Convert to a native namespace package

### DIFF
--- a/dwave/__init__.py
+++ b/dwave/__init__.py
@@ -1,17 +1,3 @@
-# Copyright 2023 D-Wave Systems Inc.
-#
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
-#
-#        http://www.apache.org/licenses/LICENSE-2.0
-#
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
-
-import pkgutil
-
-__path__ = pkgutil.extend_path(__path__, __name__)
+# Placeholder __init__.py required for the Cython build.
+# This file is not installed as part of the wheel.
+# See https://github.com/dwavesystems/dwave-optimization/issues/304

--- a/meson.build
+++ b/meson.build
@@ -112,7 +112,7 @@ py.extension_module(
     subdir: 'dwave/optimization/',
 )
 
-install_subdir('dwave', install_dir: py.get_install_dir(pure: false))
+install_subdir('dwave/optimization', install_dir: py.get_install_dir(pure: false) / 'dwave')
 
 # meson doesn't disable tests by default, so we let the user decide via the build-tests
 # option. If set to 'auto', then we build the tests for non-release builds.

--- a/releasenotes/notes/switch-to-native-namespaces-544919135e22ef1e.yaml
+++ b/releasenotes/notes/switch-to-native-namespaces-544919135e22ef1e.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Switch from pkgutil-style namespace package to native namespace package (PEP 420).
+    While native namespace packages and pkgutil-style namespace packages are
+    largely compatible, we recommend using only native ones going forward.


### PR DESCRIPTION
Rather than doing it the correct way (e.g. https://github.com/dwavesystems/dwave-optimization/pull/302), this simply does not include the `dwave/__init__.py` in the built wheel. The resulting wheel is correct, but it's definitely a workaround to avoid a Cython bug. See https://github.com/dwavesystems/dwave-optimization/issues/304 for more details.