### PR TITLE
Include missing type_traits header in type_list.hpp

### DIFF
--- a/dwave/optimization/include/dwave-optimization/type_list.hpp
+++ b/dwave/optimization/include/dwave-optimization/type_list.hpp
@@ -41,6 +41,7 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
 #include <utility>
 #include <variant>
 


### PR DESCRIPTION
This file uses `std::is_polymorphic_v` (maybe others?) that are provided by `type_traits` so this should be included.