### PR TITLE
Add MeanNode/Symbol

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/statistics.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/statistics.hpp
@@ -1,0 +1,45 @@
+// Copyright 2025 D-Wave
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include "dwave-optimization/array.hpp"
+#include "dwave-optimization/graph.hpp"
+#include "dwave-optimization/state.hpp"
+
+namespace dwave::optimization {
+
+class MeanNode : public ScalarOutputMixin<ArrayNode, true> {
+ public:
+    MeanNode(ArrayNode* arr_ptr);
+
+    /// @copydoc Node::initialize_state()
+    void initialize_state(State& state) const override;
+
+    /// @copydoc Array::integral()
+    bool integral() const override;
+
+    /// @copydoc Array::minmax()
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
+
+    /// @copydoc Node::propagate()
+    void propagate(State& state) const override;
+
+ private:
+    // these are redundant, but convenient
+    const Array* arr_ptr_;
+};
+
+}  // namespace dwave::optimization

--- a/dwave/optimization/libcpp/nodes.pxd
+++ b/dwave/optimization/libcpp/nodes.pxd
@@ -293,6 +293,11 @@ cdef extern from "dwave-optimization/nodes/sorting.hpp" namespace "dwave::optimi
         pass
 
 
+cdef extern from "dwave-optimization/nodes/statistics.hpp" namespace "dwave::optimization" nogil:
+    cdef cppclass MeanNode(ArrayNode):
+        pass
+
+
 cdef extern from "dwave-optimization/nodes/testing.hpp" namespace "dwave::optimization" nogil:
     cdef cppclass ArrayValidationNode(Node):
         pass

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -35,6 +35,7 @@ from dwave.optimization.symbols import (
     Log,
     Logical,
     Maximum,
+    Mean,
     Minimum,
     Modulus,
     Multiply,
@@ -75,6 +76,7 @@ __all__ = [
     "logical_or",
     "logical_xor",
     "maximum",
+    "mean",
     "minimum",
     "mod",
     "multiply",
@@ -935,6 +937,33 @@ def maximum(x1: ArraySymbol, x2: ArraySymbol, *xi: ArraySymbol,
         [7. 5.]
     """
     raise RuntimeError("implemented by the op() decorator")
+
+
+def mean(array: ArraySymbol) -> Mean:
+    r"""Return the mean of the array elements.
+
+    Args:
+        array: Input array symbols.
+
+    Returns:
+        A symbol that is the mean of the input array elements.
+
+    Examples:
+        This example minimizes two integer symbols of size :math:`1 \times 2`.
+
+        >>> from dwave.optimization import Model
+        >>> from dwave.optimization.mathematical import mean
+        ...
+        >>> model = Model()
+        >>> i = model.integer(3)
+        >>> m = mean(i)
+        >>> with model.lock():
+        ...     model.states.resize(1)
+        ...     i.set_state(0, [8, 4, 3])
+        ...     print(m.state(0))
+        [5.0]
+    """
+    return Mean(array)
 
 
 @_op(Minimum, NaryMinimum, "min")

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -946,9 +946,8 @@ def mean(array: ArraySymbol) -> Mean:
         array: Input array symbol.
 
     Returns:
-        A symbol that is the mean of given symbol. 
-        If given symbol is empty, mean defaults to (minimum + maximum) / 2 of 
-        given symbol.
+        A symbol that is the mean of given symbol. If given symbol is empty, 
+        mean defaults to (minimum + maximum) / 2 of given symbol.
 
     Examples:
         This example takes the mean of one symbol.

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -940,16 +940,18 @@ def maximum(x1: ArraySymbol, x2: ArraySymbol, *xi: ArraySymbol,
 
 
 def mean(array: ArraySymbol) -> Mean:
-    r"""Return the mean of the array elements.
+    r"""Return mean of given symbol.
 
     Args:
-        array: Input array symbols.
+        array: Input array symbol.
 
     Returns:
-        A symbol that is the mean of the input array elements.
+        A symbol that is the mean of given symbol. 
+        If given symbol is empty, mean defaults to (minimum + maximum) / 2 of 
+        given symbol.
 
     Examples:
-        This example minimizes two integer symbols of size :math:`1 \times 2`.
+        This example takes the mean of one symbol.
 
         >>> from dwave.optimization import Model
         >>> from dwave.optimization.mathematical import mean
@@ -962,6 +964,8 @@ def mean(array: ArraySymbol) -> Mean:
         ...     i.set_state(0, [8, 4, 3])
         ...     print(m.state(0))
         5.0
+
+    .. versionadded:: 0.6.4
     """
     return Mean(array)
 

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -961,7 +961,7 @@ def mean(array: ArraySymbol) -> Mean:
         ...     model.states.resize(1)
         ...     i.set_state(0, [8, 4, 3])
         ...     print(m.state(0))
-        [5.0]
+        5.0
     """
     return Mean(array)
 

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -964,6 +964,9 @@ def mean(array: ArraySymbol) -> Mean:
         ...     print(m.state(0))
         5.0
 
+    See Also:
+        :class:`~dwave.optimization.symbols.Mean`: equivalent symbol.
+
     .. versionadded:: 0.6.4
     """
     return Mean(array)

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -947,7 +947,7 @@ def mean(array: ArraySymbol) -> Mean:
 
     Returns:
         A symbol that is the mean of given symbol. If given symbol is empty, 
-        mean defaults to (minimum + maximum) / 2 of given symbol.
+        mean defaults to 0.0.
 
     Examples:
         This example takes the mean of one symbol.

--- a/dwave/optimization/src/nodes/statistics.cpp
+++ b/dwave/optimization/src/nodes/statistics.cpp
@@ -41,14 +41,7 @@ bool MeanNode::integral() const { return false; }
 
 std::pair<double, double> MeanNode::minmax(
         optional_cache_type<std::pair<double, double>> cache) const {
-    return memoize(cache, [&]() {
-        if (arr_ptr_->size() == 0) {
-            return std::make_pair((arr_ptr_->min() + arr_ptr_->max()) / 2.0,
-                                  (arr_ptr_->min() + arr_ptr_->max()) / 2.0);
-        }
-        // Othwerwise, ArrayNode is non-empty and therefore has min and max
-        return std::make_pair(arr_ptr_->min(), arr_ptr_->max());
-    });
+    return memoize(cache, [&]() { return std::make_pair(arr_ptr_->min(), arr_ptr_->max()); });
 }
 
 void MeanNode::propagate(State &state) const {

--- a/dwave/optimization/src/nodes/statistics.cpp
+++ b/dwave/optimization/src/nodes/statistics.cpp
@@ -1,0 +1,98 @@
+// Copyright 2025 D-Wave
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include "dwave-optimization/nodes/statistics.hpp"
+
+#include <span>
+
+#include "dwave-optimization/array.hpp"
+
+namespace dwave::optimization {
+
+MeanNode::MeanNode(ArrayNode *arr_ptr) : ScalarOutputMixin<ArrayNode, true>(), arr_ptr_(arr_ptr) {
+    add_predecessor(arr_ptr);
+}
+
+void MeanNode::initialize_state(State &state) const {
+    // If state is empty, default value for mean is zero.
+    if (arr_ptr_->size(state) == 0) {
+        emplace_data_ptr<ScalarOutputMixinStateData>(state, 0.0);
+        return;
+    }
+    // Otherwise, compute mean of values in array
+    double sum = 0.0;
+    for (const auto val : arr_ptr_->view(state)) {
+        sum += val;
+    }
+    const double mean = sum / static_cast<double>(arr_ptr_->size(state));
+    emplace_data_ptr<ScalarOutputMixinStateData>(state, mean);
+}
+
+bool MeanNode::integral() const { return false; }
+
+std::pair<double, double> MeanNode::minmax(
+        optional_cache_type<std::pair<double, double>> cache) const {
+    return memoize(cache, [&]() {
+        // If state is empty, default value for mean is zero.
+        if (arr_ptr_->size() == 0) {
+            return std::make_pair(0.0, 0.0);
+        }
+        // Othwerwise, ArrayNode is non-empty and therefore has min and max
+        return std::make_pair(arr_ptr_->min(), arr_ptr_->max());
+    });
+}
+
+void MeanNode::propagate(State &state) const {
+    const std::span<const Update> arr_updates = arr_ptr_->diff(state);
+
+    // If no update, mean is unchanged
+    if (arr_updates.empty()) {
+        return;
+    }
+
+    auto node_data = data_ptr<ScalarOutputMixinStateData>(state);
+    const double state_size = static_cast<double>(arr_ptr_->size(state));
+
+    // If state is empty, default value for mean is zero.
+    if (state_size == 0.0) {
+        node_data->set(0.0);
+        return;
+    }
+
+    // Compute size of ArrayNode prior to change
+    const double state_size_prior = state_size - static_cast<double>(arr_ptr_->size_diff(state));
+    // Compute the sum of ArrayNode prior to change
+    double sum = node_data->update.value * (state_size_prior);
+
+    if (state_size == state_size_prior) {
+        // no value was removed or placed
+        for (const Update &u : arr_updates) {
+            sum += u.value - u.old;
+        }
+    } else {
+        for (const Update &u : arr_updates) {
+            if (u.removed()) {
+                sum -= u.old;
+            } else if (u.placed()) {
+                sum += u.value;
+            } else {
+                sum += u.value - u.old;
+            }
+        }
+    }
+    // Compute new mean
+    node_data->set(sum / state_size);
+}
+
+}  // namespace dwave::optimization

--- a/dwave/optimization/src/nodes/statistics.cpp
+++ b/dwave/optimization/src/nodes/statistics.cpp
@@ -54,14 +54,8 @@ std::pair<double, double> MeanNode::minmax(
         }
         // Predecessor is dynamic and possibly empty. Therefore, mean will be
         // default value of 0.0 (i.e. predecessor is empty) or fall within the
-        // min/max of predecessor. Base on predecessor's min/max, we extend
-        // meannode min/max.
-        if (arr_ptr_->min() > 0) {
-            return std::make_pair(0.0, arr_ptr_->max());
-        } else if (arr_ptr_->max() < 0) {
-            return std::make_pair(arr_ptr_->min(), 0.0);
-        }
-        return std::make_pair(arr_ptr_->min(), arr_ptr_->max());
+        // min/max of predecessor. If necessary, extend meannode min/max.
+        return std::make_pair(std::min(arr_ptr_->min(), 0.0), std::max(arr_ptr_->max(), 0.0));
     });
 }
 

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -2778,6 +2778,9 @@ cdef class Mean(ArraySymbol):
         >>> type(m)
         <class 'dwave.optimization.symbols.Mean'>
     
+    See Also:
+        :meth:`~dwave.optimization.mathematical.mean`: equivalent method.
+
     .. versionadded:: 0.6.4
     """
     def __init__(self, ArraySymbol arr):

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -2764,7 +2764,7 @@ _register(Maximum, typeid(cppMaximumNode))
 
 cdef class Mean(ArraySymbol):
     """Mean value of the elements of a symbol. If symbol is empty, 
-        mean defaults to (minimum + maximum) / 2 of symbol.
+        mean defaults to 0.0.
 
     Examples:
         This example takes the mean of one symbol.

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -2763,7 +2763,20 @@ _register(Maximum, typeid(cppMaximumNode))
 
 
 cdef class Mean(ArraySymbol):
-    """Mean value of the elements of a symbol.
+    """Mean value of the elements of a symbol. If symbol is empty, 
+        mean defaults to (minimum + maximum) / 2 of symbol.
+
+    Examples:
+        This example takes the mean of one symbol.
+
+        >>> from dwave.optimization import Model
+        >>> from dwave.optimization.mathematical import mean
+        ...
+        >>> model = Model()
+        >>> i = model.integer(4)
+        >>> m = mean(i)
+        >>> type(m)
+        <class 'dwave.optimization.symbols.Mean'>
     
     .. versionadded:: 0.6.4
     """

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -2763,7 +2763,10 @@ _register(Maximum, typeid(cppMaximumNode))
 
 
 cdef class Mean(ArraySymbol):
-    """Mean value of the elements of a symbol."""
+    """Mean value of the elements of a symbol.
+    
+    .. versionadded:: 0.6.4
+    """
     def __init__(self, ArraySymbol arr):
         cdef _Graph model = arr.model
 

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -93,6 +93,7 @@ from dwave.optimization.libcpp.nodes cimport (
     LogicalNode as cppLogicalNode,
     MaxNode as cppMaxNode,
     MaximumNode as cppMaximumNode,
+    MeanNode as cppMeanNode,
     MinNode as cppMinNode,
     MinimumNode as cppMinimumNode,
     ModulusNode as cppModulusNode,
@@ -173,6 +174,7 @@ __all__ = [
     "Logical",
     "Max",
     "Maximum",
+    "Mean",
     "Min",
     "Minimum",
     "Modulus",
@@ -2758,6 +2760,29 @@ cdef class Maximum(ArraySymbol):
         self.initialize_arraynode(model, ptr)
 
 _register(Maximum, typeid(cppMaximumNode))
+
+
+cdef class Mean(ArraySymbol):
+    """Mean value of the elements of a symbol."""
+    def __init__(self, ArraySymbol arr):
+        cdef _Graph model = arr.model
+
+        self.ptr = model._graph.emplace_node[cppMeanNode](arr.array_ptr)
+        self.initialize_arraynode(model, self.ptr)
+
+    @classmethod
+    def _from_symbol(cls, Symbol symbol):
+        cdef cppMeanNode* ptr = dynamic_cast_ptr[cppMeanNode](symbol.node_ptr)
+        if not ptr:
+            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+        cdef Mean x = Mean.__new__(Mean)
+        x.ptr = ptr
+        x.initialize_arraynode(symbol.model, ptr)
+        return x
+
+    cdef cppMeanNode* ptr
+
+_register(Mean, typeid(cppMeanNode))
 
 
 cdef class Min(ArraySymbol):

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,7 @@ dwave_optimization_src = [
     'dwave/optimization/src/nodes/numbers.cpp',
     'dwave/optimization/src/nodes/quadratic_model.cpp',
     'dwave/optimization/src/nodes/sorting.cpp',
+    'dwave/optimization/src/nodes/statistics.cpp',
     'dwave/optimization/src/nodes/testing.cpp',
     'dwave/optimization/src/array.cpp',
     'dwave/optimization/src/graph.cpp',

--- a/releasenotes/notes/mean-symbol-932d07bdd51f738b.yaml
+++ b/releasenotes/notes/mean-symbol-932d07bdd51f738b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Added ``Mean`` symbol/node which returns the mean of its predecessor.

--- a/tests/cpp/meson.build
+++ b/tests/cpp/meson.build
@@ -26,6 +26,7 @@ tests_all = executable(
         'nodes/test_numbers.cpp',
         'nodes/test_quadratic_model.cpp',
         'nodes/test_sorting.cpp',
+        'nodes/test_statistics.cpp',
         'test_array.cpp',
         'test_graph.cpp',
         'test_iterators.cpp',

--- a/tests/cpp/nodes/test_statistics.cpp
+++ b/tests/cpp/nodes/test_statistics.cpp
@@ -1,0 +1,165 @@
+// Copyright 2025 D-Wave
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include "dwave-optimization/nodes/collections.hpp"
+#include "dwave-optimization/nodes/constants.hpp"
+#include "dwave-optimization/nodes/numbers.hpp"
+#include "dwave-optimization/nodes/statistics.hpp"
+#include "dwave-optimization/nodes/testing.hpp"
+
+using Catch::Matchers::RangeEquals;
+
+namespace dwave::optimization {
+
+TEST_CASE("MeanNode") {
+    auto graph = Graph();
+
+    GIVEN("An empty integer constant node and a mean node") {
+        auto a_ptr = graph.emplace_node<ConstantNode>();
+        auto mean_ptr = graph.emplace_node<MeanNode>(a_ptr);
+        graph.emplace_node<ArrayValidationNode>(mean_ptr);
+
+        WHEN("We initialize a state") {
+            auto state = graph.initialize_state();
+
+            THEN("The initial mean is correct") {
+                CHECK_THAT(mean_ptr->view(state), RangeEquals({0.0}));
+            }
+        }
+    }
+
+    GIVEN("A non-empty integer constant node (with integer mean) and a mean "
+          "node") {
+        auto a_ptr = graph.emplace_node<ConstantNode>(std::vector{4.0, 2.0});
+        auto mean_ptr = graph.emplace_node<MeanNode>(a_ptr);
+        graph.emplace_node<ArrayValidationNode>(mean_ptr);
+
+        WHEN("We initialize a state") {
+            auto state = graph.initialize_state();
+
+            THEN("The initial mean is correct") {
+                CHECK_THAT(mean_ptr->view(state), RangeEquals({3.0}));
+            }
+        }
+    }
+    GIVEN("A non-empty integer constant node (with non-integer mean) and a mean "
+          "node") {
+        auto a_ptr = graph.emplace_node<ConstantNode>(std::vector{4.0, 3.0, 1.0, 2.0});
+        auto mean_ptr = graph.emplace_node<MeanNode>(a_ptr);
+        graph.emplace_node<ArrayValidationNode>(mean_ptr);
+
+        WHEN("We initialize a state") {
+            auto state = graph.initialize_state();
+
+            THEN("The initial mean is correct") {
+                CHECK_THAT(mean_ptr->view(state), RangeEquals({2.5}));
+            }
+        }
+    }
+    GIVEN("A non-empty mixed constant node (with non-integer mean) and a mean "
+          "node") {
+        auto a_ptr = graph.emplace_node<ConstantNode>(std::vector{-4.5, 3.2, 1.0, -2.7});
+        auto mean_ptr = graph.emplace_node<MeanNode>(a_ptr);
+        graph.emplace_node<ArrayValidationNode>(mean_ptr);
+
+        WHEN("We initialize a state") {
+            auto state = graph.initialize_state();
+
+            THEN("The initial mean is correct") {
+                CHECK_THAT(mean_ptr->view(state), RangeEquals({-0.75}));
+            }
+        }
+    }
+
+    GIVEN("A non-empty integer node and a mean node") {
+        auto i_ptr = graph.emplace_node<IntegerNode>(3);
+        auto mean_ptr = graph.emplace_node<MeanNode>(i_ptr);
+        graph.emplace_node<ArrayValidationNode>(mean_ptr);
+
+        WHEN("We initialize a state") {
+            auto state = graph.empty_state();
+            i_ptr->initialize_state(state, {6.0, 5.0, 1.0});
+            graph.initialize_state(state);
+
+            THEN("The initial mean is correct") {
+                CHECK_THAT(mean_ptr->view(state), RangeEquals({4.0}));
+            }
+
+            AND_WHEN("We make some changes to the integer node and propagate") {
+                i_ptr->set_value(state, 1, 0.0);
+                i_ptr->set_value(state, 2, 3.0);
+                // i_ptr should now be [6.0, 0.0, 3.0]
+                graph.propagate(state);
+
+                THEN("The mean is correct") {
+                    CHECK_THAT(mean_ptr->view(state), RangeEquals({3.0}));
+                }
+            }
+        }
+    }
+
+    GIVEN("A dynamic set node and a mean node") {
+        auto set_ptr = graph.emplace_node<SetNode>(9);
+        auto mean_ptr = graph.emplace_node<MeanNode>(set_ptr);
+        graph.emplace_node<ArrayValidationNode>(mean_ptr);
+
+        WHEN("We initialize a state") {
+            auto state = graph.initialize_state();
+
+            THEN("The initial mean is correct") {
+                CHECK_THAT(mean_ptr->view(state), RangeEquals({0.0}));
+            }
+
+            AND_WHEN("We grow the set node and propagate") {
+                set_ptr->assign(state, std::vector<double>{5, 8, 2, 6});
+                graph.propagate(state);
+
+                THEN("The mean is correct") {
+                    CHECK_THAT(mean_ptr->view(state), RangeEquals({5.25}));
+                }
+
+                AND_WHEN("We commit, shrink the set node, and propagate") {
+                    graph.commit(state);
+
+                    set_ptr->shrink(state);
+                    set_ptr->shrink(state);
+                    // set should be [5, 8]
+                    graph.propagate(state);
+
+                    THEN("The mean is correct") {
+                        CHECK_THAT(mean_ptr->view(state), RangeEquals({6.5}));
+                    }
+
+                    AND_WHEN("We commit, shrink the set node to nothing, and propagate") {
+                        graph.commit(state);
+
+                        set_ptr->shrink(state);
+                        set_ptr->shrink(state);
+                        // set should be []
+                        graph.propagate(state);
+
+                        THEN("The mean is correct") {
+                            CHECK_THAT(mean_ptr->view(state), RangeEquals({0.0}));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+}  // namespace dwave::optimization

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -2136,7 +2136,7 @@ class TestMean(utils.SymbolTests):
         from dwave.optimization.symbols import Mean
         model = Model()
         c = model.constant([2, 3, 5, 1])
-        mean = dwave.optimization.symbols.Mean(c)
+        mean = dwave.optimization.mean(c)
 
         self.assertIsInstance(mean, Mean)
 

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -2123,6 +2123,32 @@ class TestMaximum(utils.SymbolTests):
         np.testing.assert_array_equal(m.state(0), np.arange(5, 10))
 
 
+class TestMean(utils.SymbolTests):
+    def generate_symbols(self):
+        model = Model()
+        c = model.constant([2, 3, 5, 1])
+        mean = dwave.optimization.symbols.Mean(c)
+
+        with model.lock():
+            yield mean
+
+    def test(self):
+        from dwave.optimization.symbols import Mean
+        model = Model()
+        c = model.constant([2, 3, 5, 1])
+        mean = dwave.optimization.symbols.Mean(c)
+
+        self.assertIsInstance(mean, Mean)
+
+    def test_state(self):
+        model = Model()
+        c = model.constant([2, 3, 5, 1])
+        mean = dwave.optimization.symbols.Mean(c)
+        model.states.resize(1)
+        with model.lock():
+            np.testing.assert_array_equal(mean.state(0), np.array([2.75]))
+
+
 class TestMin(utils.ReduceTests):
     empty_requires_initial = True
 


### PR DESCRIPTION
Basic implementation of numpy.mean() without axis arguments. Fix #238.