### PR TITLE
Fix expensive resursion in Graph::recursive_reset()

### DIFF
--- a/dwave/optimization/src/graph.cpp
+++ b/dwave/optimization/src/graph.cpp
@@ -143,6 +143,9 @@ void Graph::recursive_reset(State& state, const Node* ptr) {
         return;
     }
 
+    // We've already been reset so nothing to do
+    if (!state[index]) return;
+
     // Otherwise, reset our own state and then all of our successors
     state[index].reset();
 


### PR DESCRIPTION
Calling `Graph::recursive_reset()` on a graph with many successive diamonds would previously be very slow to due the combinatorial explosion of paths through the graph.