### PR TITLE
Add IsInNode/Symbol

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/set_routines.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/set_routines.hpp
@@ -22,8 +22,6 @@
 
 namespace dwave::optimization {
 
-struct IsInNodeData;
-
 class IsInNode : public ArrayOutputMixin<ArrayNode> {
  public:
     IsInNode(ArrayNode* element_ptr, ArrayNode* test_elements_ptr);
@@ -75,8 +73,6 @@ class IsInNode : public ArrayOutputMixin<ArrayNode> {
     // these are redundant, but convenient
     const Array* element_ptr_;
     const Array* test_elements_ptr_;
-
-    inline void rm_index(IsInNodeData*& node_data, const ssize_t rm_index, const double key) const;
 };
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/include/dwave-optimization/nodes/set_routines.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/set_routines.hpp
@@ -74,8 +74,7 @@ class IsInNode : public ArrayOutputMixin<ArrayNode> {
     const Array* element_ptr_;
     const Array* test_elements_ptr_;
 
-    inline void rm_index_from_element_indices_key(IsInNodeData*& node_data, const ssize_t rm_index,
-                                                  const double key) const;
+    inline void rm_index(IsInNodeData*& node_data, const ssize_t rm_index, const double key) const;
 };
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/include/dwave-optimization/nodes/set_routines.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/set_routines.hpp
@@ -22,6 +22,8 @@
 
 namespace dwave::optimization {
 
+struct IsInNodeData;
+
 class IsInNode : public ArrayOutputMixin<ArrayNode> {
  public:
     IsInNode(ArrayNode* element_ptr, ArrayNode* test_elements_ptr);
@@ -71,6 +73,9 @@ class IsInNode : public ArrayOutputMixin<ArrayNode> {
     // these are redundant, but convenient
     const Array* element_ptr_;
     const Array* test_elements_ptr_;
+
+    inline void rm_index_from_element_indices_key(IsInNodeData*& node_data, const ssize_t rm_index,
+                                                  const double key) const;
 };
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/include/dwave-optimization/nodes/set_routines.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/set_routines.hpp
@@ -1,0 +1,76 @@
+// Copyright 2025 D-Wave
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <span>
+
+#include "dwave-optimization/array.hpp"
+#include "dwave-optimization/graph.hpp"
+#include "dwave-optimization/state.hpp"
+
+namespace dwave::optimization {
+
+class IsInNode : public ArrayOutputMixin<ArrayNode> {
+ public:
+    IsInNode(ArrayNode* element_ptr, ArrayNode* test_elements_ptr);
+
+    /// @copydoc Array::buff()
+    double const* buff(const State& state) const override;
+
+    /// @copydoc Node::commit()
+    void commit(State& state) const override;
+
+    /// @copydoc Array::diff()
+    std::span<const Update> diff(const State& state) const override;
+
+    /// @copydoc Node::initialize_state()
+    void initialize_state(State& state) const override;
+
+    /// @copydoc Array::integral()
+    bool integral() const override;
+
+    /// @copydoc Array::minmax()
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
+
+    /// @copydoc Node::propagate()
+    void propagate(State& state) const override;
+
+    /// @copydoc Node::revert()
+    void revert(State& state) const override;
+
+    using Array::shape;
+
+    /// @copydoc Array::shape()
+    std::span<const ssize_t> shape(const State& state) const override;
+
+    using Array::size;
+
+    /// @copydoc Array::size()
+    ssize_t size(const State& state) const override;
+
+    /// @copydoc Array::size_diff()
+    ssize_t size_diff(const State& state) const override;
+
+    /// @copydoc Array::sizeinfo()
+    SizeInfo sizeinfo() const override;
+
+ private:
+    // these are redundant, but convenient
+    const Array* element_ptr_;
+    const Array* test_elements_ptr_;
+};
+
+}  // namespace dwave::optimization

--- a/dwave/optimization/include/dwave-optimization/nodes/set_routines.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/set_routines.hpp
@@ -43,9 +43,11 @@ class IsInNode : public ArrayOutputMixin<ArrayNode> {
     /// @copydoc Array::integral()
     bool integral() const override;
 
-    /// @copydoc Array::minmax()
-    std::pair<double, double> minmax(
-            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
+    /// @copydoc Array::min()
+    double min() const override;
+
+    /// @copydoc Array::max()
+    double max() const override;
 
     /// @copydoc Node::propagate()
     void propagate(State& state) const override;

--- a/dwave/optimization/libcpp/nodes/__init__.pxd
+++ b/dwave/optimization/libcpp/nodes/__init__.pxd
@@ -27,6 +27,7 @@ from dwave.optimization.libcpp.nodes.naryop cimport *
 from dwave.optimization.libcpp.nodes.numbers cimport *
 from dwave.optimization.libcpp.nodes.quadratic_model cimport *
 from dwave.optimization.libcpp.nodes.reduce cimport *
+from dwave.optimization.libcpp.nodes.set_routines cimport *
 from dwave.optimization.libcpp.nodes.softmax cimport *
 from dwave.optimization.libcpp.nodes.sorting cimport *
 from dwave.optimization.libcpp.nodes.statistics cimport *

--- a/dwave/optimization/libcpp/nodes/set_routines.pxd
+++ b/dwave/optimization/libcpp/nodes/set_routines.pxd
@@ -1,0 +1,20 @@
+# Copyright 2025 D-Wave
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from dwave.optimization.libcpp.graph cimport ArrayNode
+
+
+cdef extern from "dwave-optimization/nodes/set_routines.hpp" namespace "dwave::optimization" nogil:
+    cdef cppclass IsInNode(ArrayNode):
+        pass

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -32,6 +32,7 @@ from dwave.optimization.symbols import (
     Exp,
     Expit,
     Extract,
+    IsIn,
     LinearProgram,
     LinearProgramFeasible,
     LinearProgramObjectiveValue,
@@ -77,6 +78,7 @@ __all__ = [
     "expit",
     "extract",
     "hstack",
+    "isin",
     "linprog",
     "log",
     "logical",
@@ -711,6 +713,37 @@ def hstack(arrays: collections.abc.Sequence[ArraySymbol]) -> ArraySymbol:
         return concatenate(arrays, 0)
     else:
         return concatenate(arrays, 1)
+
+
+def isin(element: ArraySymbol, test_elements: ArraySymbol) -> IsIn:
+    """ Determine element-wise containment between two symbols. Given two
+    symbols: element and test_elements, returns an array of the same shape
+    as element such that element[index] = True if element[index] is in
+    test_elements and False otherwise.
+
+    Args:
+        element: Input array.
+        test_elements: Input array containing the values against which to test
+                       each value of element. 
+
+    Examples:
+        >>> from dwave.optimization.model import Model
+        >>> from dwave.optimization.mathematical import isin
+        >>> model = Model()
+        >>> model.states.resize(1)
+        >>> element = model.constant([1.3, -1.0, 3.0])
+        >>> test_elements = model.constant([3.0, -1.1, -2.0, 4.1, -1.0])
+        >>> contains = isin(element, test_elements)
+        >>> with model.lock():
+        ...     print(contains.state(0))
+        [0. 1. 1.]
+
+    See Also:
+        :class:`~dwave.optimization.IsIn`: equivalent symbol.
+
+    .. versionadded:: 0.6.5
+    """
+    return IsIn(element, test_elements)
 
 
 class LPResult:

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -717,8 +717,8 @@ def hstack(arrays: collections.abc.Sequence[ArraySymbol]) -> ArraySymbol:
 
 def isin(element: ArraySymbol, test_elements: ArraySymbol) -> IsIn:
     """ Determine element-wise containment between two symbols. Given two
-    symbols: element and test_elements, returns an array of the same shape
-    as element such that element[index] = True if element[index] is in
+    symbols: element and test_elements, returns an output array of the same
+    shape as element such that output[index] = True if element[index] is in
     test_elements and False otherwise.
 
     Args:
@@ -741,7 +741,7 @@ def isin(element: ArraySymbol, test_elements: ArraySymbol) -> IsIn:
     See Also:
         :class:`~dwave.optimization.symbols.IsIn`: equivalent symbol.
 
-    .. versionadded:: 0.6.7
+    .. versionadded:: 0.6.8
     """
     return IsIn(element, test_elements)
 

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -739,9 +739,9 @@ def isin(element: ArraySymbol, test_elements: ArraySymbol) -> IsIn:
         [0. 1. 1.]
 
     See Also:
-        :class:`~dwave.optimization.IsIn`: equivalent symbol.
+        :class:`~dwave.optimization.symbols.IsIn`: equivalent symbol.
 
-    .. versionadded:: 0.6.5
+    .. versionadded:: 0.6.7
     """
     return IsIn(element, test_elements)
 

--- a/dwave/optimization/src/nodes/set_routines.cpp
+++ b/dwave/optimization/src/nodes/set_routines.cpp
@@ -14,25 +14,37 @@
 
 #include "dwave-optimization/nodes/set_routines.hpp"
 
+#include <vector>
+
 #include "_state.hpp"
 
 namespace dwave::optimization {
 
-/// IsInNode
+// IsInNode *****************************************************************
+struct IsInNodePredData {
+    IsInNodePredData() = default;
+
+    // # of indices from `test_elements` with a given value
+    ssize_t test_elements_count;
+    // All indices of `element` with a given value
+    std::vector<ssize_t> element_indices;
+};
+
 struct IsInNodeDataHelper_ {
     IsInNodeDataHelper_(std::vector<double> element, std::vector<double> test_elements) {
         element_isin.reserve(element.size());
 
         for (const double& val : test_elements) {
-            test_elements_counter[val] += 1;
+            pred_data[val].test_elements_count += 1;
         }
         for (ssize_t index = 0, stop = element.size(); index < stop; index++) {
-            element_isin.emplace_back(test_elements_counter.contains(element[index]));
-            element_indices[element[index]].push_back(index);
+            IsInNodePredData& pred_data_struct = pred_data[element[index]];
+            pred_data_struct.element_indices.push_back(index);
+            element_isin.emplace_back(pred_data_struct.test_elements_count > 0);
         }
     }
-    std::unordered_map<double, ssize_t> test_elements_counter;
-    std::unordered_map<double, std::vector<ssize_t>> element_indices;
+
+    std::unordered_map<double, IsInNodePredData> pred_data;
     // element_isin[i] == true iff `element[i]` is in`test_elements`
     std::vector<bool> element_isin;
 };
@@ -42,18 +54,14 @@ struct IsInNodeData : public ArrayNodeStateData {
             : IsInNodeData(IsInNodeDataHelper_(std::move(element), std::move(test_elements))) {}
     IsInNodeData(IsInNodeDataHelper_&& helper)
             : ArrayNodeStateData(std::move(helper.element_isin)),
-              test_elements_counter(std::move(helper.test_elements_counter)),
-              element_indices(std::move(helper.element_indices)) {}
-
-    // # of elements from `test_elements` with a given value (key)
-    std::unordered_map<double, ssize_t> test_elements_counter;
-    // All indices of `element` with a given value (key)
-    std::unordered_map<double, std::vector<ssize_t>> element_indices;
+              pred_data(std::move(helper.pred_data)) {}
 
     // Used to track if elements are added/removed from `test_elements`
     // during IsInNode::propagate()
     std::unordered_map<double, bool> add_or_rm_test_elements;
-
+    // For each value (key) in `element` and `test_elements`, store a
+    // IsInNodePredData struct.
+    std::unordered_map<double, IsInNodePredData> pred_data;
     // Needed for IsInNode::revert()
     std::vector<Update> element_updates;
     std::vector<Update> test_element_updates;
@@ -94,26 +102,25 @@ std::pair<double, double> IsInNode::minmax(
     });
 }
 
-inline void IsInNode::rm_index_from_element_indices_key(IsInNodeData*& node_data,
-                                                        const ssize_t rm_index,
-                                                        const double key) const {
-    // Get iterator containing indices of `element` with value `key`
-    // Note: find() must be successful
-    auto indices_iter = node_data->element_indices.find(key);
-    assert(indices_iter != node_data->element_indices.end());
+inline void IsInNode::rm_index(IsInNodeData*& node_data, const ssize_t rm_index,
+                               const double key) const {
+    auto pred_data_it = node_data->pred_data.find(key);
+    // find() should be successful since we need to remove the index
+    assert(pred_data_it != node_data->pred_data.end());
     // Vector containing indices of `element` with value `key`
-    std::vector<ssize_t>& indices_vec = indices_iter->second;
+    std::vector<ssize_t>& indices_vec = pred_data_it->second.element_indices;
     // Find index of `indices_vec` equal to `rm_index`
-    // Note: find() must be successful
     auto index_ptr = std::find(indices_vec.begin(), indices_vec.end(), rm_index);
+    // find() should be successful since we need to remove the index
     assert(index_ptr != indices_vec.end());
     // swap and pop
     *index_ptr = indices_vec.back();
     indices_vec.pop_back();
-    // Uncomment to reduce bloating
-    // if (indices_vec.empty()) {
-    //     node_data->element_indices.erase(indices_iter);
-    // }
+
+    // Reduce bloating
+    if (indices_vec.empty() && pred_data_it->second.test_elements_count == 0) {
+        node_data->pred_data.erase(pred_data_it);
+    }
 }
 
 void IsInNode::propagate(State& state) const {
@@ -134,12 +141,12 @@ void IsInNode::propagate(State& state) const {
     for (const Update& update : test_elements_diff) {
         if (!update.placed()) {
             // i.e. changed or removed.
-            auto count = node_data->test_elements_counter.find(update.old);
+            ssize_t& count = node_data->pred_data[update.old].test_elements_count;
             // `update.old` must be in `test_elements_counter`
-            assert(count != node_data->test_elements_counter.end());
-            count->second -= 1;
+            assert(count > 0);
+            count -= 1;
 
-            if (count->second == 0) {
+            if (count == 0) {
                 // Deleting `update.old` from `test_elements` results in no index
                 // of `test_elements` having the value `update.old`. Record it to
                 // update the containment of `element` later.
@@ -147,12 +154,11 @@ void IsInNode::propagate(State& state) const {
             }
         }
         if (!update.removed()) {
-            // i.e. changed or added. Note: `update.value` may not occur in
-            // `test_elements_counter`, hence try_emplace
-            auto [count, _] = node_data->test_elements_counter.try_emplace(update.value, 0);
-            count->second += 1;
+            // i.e. changed or added.
+            ssize_t& count = node_data->pred_data[update.value].test_elements_count;
+            count += 1;
 
-            if (count->second == 1) {
+            if (count == 1) {
                 // Previously, `update.value` did not occur in `test_elements`.
                 // Record it to update the containment of `element` later.
                 node_data->add_or_rm_test_elements.insert_or_assign(update.value, true);
@@ -163,34 +169,34 @@ void IsInNode::propagate(State& state) const {
     // Handle changes to `element`
     for (const Update& update : element_diff) {
         if (!update.placed()) {  // i.e. changed or removed
-            rm_index_from_element_indices_key(node_data, update.index, update.old);
+            rm_index(node_data, update.index, update.old);
         }
         if (!update.removed()) {  // i.e. changed or added
-            node_data->element_indices[update.value].push_back(update.index);
+            IsInNodePredData& pred_data_struct = node_data->pred_data[update.value];
+            pred_data_struct.element_indices.push_back(update.index);
             // Record whether or not the value of `element` at `update.index` is
             // in `test_elements`. Allow emplace_back()
-            node_data->set(update.index, node_data->test_elements_counter.contains(update.value),
-                           true);
+            node_data->set(update.index, pred_data_struct.test_elements_count > 0, true);
         }
     }
 
     // `add_or_rm_test_elements` contains all unique values of `test_elements`
     // that are new or fully removed
     for (const auto& [key, assignment] : node_data->add_or_rm_test_elements) {
-        // Find `key` (should it exist) in `element_indices`
-        auto indices_iter = node_data->element_indices.find(key);
+        auto pred_data_it = node_data->pred_data.find(key);
+        // find() should be successful since we need to remove the index
+        assert(pred_data_it != node_data->pred_data.end());
+        // Vector containing indices of `element` with value `key`
+        const std::vector<ssize_t>& indices_vec = pred_data_it->second.element_indices;
 
-        if (indices_iter != node_data->element_indices.end()) {
-            // indices_iter->second is vector containing indices of `element` with
-            // value `key`
-            for (const ssize_t& index : indices_iter->second) {
+        if (!indices_vec.empty()) {
+            for (const ssize_t& index : indices_vec) {
                 node_data->set(index, assignment);
             }
+            // Reduce bloating
+        } else if (!assignment) {
+            node_data->pred_data.erase(pred_data_it);
         }
-        // Uncomment to reduce bloating
-        // if (!assignment) {
-        //     node_data->test_elements_counter.erase(key);
-        // }
     }
     node_data->add_or_rm_test_elements.clear();
 
@@ -206,27 +212,28 @@ void IsInNode::revert(State& state) const {
     // Revert the changes to `test_elements`
     for (const Update& update : node_data->test_element_updates | std::views::reverse) {
         if (!update.placed()) {  // i.e. removed or changed
-            node_data->test_elements_counter[update.old] += 1;
+            node_data->pred_data[update.old].test_elements_count += 1;
         }
         if (!update.removed()) {  // i.e. changed or removed.
-            auto count = node_data->test_elements_counter.find(update.value);
-            // `update.value` must be in `test_elements_counter`
-            assert(count != node_data->test_elements_counter.end());
-            count->second -= 1;
-            // Uncomment to reduce bloating
-            // if (count->second == 0) {
-            //     node_data->test_elements_counter.erase(count);
-            // }
+            auto pred_data_it = node_data->pred_data.find(update.value);
+            // find() should be successful since we need to remove the index
+            assert(pred_data_it != node_data->pred_data.end());
+            pred_data_it->second.test_elements_count -= 1;
+            // Reduce bloating
+            if (pred_data_it->second.test_elements_count == 0 &&
+                pred_data_it->second.element_indices.empty()) {
+                node_data->pred_data.erase(pred_data_it);
+            }
         }
     }
 
     // Revert the changes to `element`
     for (const Update& update : node_data->element_updates | std::views::reverse) {
         if (!update.placed()) {  // i.e. removed or changed
-            node_data->element_indices[update.old].push_back(update.index);
+            node_data->pred_data[update.old].element_indices.push_back(update.index);
         }
         if (!update.removed()) {  // i.e. placed or changed
-            rm_index_from_element_indices_key(node_data, update.index, update.value);
+            rm_index(node_data, update.index, update.value);
         }
     }
 

--- a/dwave/optimization/src/nodes/set_routines.cpp
+++ b/dwave/optimization/src/nodes/set_routines.cpp
@@ -20,14 +20,14 @@
 
 namespace dwave::optimization {
 
-// IsInNode *****************************************************************
+// IsInNode *******************************************************************
 struct IsInNodeSetData {
     IsInNodeSetData() = default;
 
     // # of indices from `test_elements` with a given value
-    ssize_t test_elements_count;
+    ssize_t test_elements_count;  // default is 0
     // All indices of `element` with a given value
-    std::vector<ssize_t> element_indices;
+    std::vector<ssize_t> element_indices;  // default is empty vector
 };
 
 struct IsInNodeDataHelper_ {
@@ -37,7 +37,7 @@ struct IsInNodeDataHelper_ {
         for (const double& val : test_elements) {
             set_data[val].test_elements_count += 1;
         }
-        for (ssize_t index = 0, stop = element.size(); index < stop; index++) {
+        for (ssize_t index = 0, stop = element.size(); index < stop; ++index) {
             IsInNodeSetData& set_data_struct = set_data[element[index]];
             set_data_struct.element_indices.push_back(index);
             element_isin.emplace_back(set_data_struct.test_elements_count > 0);
@@ -95,12 +95,9 @@ void IsInNode::initialize_state(State& state) const {
 
 bool IsInNode::integral() const { return true; }  // All values are true/false
 
-std::pair<double, double> IsInNode::minmax(
-        optional_cache_type<std::pair<double, double>> cache) const {
-    return memoize(cache, [&]() {
-        return std::make_pair(0.0, 1.0);  // All values are true/false
-    });
-}
+double IsInNode::min() const { return 0.0; }  // All values are true/false
+
+double IsInNode::max() const { return 1.0; }  // All values are true/false
 
 inline void IsInNode::rm_index(IsInNodeData*& node_data, const ssize_t rm_index,
                                const double key) const {

--- a/dwave/optimization/src/nodes/set_routines.cpp
+++ b/dwave/optimization/src/nodes/set_routines.cpp
@@ -99,15 +99,14 @@ double IsInNode::min() const { return 0.0; }  // All values are true/false
 
 double IsInNode::max() const { return 1.0; }  // All values are true/false
 
-inline void IsInNode::rm_index(IsInNodeData*& node_data, const ssize_t rm_index,
-                               const double key) const {
+inline void rm_index(IsInNodeData*& node_data, const ssize_t index, const double key) {
     auto set_data_it = node_data->set_data.find(key);
     // find() should be successful since we need to remove the index
     assert(set_data_it != node_data->set_data.end());
     // Vector containing indices of `element` with value `key`
     std::vector<ssize_t>& indices_vec = set_data_it->second.element_indices;
     // Find index of `indices_vec` equal to `rm_index`
-    auto index_ptr = std::find(indices_vec.begin(), indices_vec.end(), rm_index);
+    auto index_ptr = std::find(indices_vec.begin(), indices_vec.end(), index);
     // find() should be successful since we need to remove the index
     assert(index_ptr != indices_vec.end());
     // swap and pop
@@ -139,8 +138,7 @@ void IsInNode::propagate(State& state) const {
         if (!update.placed()) {
             // i.e. changed or removed.
             ssize_t& count = node_data->set_data[update.old].test_elements_count;
-            // `update.old` must be in `test_elements_counter`
-            assert(count > 0);
+            assert(count > 0 && "update.old should be in test_elements_counter");
             count -= 1;
 
             if (count == 0) {

--- a/dwave/optimization/src/nodes/set_routines.cpp
+++ b/dwave/optimization/src/nodes/set_routines.cpp
@@ -1,0 +1,202 @@
+// Copyright 2025 D-Wave
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include "dwave-optimization/nodes/set_routines.hpp"
+
+#include <unordered_set>
+
+#include "_state.hpp"
+
+namespace dwave::optimization {
+
+/// IsInNode
+struct IsInNodeDataHelper_ {
+    IsInNodeDataHelper_(std::vector<double> element, std::vector<double> test_elements) {
+        for (const double val : test_elements) {
+            test_elements_counter[val] += 1;
+        }
+        for (ssize_t index = 0, stop = element.size(); index < stop; index++) {
+            element_isin.emplace_back(test_elements_counter.count(element[index]) > 0);
+            element_indices[element[index]].insert(index);
+        }
+    }
+    // # of test_elements per value
+    std::unordered_map<double, ssize_t> test_elements_counter;
+    // all indices of elements with a given value
+    std::unordered_map<double, std::unordered_set<ssize_t>> element_indices;
+    // Indicator vector: element_isin[i] == true iff element[i] is in test_elements
+    std::vector<ssize_t> element_isin;
+};
+
+struct IsInNodeData : public ArrayNodeStateData {
+    IsInNodeData(std::vector<double> element, std::vector<double> test_elements)
+            : IsInNodeData(IsInNodeDataHelper_(std::move(element), std::move(test_elements))) {}
+    IsInNodeData(IsInNodeDataHelper_&& helper)
+            : ArrayNodeStateData(std::move(helper.element_isin)),
+              test_elements_counter(std::move(helper.test_elements_counter)),
+              element_indices(std::move(helper.element_indices)) {}
+
+    std::unordered_map<double, ssize_t> test_elements_counter;
+    std::unordered_map<double, std::unordered_set<ssize_t>> element_indices;
+    std::vector<Update> element_updates;
+    std::vector<Update> test_element_updates;
+};
+
+IsInNode::IsInNode(ArrayNode* element_ptr, ArrayNode* test_elements_ptr)
+        : ArrayOutputMixin(element_ptr->shape()),
+          element_ptr_(element_ptr),
+          test_elements_ptr_(test_elements_ptr) {
+    add_predecessor(element_ptr);
+    add_predecessor(test_elements_ptr);
+}
+
+double const* IsInNode::buff(const State& state) const {
+    return data_ptr<IsInNodeData>(state)->buff();
+}
+
+void IsInNode::commit(State& state) const { data_ptr<IsInNodeData>(state)->commit(); }
+
+std::span<const Update> IsInNode::diff(const State& state) const {
+    return data_ptr<IsInNodeData>(state)->diff();
+}
+
+void IsInNode::initialize_state(State& state) const {
+    const Array::View element = element_ptr_->view(state);
+    const Array::View test_elements = test_elements_ptr_->view(state);
+
+    emplace_data_ptr<IsInNodeData>(state, std::vector<double>{element.begin(), element.end()},
+                                   std::vector<double>{test_elements.begin(), test_elements.end()});
+}
+
+bool IsInNode::integral() const { return true; }  // all values are True/False
+
+std::pair<double, double> IsInNode::minmax(
+        optional_cache_type<std::pair<double, double>> cache) const {
+    return memoize(cache, [&]() {
+        return std::make_pair(0.0, 1.0);  // all values are True/False
+    });
+}
+
+void IsInNode::propagate(State& state) const {
+    auto node_data = data_ptr<IsInNodeData>(state);
+    auto& element_indices = node_data->element_indices;
+    auto& test_elements_counter = node_data->test_elements_counter;
+
+    auto test_elements_diff = test_elements_ptr_->diff(state);
+    // Save a copy of `test_elements` updates so we can use them in case we need to revert
+    node_data->test_element_updates.assign(test_elements_diff.begin(), test_elements_diff.end());
+
+    // Handle changes to `test_elements`
+    for (const Update& update : test_elements_diff) {
+        if (!update.placed()) {  // i.e. changed or removed
+            test_elements_counter[update.old] -= 1;
+
+            if (test_elements_counter[update.old] == 0) {
+                // Remove key to reduce bloating
+                test_elements_counter.erase(update.old);
+                // Each index of `element` with the value `update.old` is no
+                // longer in `test_elements`
+                for (const auto index : element_indices[update.old]) {
+                    node_data->set(index, 0.0);
+                }
+            }
+        }
+        if (!update.removed()) {  // i.e. changed or added
+            test_elements_counter[update.value] += 1;
+            if (test_elements_counter[update.value] == 1) {
+                // Each index of `element` with the value `update.value` is in
+                // `test_elements` now.
+                for (const auto index : element_indices[update.value]) {
+                    node_data->set(index, 1.0);
+                }
+            }
+        }
+    }
+
+    auto element_diff = element_ptr_->diff(state);
+    // Save a copy of `element` updates so we can use them in case we need to revert
+    node_data->element_updates.assign(element_diff.begin(), element_diff.end());
+
+    // Handle changes to `element`
+    for (const Update& update : element_diff) {
+        if (!update.placed()) {  // i.e. changed or removed
+            element_indices[update.old].erase(update.index);
+            // Remove key if set is empty to reduce bloating
+            if (element_indices[update.old].empty()) {
+                element_indices.erase(update.old);
+            }
+        }
+        if (!update.removed()) {  // i.e. changed or added
+            element_indices[update.value].insert(update.index);
+            node_data->set(update.index, test_elements_counter[update.value] > 0, true);
+        }
+    }
+
+    // Resize if necessary
+    if (element_ptr_->size_diff(state) != 0) {
+        node_data->trim_to(element_ptr_->size(state));
+    }
+}
+
+void IsInNode::revert(State& state) const {
+    auto node_data = data_ptr<IsInNodeData>(state);
+    auto& element_indices = node_data->element_indices;
+    auto& test_elements_counter = node_data->test_elements_counter;
+
+    // Revert the changes to `test_elements`
+    for (const Update& update : node_data->test_element_updates | std::views::reverse) {
+        if (!update.placed()) {  // i.e. removed or changed
+            test_elements_counter[update.old] += 1;
+        }
+        if (!update.removed()) {  // i.e. placed or changed
+            test_elements_counter[update.value] -= 1;
+            // Remove key to reduce bloating
+            if (test_elements_counter[update.value] == 0) {
+                test_elements_counter.erase(update.value);
+            }
+        }
+    }
+
+    // Revert the changes to `element`
+    for (const Update& update : node_data->element_updates | std::views::reverse) {
+        if (!update.placed()) {  // i.e. removed or changed
+            element_indices[update.old].insert(update.index);
+        }
+        if (!update.removed()) {  // i.e. placed or changed
+            element_indices[update.value].erase(update.index);
+            // Remove key if set is empty to reduce bloating
+            if (element_indices[update.value].empty()) {
+                element_indices.erase(update.value);
+            }
+        }
+    }
+
+    node_data->element_updates.clear();
+    node_data->test_element_updates.clear();
+    node_data->revert();
+}
+
+std::span<const ssize_t> IsInNode::shape(const State& state) const {
+    return element_ptr_->shape(state);
+}
+
+ssize_t IsInNode::size(const State& state) const { return data_ptr<IsInNodeData>(state)->size(); }
+
+ssize_t IsInNode::size_diff(const State& state) const {
+    return data_ptr<IsInNodeData>(state)->size_diff();
+}
+
+SizeInfo IsInNode::sizeinfo() const { return element_ptr_->sizeinfo(); }
+
+}  // namespace dwave::optimization

--- a/dwave/optimization/symbols/__init__.py
+++ b/dwave/optimization/symbols/__init__.py
@@ -88,6 +88,7 @@ from dwave.optimization.symbols.reduce import (
     Prod,
     Sum,
 )
+from dwave.optimization.symbols.set_routines import IsIn
 from dwave.optimization.symbols.softmax import SoftMax
 from dwave.optimization.symbols.sorting import ArgSort
 from dwave.optimization.symbols.statistics import Mean
@@ -137,6 +138,7 @@ __all__ = [
     "Extract",
     "Input",
     "IntegerVariable",
+    "IsIn",
     "LessEqual",
     "LinearProgram",
     "LinearProgramFeasible",

--- a/dwave/optimization/symbols/set_routines.pyi
+++ b/dwave/optimization/symbols/set_routines.pyi
@@ -1,0 +1,17 @@
+# Copyright 2025 D-Wave
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from dwave.optimization.model import ArraySymbol as _ArraySymbol
+
+class IsIn(_ArraySymbol): ...

--- a/dwave/optimization/symbols/set_routines.pyx
+++ b/dwave/optimization/symbols/set_routines.pyx
@@ -1,0 +1,43 @@
+# cython: auto_pickle=False
+
+# Copyright 2025 D-Wave
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+from cython.operator cimport typeid
+
+from dwave.optimization._model cimport _Graph, _register, ArraySymbol
+from dwave.optimization.libcpp.nodes.set_routines cimport IsInNode
+
+
+cdef class IsIn(ArraySymbol):
+    """Determine element-wise containment between two symbols. Given two
+    symbols: element and test_elements, returns an array of the same shape
+    as element such that element[index] = True if element[index] is in
+    test_elements and False otherwise.
+
+    See Also:
+        :meth:`~dwave.optimization.mathematical.isin`: equivalent method.
+
+    .. versionadded:: 0.6.7
+    """
+    def __init__(self, ArraySymbol element, ArraySymbol test_elements):
+        cdef _Graph model = element.model
+
+        if element.model is not test_elements.model:
+            raise ValueError("element and test_elements do not share the same underlying model")
+
+        cdef IsInNode* ptr = model._graph.emplace_node[IsInNode](element.array_ptr, test_elements.array_ptr)
+        self.initialize_arraynode(model, ptr)
+
+_register(IsIn, typeid(IsInNode))

--- a/dwave/optimization/symbols/set_routines.pyx
+++ b/dwave/optimization/symbols/set_routines.pyx
@@ -22,14 +22,14 @@ from dwave.optimization.libcpp.nodes.set_routines cimport IsInNode
 
 cdef class IsIn(ArraySymbol):
     """Determine element-wise containment between two symbols. Given two
-    symbols: element and test_elements, returns an array of the same shape
-    as element such that element[index] = True if element[index] is in
+    symbols: element and test_elements, returns an output array of the same
+    shape as element such that output[index] = True if element[index] is in
     test_elements and False otherwise.
 
     See Also:
         :meth:`~dwave.optimization.mathematical.isin`: equivalent method.
 
-    .. versionadded:: 0.6.7
+    .. versionadded:: 0.6.8
     """
     def __init__(self, ArraySymbol element, ArraySymbol test_elements):
         cdef _Graph model = element.model

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,7 @@ dwave_optimization_src = [
     'dwave/optimization/src/nodes/numbers.cpp',
     'dwave/optimization/src/nodes/quadratic_model.cpp',
     'dwave/optimization/src/nodes/reduce.cpp',
+    'dwave/optimization/src/nodes/set_routines.cpp',
     'dwave/optimization/src/nodes/softmax.cpp',
     'dwave/optimization/src/nodes/sorting.cpp',
     'dwave/optimization/src/nodes/statistics.cpp',

--- a/meson.build
+++ b/meson.build
@@ -107,6 +107,7 @@ foreach name : [
     'numbers',
     'quadratic_model',
     'reduce',
+    'set_routines',
     'softmax',
     'sorting',
     'statistics',

--- a/releasenotes/notes/isin-symbol-0980669e07396b4c.yaml
+++ b/releasenotes/notes/isin-symbol-0980669e07396b4c.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added ``IsIn`` symbol/node which computes the element-wise 
+    containment of one symbol with another.
+

--- a/tests/cpp/meson.build
+++ b/tests/cpp/meson.build
@@ -23,6 +23,7 @@ tests_all = executable(
         'nodes/test_numbers.cpp',
         'nodes/test_quadratic_model.cpp',
         'nodes/test_reduce.cpp',
+        'nodes/test_set_routines.cpp',
         'nodes/test_softmax.cpp',
         'nodes/test_sorting.cpp',
         'nodes/test_statistics.cpp',

--- a/tests/cpp/nodes/test_set_routines.cpp
+++ b/tests/cpp/nodes/test_set_routines.cpp
@@ -91,6 +91,18 @@ TEST_CASE("IsInNode") {
                     THEN("The isin state is correct") {
                         CHECK_THAT(isin_ptr->view(state), RangeEquals({0.0, 0.0, 1.0}));
                     }
+                    AND_WHEN("We commit, make changes to test_elements integer node, and propagate") {
+                        graph.commit(state);
+                        i1_ptr->set_value(state, 5, 3);
+                        i1_ptr->set_value(state, 5, 10);
+                        // i1_ptr should now be [5, 2, 7, 4, 2, 10]
+
+                        graph.propagate(state);
+
+                        THEN("The isin state is correct") {
+                            CHECK_THAT(isin_ptr->view(state), RangeEquals({0.0, 0.0, 1.0}));
+                        }
+                    }
                 }
             }
         }

--- a/tests/cpp/nodes/test_set_routines.cpp
+++ b/tests/cpp/nodes/test_set_routines.cpp
@@ -1,0 +1,170 @@
+// Copyright 2025 D-Wave
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <catch2/benchmark/catch_benchmark_all.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include "dwave-optimization/nodes/collections.hpp"
+#include "dwave-optimization/nodes/constants.hpp"
+#include "dwave-optimization/nodes/numbers.hpp"
+#include "dwave-optimization/nodes/set_routines.hpp"
+#include "dwave-optimization/nodes/testing.hpp"
+
+using Catch::Matchers::RangeEquals;
+
+namespace dwave::optimization {
+
+TEST_CASE("IsInNode") {
+    auto graph = Graph();
+
+    GIVEN("Two constant nodes and an isin node") {
+        auto c1_ptr = graph.emplace_node<ConstantNode>(std::vector{1.1, 5.0, 3.0, 2.0});
+        auto c2_ptr = graph.emplace_node<ConstantNode>(std::vector{1.1, 2.2});
+
+        auto isin_ptr = graph.emplace_node<IsInNode>(c2_ptr, c1_ptr);
+
+        graph.emplace_node<ArrayValidationNode>(isin_ptr);
+
+        CHECK(isin_ptr->min() == 0.0);
+        CHECK(isin_ptr->max() == 1.0);
+
+        WHEN("We initialize a state") {
+            auto state = graph.initialize_state();
+
+            THEN("The initial isin state is correct") {
+                CHECK_THAT(isin_ptr->view(state), RangeEquals({1.0, 0.0}));
+            }
+        }
+    }
+
+    GIVEN("Two integer nodes and an isin node") {
+        auto i1_ptr = graph.emplace_node<IntegerNode>(6);
+        auto i2_ptr = graph.emplace_node<IntegerNode>(3);
+
+        auto isin_ptr = graph.emplace_node<IsInNode>(i2_ptr, i1_ptr);
+
+        graph.emplace_node<ArrayValidationNode>(isin_ptr);
+
+        WHEN("We initialize a state") {
+            auto state = graph.empty_state();
+            i1_ptr->initialize_state(state, {5, 1, 7, 9, 1, 1});
+            i2_ptr->initialize_state(state, {2, 1, 9});
+            graph.initialize_state(state);
+
+            THEN("The initial isin state is correct") {
+                CHECK_THAT(isin_ptr->view(state), RangeEquals({0.0, 1.0, 1.0}));
+            }
+
+            AND_WHEN("We make some changes to test_elements integer node and propagate") {
+                i1_ptr->set_value(state, 1, 2);
+                i1_ptr->set_value(state, 3, 4);
+                // i1_ptr should now be [5, 2, 7, 4, 1, 1]
+
+                graph.propagate(state);
+
+                THEN("The isin state is correct") {
+                    CHECK_THAT(isin_ptr->view(state), RangeEquals({1.0, 1.0, 0.0}));
+                }
+                AND_WHEN("We commit, make changes to both integer nodes, and propagate") {
+                    graph.commit(state);
+                    i1_ptr->set_value(state, 4, 2);
+                    i1_ptr->set_value(state, 5, 10);
+                    // i1_ptr should now be [5, 2, 7, 4, 2, 10]
+                    i2_ptr->set_value(state, 0, 3);
+                    i2_ptr->set_value(state, 2, 10);
+                    // i2_ptr should now be [3, 1, 10]
+
+                    graph.propagate(state);
+
+                    THEN("The isin state is correct") {
+                        CHECK_THAT(isin_ptr->view(state), RangeEquals({0.0, 0.0, 1.0}));
+                    }
+                }
+            }
+        }
+        WHEN("We initialize a state") {
+            auto state = graph.empty_state();
+            i1_ptr->initialize_state(state, {5, 1, 7, 9, 1, 1});
+            i2_ptr->initialize_state(state, {0, 1, 0});
+            graph.initialize_state(state);
+
+            CHECK_THAT(isin_ptr->view(state), RangeEquals({0.0, 1.0, 0.0}));
+            THEN("We make some changes to both integer node, and revert") {
+                graph.commit(state);
+                i1_ptr->set_value(state, 0, 2);
+                i1_ptr->set_value(state, 4, 4);
+                // i1_ptr should now be [2, 1, 7, 9, 4, 1]
+                i2_ptr->set_value(state, 0, 4);
+                i2_ptr->set_value(state, 1, 10);
+                i2_ptr->set_value(state, 2, 1);
+                // i2_ptr should now be [4, 10, 1]
+
+                graph.revert(state);
+
+                THEN("The isin state is correct") {
+                    CHECK_THAT(isin_ptr->view(state), RangeEquals({0.0, 1.0, 0.0}));
+                }
+            }
+        }
+    }
+
+    GIVEN("Two dynamic set nodes and an isin node") {
+        auto set1_ptr = graph.emplace_node<SetNode>(6);
+        auto set2_ptr = graph.emplace_node<SetNode>(10);
+        auto isin_ptr = graph.emplace_node<IsInNode>(set2_ptr, set1_ptr);
+        graph.emplace_node<ArrayValidationNode>(isin_ptr);
+
+        CHECK(isin_ptr->size() == -1);
+
+        WHEN("We initialize a state") {
+            auto state = graph.initialize_state();
+
+            THEN("The isin's state is empty like the set2's") {
+                CHECK(isin_ptr->size(state) == 0);
+                REQUIRE(isin_ptr->ndim() == 1);
+                CHECK(isin_ptr->shape(state)[0] == 0);
+            }
+
+            AND_WHEN("We grow the set nodes and propagate") {
+                set1_ptr->assign(state, std::vector<double>{2, 4, 5});
+                set2_ptr->assign(state, std::vector<double>{3, 1, 6, 7});
+                graph.propagate(state);
+
+                THEN("The isin's state is correct") {
+                    CHECK_THAT(isin_ptr->view(state), RangeEquals({0.0, 0.0, 0.0, 0.0}));
+                }
+
+                AND_WHEN("We commit, shrink and change the set nodes, and propagate") {
+                    graph.commit(state);
+
+                    set1_ptr->shrink(state);
+                    // set1 should be [2, 4]
+                    set2_ptr->grow(state);
+                    set2_ptr->grow(state);
+                    // set2 should be [3, 1, 6, 7, 0, 2]
+
+                    graph.propagate(state);
+
+                    THEN("The isin's state is correct") {
+                        CHECK(isin_ptr->size(state) == 6);
+                        CHECK_THAT(isin_ptr->view(state),
+                                   RangeEquals({0.0, 0.0, 0.0, 0.0, 0.0, 1.0}));
+                    }
+                }
+            }
+        }
+    }
+}
+}  // namespace dwave::optimization

--- a/tests/cpp/nodes/test_set_routines.cpp
+++ b/tests/cpp/nodes/test_set_routines.cpp
@@ -15,6 +15,7 @@
 #include <catch2/benchmark/catch_benchmark_all.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
+#include <vector>
 
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
@@ -91,7 +92,9 @@ TEST_CASE("IsInNode") {
                     THEN("The isin state is correct") {
                         CHECK_THAT(isin_ptr->view(state), RangeEquals({0.0, 0.0, 1.0}));
                     }
-                    AND_WHEN("We commit, make changes to test_elements integer node, and propagate") {
+                    AND_WHEN(
+                            "We commit, make changes to test_elements integer node, and "
+                            "propagate") {
                         graph.commit(state);
                         i1_ptr->set_value(state, 5, 3);
                         i1_ptr->set_value(state, 5, 10);

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -1794,6 +1794,36 @@ class TestIntegerVariable(utils.SymbolTests):
             np.testing.assert_array_equal(x.state(), [0, 0, 0, -1, 0])
 
 
+class TestIsIn(utils.SymbolTests):
+    def generate_symbols(self):
+        model = Model()
+        element = model.constant([-1.9, -2, 1.7, 1.6])
+        test_elements = model.constant([0, -2, 9.5, 3.2])
+        contains = dwave.optimization.symbols.IsIn(element, test_elements)
+
+        with model.lock():
+            yield contains
+
+    def test(self):
+        from dwave.optimization.symbols import IsIn
+        model = Model()
+        element = model.constant([-1.9, -2, 1.7, 1.6])
+        test_elements = model.constant([0, -2, 9.5, 3.2])
+        contains = dwave.optimization.isin(element, test_elements)
+
+        self.assertIsInstance(contains, IsIn)
+
+    def test_state(self):
+        model = Model()
+        element = model.constant([-1.9, -2, 1.7, 1.6])
+        test_elements = model.constant([0, -2, 9.5, -1.9])
+        contains = dwave.optimization.symbols.IsIn(element, test_elements)
+        model.states.resize(1)
+        with model.lock():
+            expected = np.array([1.0, 1.0, 0.0, 0.0])
+            np.testing.assert_array_almost_equal(contains.state(0), expected)
+
+
 class TestLessEqual(utils.SymbolTests):
     def generate_symbols(self):
         model = Model()


### PR DESCRIPTION
Initial minimal implementation of [numpy.isin() ](https://numpy.org/doc/stable/reference/generated/numpy.isin.html#numpy.isin) using lookup tables. Fixes #76. Given that this fixes an old issue, I wanted to check which functionality from [numpy.isin()](https://numpy.org/doc/stable/reference/generated/numpy.isin.html#numpy.isin) we should port over for this node. Should this node include any of the following?

1. `bool assume_unique` (kwarg)
2. `bool invert` (kwarg)
3. `kind {None, sort, table}` (kwarg)

Regarding 2, I believe this could just be done with the EqualNode. For example:
```
>>> from dwave.optimization.model import Model
>>> from dwave.optimization.mathematical import isin
>>> model = Model()
>>> model.states.resize(1)
>>> element = model.constant([1.3, -1.0, 3.0])
>>> test_elements = model.constant([3.0, -1.1, -2.0, 4.1, -1.0])
>>> contains = isin(element, test_elements)
>>> inverted_contains = contains == [0.0, 0.0, 0.0]
>>> with model.lock():
...     print(contains.state(0))
...     print(inverted_contains.state(0))
[0. 1. 1.]
[1. 0. 0.]
```

Regarding 3, given we already have an ArgSortNode, it seems reasonable that we could pass this node a bool like `sorted` which could indicate whether its predecessors are ArgSortNodes. We could implement methods to deal with these cases and call them or the current lookup table methods from `IsInNode::initialize_state` and `IsInNode::propagate`.

I believe there is additional optimization that can be done to `IsInNode::propagate` but I wanted to deal with the above questions before optimizing it further.