### PR TITLE
Allow ConstantNode to hold python refs to data

### DIFF
--- a/dwave/optimization/_model.pxd
+++ b/dwave/optimization/_model.pxd
@@ -48,11 +48,6 @@ cdef class _Graph:
     # The number of times "lock()" has been called.
     cdef readonly Py_ssize_t _lock_count
 
-    # Used to keep NumPy arrays that own data alive etc etc
-    # We could pair each of these with an expired_ptr for the node holding
-    # memory for easier cleanup later if that becomes a concern.
-    cdef object _data_sources
-
 
 cdef class Symbol:
     # Inheriting nodes must call this method from their __init__()

--- a/dwave/optimization/_model.pyx
+++ b/dwave/optimization/_model.pyx
@@ -93,7 +93,6 @@ cdef class _Graph:
     """
     def __cinit__(self):
         self._lock_count = 0
-        self._data_sources = []
 
     def __init__(self, *args, **kwargs):
         # disallow direct construction of _Graphs, they should be constructed

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -22,6 +22,7 @@ import numbers
 
 cimport cpython.buffer
 cimport cpython.object
+from cpython.ref cimport PyObject
 import cython
 cimport cython
 import numpy as np
@@ -29,6 +30,7 @@ import numpy as np
 from cython.operator cimport dereference as deref, typeid
 from libc.math cimport modf
 from libcpp cimport bool
+from libcpp.memory cimport make_unique, unique_ptr
 from libcpp.optional cimport nullopt, optional
 from libcpp.span cimport span
 from libcpp.utility cimport move
@@ -951,6 +953,25 @@ cdef class Concatenate(ArraySymbol):
 _register(Concatenate, typeid(cppConcatenateNode))
 
 
+cdef extern from *:
+    """
+    #include "Python.h"
+
+    struct PyDataSource : dwave::optimization::ConstantNode::DataSource {
+        PyDataSource(PyObject* ptr) : ptr_(ptr) {
+            Py_INCREF(ptr);
+        }
+        ~PyDataSource() {
+            Py_DECREF(ptr_);
+        }
+
+        PyObject* ptr_;
+    };
+    """
+    cppclass PyDataSource:
+        PyDataSource(PyObject*)
+
+
 cdef class Constant(ArraySymbol):
     """Constant symbol.
 
@@ -977,13 +998,14 @@ cdef class Constant(ArraySymbol):
         if flat.size:
             start = &flat[0]
 
+        # Make a PyDataSource that will essentially take ownership of the numpy array,
+        # preventing garbage collection from deallocating it before the C++ node is
+        # destructed
+        cdef unique_ptr[PyDataSource] data_source = make_unique[PyDataSource](<PyObject*>(array))
         # Get an observing pointer to the C++ ConstantNode
-        self.ptr = model._graph.emplace_node[cppConstantNode](start, shape)
+        self.ptr = model._graph.emplace_node[cppConstantNode](move(data_source), start, shape)
 
         self.initialize_arraynode(model, self.ptr)
-
-        # Have the parent model hold a reference to the array, so it's kept alive
-        model._data_sources.append(array)
 
     def __bool__(self):
         if not self._is_scalar():


### PR DESCRIPTION
Now holding on to references to numpy arrays used for Constants on the model is no longer needed.