### PR TITLE
Add broadcasting support

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
@@ -25,6 +25,68 @@
 
 namespace dwave::optimization {
 
+class BroadcastToNode : public ArrayNode {
+ public:
+    BroadcastToNode(ArrayNode* array_ptr, std::initializer_list<ssize_t> shape);
+    BroadcastToNode(ArrayNode* array_ptr, std::span<const ssize_t> shape);
+
+    /// @copydoc Array::buff()
+    double const* buff(const State& state) const override;
+
+    /// @copydoc Node::commit()
+    void commit(State& state) const override;
+
+    /// Broadcast nodes are always treated as non-contiguous.
+    bool contiguous() const override { return false; }
+
+    /// @copydoc Array::diff()
+    std::span<const Update> diff(const State& state) const override;
+
+    /// @copydoc Node::initialize_state()
+    void initialize_state(State& state) const override;
+
+    /// @copydoc Array::integral()
+    bool integral() const override;
+
+    /// @copydoc Array::minmax()
+    std::pair<double, double> minmax(
+            optional_cache_type<std::pair<double, double>> cache = std::nullopt) const override;
+
+    /// @copydoc Array::ndim()
+    ssize_t ndim() const override;
+
+    /// @copydoc Node::propagate()
+    void propagate(State& state) const override;
+
+    /// @copydoc Node::revert()
+    void revert(State& state) const override;
+
+    /// @copydoc Array::shape()
+    std::span<const ssize_t> shape() const override;
+    std::span<const ssize_t> shape(const State& state) const override;
+
+    /// @copydoc Array::size()
+    ssize_t size() const override;
+    ssize_t size(const State& state) const override;
+
+    /// @copydoc Array::size_diff()
+    ssize_t size_diff(const State& state) const override;
+
+    /// @copydoc Array::strides()
+    std::span<const ssize_t> strides() const override;
+
+ private:
+    /// Translate a linear index of the predecessor into a linear index of the
+    /// BroadcastToNode.
+    ssize_t reindex(ssize_t index) const;
+
+    ArrayNode* array_ptr_;
+
+    ssize_t ndim_;
+    std::unique_ptr<ssize_t[]> shape_;
+    std::unique_ptr<ssize_t[]> strides_;
+};
+
 class ConcatenateNode : public ArrayOutputMixin<ArrayNode> {
  public:
     explicit ConcatenateNode(std::span<ArrayNode*> array_ptrs, ssize_t axis);

--- a/dwave/optimization/libcpp/nodes.pxd
+++ b/dwave/optimization/libcpp/nodes.pxd
@@ -134,6 +134,9 @@ cdef extern from "dwave-optimization/nodes/lambda.hpp" namespace "dwave::optimiz
 
 
 cdef extern from "dwave-optimization/nodes/manipulation.hpp" namespace "dwave::optimization" nogil:
+    cdef cppclass BroadcastToNode(ArrayNode):
+        pass
+
     cdef cppclass ConcatenateNode(ArrayNode):
         Py_ssize_t axis()
 

--- a/dwave/optimization/src/nodes/manipulation.cpp
+++ b/dwave/optimization/src/nodes/manipulation.cpp
@@ -48,7 +48,7 @@ std::vector<ssize_t> diff_offsets(std::span<const ssize_t> from_shape,
     ssize_t multiplier = 1;
     for (const auto stop = from_shape.rend(); from_it != stop; ++from_it, ++to_it) {
         if (*from_it == *to_it) {
-            // The shapes matche, there is no broadcasting here
+            // The shapes match, there is no broadcasting here
 
             // In the case that we're dynamic, this will result in a negative multiplier,
             // but that's OK because it's only the 0th dimension so we'll never use it.

--- a/dwave/optimization/src/nodes/manipulation.cpp
+++ b/dwave/optimization/src/nodes/manipulation.cpp
@@ -22,6 +22,281 @@
 
 namespace dwave::optimization {
 
+// Return the linear offsets that need to be applied to each update when broadcasting from
+// `from_shape` to `to_shape`.
+std::vector<ssize_t> diff_offsets(std::span<const ssize_t> from_shape,
+                                  std::span<const ssize_t> to_shape) {
+    std::vector<ssize_t> offsets{0};  // for an identity broadcast there is only one offset
+
+    auto expand = [](const std::vector<ssize_t>& offsets, ssize_t size, ssize_t multiplier) {
+        assert(size > 0);
+        assert(multiplier > 0);
+        std::vector<ssize_t> new_offsets;
+        for (const ssize_t& offset : offsets) {
+            for (ssize_t i = 0; i < size; ++i) {
+                new_offsets.emplace_back(offset + i * multiplier);
+            }
+        }
+
+        return new_offsets;
+    };
+
+    assert(from_shape.size() <= to_shape.size());
+
+    auto from_it = from_shape.rbegin();
+    auto to_it = to_shape.rbegin();
+    ssize_t multiplier = 1;
+    for (const auto stop = from_shape.rend(); from_it != stop; ++from_it, ++to_it) {
+        if (*from_it == *to_it) {
+            // The shapes matche, there is no broadcasting here
+
+            // In the case that we're dynamic, this will result in a negative multiplier,
+            // but that's OK because it's only the 0th dimension so we'll never use it.
+            multiplier *= *from_it;
+        } else {
+            assert(*from_it == 1);  // should be checked in constructor
+            offsets = expand(offsets, *to_it, multiplier);
+        }
+    }
+
+    // all of the dimensions we're prepending need offsets
+    for (auto stop = to_shape.rend(); to_it != stop; ++to_it) {
+        offsets = expand(offsets, *to_it, multiplier);
+    }
+
+    // We need it to be sorted in order to potentially support dynamic nodes
+    // Also it's more convenient to debug.
+    std::ranges::sort(offsets);
+
+    return offsets;
+}
+
+class BroadcastToNodeData : public NodeStateData {
+ public:
+    BroadcastToNodeData(std::vector<ssize_t>&& diff_offsets)
+            : diff_offsets(std::move(diff_offsets)) {}
+
+    virtual void commit() { diff.clear(); }
+    virtual void revert() { diff.clear(); }
+
+    const std::vector<ssize_t> diff_offsets;
+
+    std::vector<Update> diff;
+};
+
+class DynamicBroadcastToNodeData : public BroadcastToNodeData {
+ public:
+    DynamicBroadcastToNodeData(std::vector<ssize_t>&& diff_offsets, std::vector<ssize_t>&& shape)
+            : BroadcastToNodeData(std::move(diff_offsets)), shape(std::move(shape)) {}
+
+    virtual void commit() {
+        BroadcastToNodeData::commit();
+        old_shape = shape;
+        size_diff = 0;
+    }
+
+    virtual void revert() {
+        BroadcastToNodeData::revert();
+        shape = old_shape;
+        size_diff = 0;
+    }
+
+    std::vector<ssize_t> shape;
+    std::vector<ssize_t> old_shape = shape;  // for easy reverting
+
+    ssize_t size_diff = 0;
+};
+
+BroadcastToNode::BroadcastToNode(ArrayNode* array_ptr, std::initializer_list<ssize_t> shape)
+        : BroadcastToNode(array_ptr, std::span(shape)) {}
+
+BroadcastToNode::BroadcastToNode(ArrayNode* array_ptr, std::span<const ssize_t> shape)
+        : array_ptr_(array_ptr),
+          ndim_(shape.size()),
+          shape_(std::make_unique<ssize_t[]>(ndim_)),
+          strides_(std::make_unique<ssize_t[]>(ndim_)) {
+    // Fill in our shape_ and then make it accessible locally as a span
+    std::copy(shape.begin(), shape.end(), shape_.get());
+    const std::span<const ssize_t> target_shape(shape_.get(), ndim_);
+
+    // Make our strides locally accessible as a span.
+    std::span<ssize_t> target_strides(strides_.get(), ndim_);
+
+    // Finally get our source shape and strides
+    const auto source_shape = array_ptr_->shape();
+    const auto source_strides = array_ptr_->strides();
+
+    // Alright, let's check that our source and target shapes are compatible
+    // and at the same time fill in our strides
+
+    if (source_shape.size() > target_shape.size()) {
+        throw std::invalid_argument("array has more dimensions (" +
+                                    std::to_string(source_shape.size()) +
+                                    ") than can be broadast to " + shape_to_string(target_shape));
+    }
+
+    if (array_ptr_->dynamic() &&
+        (source_shape.size() != target_shape.size() || target_shape[0] >= 0)) {
+        throw std::invalid_argument(
+                "dynamic arrays can only be broadcast to another dynamic shape with the same "
+                "number of dimensions");
+    }
+
+    // Walk backwards through all four arrays. Zip would be nice here...
+    auto rit_sshape = source_shape.rbegin();
+    auto rit_sstrides = source_strides.rbegin();
+    auto rit_tshape = target_shape.rbegin();
+    auto rit_tstrides = target_strides.rbegin();
+    for (const auto stop = source_shape.rend(); rit_sshape != stop;
+         ++rit_tshape, ++rit_tstrides, ++rit_sshape, ++rit_sstrides) {
+        if (*rit_sshape == *rit_tshape) {
+            // source and target match in dimension size, strides are therefore
+            // preserved
+            *rit_tstrides = *rit_sstrides;
+        } else if (*rit_sshape == 1) {
+            // source dimension size is 1, so we can stretch it out
+            *rit_tstrides = 0;  // stretched
+        } else {
+            // not compatible!
+            throw std::invalid_argument("array of shape " + shape_to_string(source_shape) +
+                                        " could not be broadcast to " +
+                                        shape_to_string(target_shape));
+        }
+    }
+
+    // All of the dimensions we're adding at the "front" get 0 strides
+    for (auto stop = target_shape.rend(); rit_tshape != stop; ++rit_tshape, ++rit_tstrides) {
+        *rit_tstrides = 0;
+    }
+
+    add_predecessor(array_ptr);
+}
+
+double const* BroadcastToNode::buff(const State& state) const { return array_ptr_->buff(state); }
+
+void BroadcastToNode::commit(State& state) const { data_ptr<BroadcastToNodeData>(state)->commit(); }
+
+std::span<const Update> BroadcastToNode::diff(const State& state) const {
+    return data_ptr<BroadcastToNodeData>(state)->diff;
+}
+
+bool BroadcastToNode::integral() const { return array_ptr_->integral(); }
+
+void BroadcastToNode::initialize_state(State& state) const {
+    std::vector<ssize_t> offsets = diff_offsets(array_ptr_->shape(), this->shape());
+
+    if (ndim_ && shape_[0] < 0) {
+        // dynamic
+        // In addition to storing the offsets, when we're dynamic we need to store our current
+        // shape/size as well. Luckily, they are easy to calculate because we cannot broadcast
+        // along shape[0].
+
+        std::vector<ssize_t> shape(this->shape().begin(), this->shape().end());
+        assert(this->ndim() > 0);
+        assert(array_ptr_->ndim() > 0);
+        assert(shape[0] == -1);
+        shape[0] = array_ptr_->shape(state)[0];
+        assert(shape[0] >= 0);
+
+        emplace_data_ptr<DynamicBroadcastToNodeData>(state, std::move(offsets), std::move(shape));
+    } else {
+        // not dynamic
+        emplace_data_ptr<BroadcastToNodeData>(state, std::move(offsets));
+    }
+}
+
+std::pair<double, double> BroadcastToNode::minmax(
+        optional_cache_type<std::pair<double, double>> cache) const {
+    return memoize(cache, [&]() { return array_ptr_->minmax(cache); });
+}
+
+ssize_t BroadcastToNode::ndim() const { return ndim_; }
+
+void BroadcastToNode::propagate(State& state) const {
+    BroadcastToNodeData* data_ptr = this->data_ptr<BroadcastToNodeData>(state);
+
+    const auto from_diff = array_ptr_->diff(state);
+    if (from_diff.empty()) return;  // exit early if nothing to propagate
+
+    auto& to_diff = data_ptr->diff;
+    assert(to_diff.empty());  // should be cleared between propagations
+
+    const auto& diff_offsets = data_ptr->diff_offsets;
+
+    ssize_t size_diff = 0;
+    for (Update update : deduplicate_diff_view(from_diff)) {
+        // we need to convert from our predecessor's index to ours 
+        const ssize_t index = reindex(update.index);
+
+        if (update.placed()) {
+            for (const ssize_t offset : diff_offsets) {
+                update.index = index + offset;
+                to_diff.emplace_back(update);
+                size_diff += 1;
+            }
+        } else if (update.removed()) {
+            for (const ssize_t offset : diff_offsets | std::views::reverse) {
+                update.index = index + offset;
+                to_diff.emplace_back(update);
+                size_diff -= 1;
+            }
+        } else {
+            for (const ssize_t offset : diff_offsets) {
+                update.index = index + offset;
+                to_diff.emplace_back(update);
+            }
+        }
+    }
+
+    // we also need to update the shape/sizediff, if we're dynamic
+    if (dynamic()) {
+        auto* dynamic_data_ptr = this->data_ptr<DynamicBroadcastToNodeData>(state);
+        dynamic_data_ptr->shape[0] = array_ptr_->shape(state)[0];
+        dynamic_data_ptr->size_diff = size_diff;
+    }
+
+    if (to_diff.size()) Node::propagate(state);
+}
+
+ssize_t BroadcastToNode::reindex(const ssize_t index) const {
+    std::vector<ssize_t> multi_index = unravel_index(index, array_ptr_->shape());
+    assert(this->ndim() >= array_ptr_->ndim());
+    multi_index.insert(multi_index.begin(), this->ndim() - array_ptr_->ndim(), 0);
+    return ravel_multi_index(multi_index, this->shape());
+}
+
+void BroadcastToNode::revert(State& state) const { data_ptr<BroadcastToNodeData>(state)->revert(); }
+
+std::span<const ssize_t> BroadcastToNode::shape() const {
+    return std::span<const ssize_t>(shape_.get(), ndim_);
+}
+
+std::span<const ssize_t> BroadcastToNode::shape(const State& state) const {
+    if (!ndim_ || shape_[0] >= 0) return shape();  // not dynamic
+    return data_ptr<DynamicBroadcastToNodeData>(state)->shape;
+}
+
+ssize_t BroadcastToNode::size() const {
+    if (ndim_ && shape_[0] < 0) return -1;  // dynamic
+    return std::accumulate(shape_.get(), shape_.get() + ndim_, 1, std::multiplies<ssize_t>());
+}
+
+ssize_t BroadcastToNode::size(const State& state) const {
+    if (!ndim_ || shape_[0] >= 0) return size();  // not dynamic
+    const auto& shape = data_ptr<DynamicBroadcastToNodeData>(state)->shape;
+    assert(shape.size() > 0 && shape[0] >= 0);
+    return std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<ssize_t>());
+}
+
+ssize_t BroadcastToNode::size_diff(const State& state) const {
+    if (!ndim_ || shape_[0] >= 0) return 0;  // not dynamic
+    return data_ptr<DynamicBroadcastToNodeData>(state)->size_diff;
+}
+
+std::span<const ssize_t> BroadcastToNode::strides() const {
+    return std::span<const ssize_t>(strides_.get(), ndim_);
+}
+
 std::vector<ssize_t> make_concatenate_shape(std::span<ArrayNode*> array_ptrs, ssize_t axis);
 
 double const* ConcatenateNode::buff(const State& state) const {

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -67,6 +67,7 @@ from dwave.optimization.libcpp.nodes cimport (
     ArrayValidationNode as cppArrayValidationNode,
     BasicIndexingNode as cppBasicIndexingNode,
     BinaryNode as cppBinaryNode,
+    BroadcastToNode as cppBroadcastToNode,
     BSplineNode as cppBSplineNode,
     ConcatenateNode as cppConcatenateNode,
     ConstantNode as cppConstantNode,
@@ -151,6 +152,7 @@ __all__ = [
     "ArgSort",
     "BasicIndexing",
     "BinaryVariable",
+    "BroadcastTo",
     "BSpline",
     "Concatenate",
     "Constant",
@@ -1025,6 +1027,39 @@ cdef class BinaryVariable(ArraySymbol):
     cdef cppBinaryNode* ptr
 
 _register(BinaryVariable, typeid(cppBinaryNode))
+
+
+cdef class BroadcastTo(ArraySymbol):
+    """BroadcastTo symbol.
+
+    See Also:
+        :func:`~dwave.optimization.mathematical.broadcast_to`: equivalent function.
+
+    .. versionadded:: 0.6.5
+    """
+    def __init__(self, ArraySymbol node, shape):
+        cdef _Graph model = node.model
+
+        cdef cppBroadcastToNode* ptr = model._graph.emplace_node[cppBroadcastToNode](
+            node.array_ptr,
+            as_cppshape(shape, nonnegative=False),
+        )
+
+        self.initialize_arraynode(model, ptr)
+
+    @classmethod
+    def _from_zipfile(cls, zf, directory, _Graph model, predecessors):
+        if len(predecessors) != 1:
+            raise ValueError(f"{cls.__name__} must have exactly one predecessor")
+
+        with zf.open(directory + "shape.json", "r") as f:
+            return BroadcastTo(*predecessors, json.load(f))
+
+    def _into_zipfile(self, zf, directory):
+        encoder = json.JSONEncoder(separators=(',', ':'))
+        zf.writestr(directory + "shape.json", encoder.encode(self.shape()))
+
+_register(BroadcastTo, typeid(cppBroadcastToNode))
 
 
 cdef class BSpline(ArraySymbol):

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -1059,6 +1059,10 @@ cdef class BroadcastTo(ArraySymbol):
         encoder = json.JSONEncoder(separators=(',', ':'))
         zf.writestr(directory + "shape.json", encoder.encode(self.shape()))
 
+    def state_size(self):
+        """Broadcasting symbols are stateless"""
+        return 0
+
 _register(BroadcastTo, typeid(cppBroadcastToNode))
 
 

--- a/releasenotes/notes/feature-broadcasting-773034ff391baf44.yaml
+++ b/releasenotes/notes/feature-broadcasting-773034ff391baf44.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add support for broadcasting array symbols to new shapes. This includes:
+
+    * A ``BroadcastTo`` symbol.
+    * New ``broadcast_to()`` and ``broadcast_symbols()`` functions.
+    * A C++ ``BroadcastToNode``.

--- a/tests/test_mathematical.py
+++ b/tests/test_mathematical.py
@@ -95,6 +95,30 @@ class Test_atleast_2d(unittest.TestCase):
             np.testing.assert_array_equal(out.state(), [[1, 2], [3, 4]])
 
 
+class Test_broadcast_symbols(unittest.TestCase):
+    def test(self):
+        model = Model()
+        x = model.constant([0, 1, 2])  # (3,)
+        y = model.constant([[0], [1]])  # (2, 1)
+
+        xb, yb = dwave.optimization.broadcast_symbols(x, y)
+
+        model.states.resize(1)
+        with model.lock():
+            np.testing.assert_array_equal(xb.state(), [[0, 1, 2], [0, 1, 2]])
+            np.testing.assert_array_equal(yb.state(), [[0, 0, 0], [1, 1, 1]])
+
+    def test_identity(self):
+        model = Model()
+        x = model.integer()
+        y = model.constant(0)
+
+        xb, yb = dwave.optimization.broadcast_symbols(x, y)
+
+        self.assertEqual(xb.id(), x.id())
+        self.assertEqual(yb.id(), y.id())
+
+
 class TestHStack(unittest.TestCase):
     def test_0d(self):
         model = Model()

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -723,6 +723,16 @@ class TestBroadcastTo(utils.SymbolTests):
 
         self.assertEqual(model.num_symbols(), 1)  # no side effects
 
+    def test_state_size(self):
+        for symbol in self.generate_symbols():
+            self.assertEqual(symbol.state_size(), 0)
+
+        model = Model()
+        x = model.constant(5)
+        dwave.optimization.broadcast_to(x, (10, 5))
+        self.assertEqual(model.num_symbols(), 2)
+        self.assertEqual(model.state_size(), x.state_size())
+
 
 class TestBSpline(utils.SymbolTests):
     def generate_symbols(self):


### PR DESCRIPTION
Note that we don't (yet) support implicit broadcasting. Only explicit. The reason is to avoid excessive duplicate symbol creation. In the future we should add caching and/or a way to remove duplicate symbols.

Closes https://github.com/dwavesystems/dwave-optimization/issues/15