### PR TITLE
Move AdvancedIndexingNode's shape to node state data

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
@@ -119,6 +119,8 @@ class AdvancedIndexingNode : public ArrayNode {
         return std::span(array_item_strides_.get(), array_ptr_->ndim());
     }
 
+    void update_dynamic_shape(State& state) const;
+
     // We could do dynamic_cast<Array*>(predecessors[0]), but since there's
     // only one we just go ahead and hold a direct pointer
     const Array* array_ptr_;
@@ -126,7 +128,6 @@ class AdvancedIndexingNode : public ArrayNode {
     const ssize_t ndim_;
     std::unique_ptr<ssize_t[]> strides_;
     std::unique_ptr<ssize_t[]> shape_;
-    std::unique_ptr<ssize_t[]> dynamic_shape_;
 
     std::unique_ptr<ssize_t[]> array_item_strides_;
 

--- a/releasenotes/notes/fix-adv-indexing-dynamic-shape-8ad943e35d22cccd.yaml
+++ b/releasenotes/notes/fix-adv-indexing-dynamic-shape-8ad943e35d22cccd.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Due to the way `AdvancedIndexingNode` held the data for its shape in the
+    dynamic size case (i.e. when the indexers are dynamic), it was possible to
+    encounter issues when mutating multiple states on the model. This has been
+    fixed by tracking the shape on the node's state data.


### PR DESCRIPTION
Previously, `AdvancedIndexingNode` kept an array as an attribute to hold the shape in the dynamic case (when indexing arrays have a dynamic size).

However, this could lead to inconsistent reported shape when mutating multiple states. Fixed by moving the shape data to live on the node state data, just like `BasicIndexingNode`.