### PR TITLE
Support two dynamic predecessors for BinaryOp

### DIFF
--- a/releasenotes/notes/binaryopnode-support-both-predecessors-dynamic-096fc6daa7c0fe0b.yaml
+++ b/releasenotes/notes/binaryopnode-support-both-predecessors-dynamic-096fc6daa7c0fe0b.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Allow BinaryOpNode (which Add, And, Multiply, etc. rely on) to accept two
+    dynamic-sized predecessors, as long as they have an equivalent shape as
+    determined by their `sizeinfo()`.


### PR DESCRIPTION
This is not an optimal implementation for handling the dynamic case with both parents having updates, but I tried to strike a balance between efficiency and keeping the changes minimal (by using `deduplicate_diff()`, even though it preserves the update values we don't care about).