### PR TITLE
Add C++ support for bool dtype

### DIFF
--- a/dwave/optimization/include/dwave-optimization/iterators.hpp
+++ b/dwave/optimization/include/dwave-optimization/iterators.hpp
@@ -67,7 +67,7 @@ class BufferIterator {
     template <DType T>
     explicit BufferIterator(const T* ptr) noexcept
         requires(!DType<From>)
-            : ptr_(ptr), format_(format_of(ptr)), shape_() {}
+            : ptr_(ptr), format_(format_of<T>()), shape_() {}
 
     /// Construct a contiguous iterator pointing to ptr when the type of ptr is
     /// known at compile-time.
@@ -88,7 +88,7 @@ class BufferIterator {
             noexcept
         requires(!DType<From>)
             : ptr_(ptr),
-              format_(format_of(ptr)),
+              format_(format_of<T>()),
               shape_(std::make_unique<ShapeInfo>(ndim, shape, strides)) {}
 
     /// Construct a non-contiguous iterator from a shape/strides defined as
@@ -158,19 +158,21 @@ class BufferIterator {
         } else {
             // In this case we need to do some switch behavior at runtime
             switch (format_) {
-                case FormatCharacter::f:
+                case FormatCharacter::float_:
                     return *static_cast<const float*>(ptr_);
-                case FormatCharacter::d:
+                case FormatCharacter::double_:
                     return *static_cast<const double*>(ptr_);
-                case FormatCharacter::i:
+                case FormatCharacter::bool_:
+                    return *static_cast<const bool*>(ptr_);
+                case FormatCharacter::int_:
                     return *static_cast<const int*>(ptr_);
-                case FormatCharacter::b:
+                case FormatCharacter::signedchar_:
                     return *static_cast<const signed char*>(ptr_);
-                case FormatCharacter::h:
+                case FormatCharacter::signedshort_:
                     return *static_cast<const signed short*>(ptr_);
-                case FormatCharacter::l:
+                case FormatCharacter::signedlong_:
                     return *static_cast<const signed long*>(ptr_);
-                case FormatCharacter::Q:
+                case FormatCharacter::signedlonglong_:
                     return *static_cast<const signed long long*>(ptr_);
             }
             unreachable();
@@ -288,19 +290,21 @@ class BufferIterator {
         } else {
             // Otherwise we do a runtime check
             switch (format_) {
-                case FormatCharacter::f:
+                case FormatCharacter::float_:
                     return sizeof(float);
-                case FormatCharacter::d:
+                case FormatCharacter::double_:
                     return sizeof(double);
-                case FormatCharacter::i:
+                case FormatCharacter::bool_:
+                    return sizeof(bool);
+                case FormatCharacter::int_:
                     return sizeof(int);
-                case FormatCharacter::b:
+                case FormatCharacter::signedchar_:
                     return sizeof(signed char);
-                case FormatCharacter::h:
+                case FormatCharacter::signedshort_:
                     return sizeof(signed short);
-                case FormatCharacter::l:
+                case FormatCharacter::signedlong_:
                     return sizeof(signed long);
-                case FormatCharacter::Q:
+                case FormatCharacter::signedlonglong_:
                     return sizeof(signed long long);
             }
         }
@@ -474,24 +478,6 @@ class BufferIterator {
     std::conditional<DType<From>, empty, FormatCharacter>::type format_;
 
     std::unique_ptr<ShapeInfo> shape_ = nullptr;
-
-    // Convenience functions for getting the format character from a compile-time type.
-    // todo: move into the outer namespace.
-    static constexpr FormatCharacter format_of(const float* const) { return FormatCharacter::f; }
-    static constexpr FormatCharacter format_of(const double* const) { return FormatCharacter::d; }
-    static constexpr FormatCharacter format_of(const int* const) { return FormatCharacter::i; }
-    static constexpr FormatCharacter format_of(const signed char* const) {
-        return FormatCharacter::b;
-    }
-    static constexpr FormatCharacter format_of(const signed short* const) {
-        return FormatCharacter::h;
-    }
-    static constexpr FormatCharacter format_of(const signed long* const) {
-        return FormatCharacter::l;
-    }
-    static constexpr FormatCharacter format_of(const signed long long* const) {
-        return FormatCharacter::Q;
-    }
 };
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/include/dwave-optimization/typing.hpp
+++ b/dwave/optimization/include/dwave-optimization/typing.hpp
@@ -21,12 +21,13 @@ namespace dwave::optimization {
 
 /// The `DType<T>` concept is satisfied if and only if `T` is one of the
 /// supported data types. This list is a subset of the `dtype`s supported by
-/// NumPy as is designed for consistency/compatibility with NumPy.
+/// NumPy and is designed for consistency/compatibility with NumPy.
 /// See https://numpy.org/doc/stable/reference/arrays.dtypes.html for more
 /// information.
 template <typename T>
 concept DType = std::same_as<T, float> ||         // np.float32
                 std::same_as<T, double> ||        // np.float64
+                std::same_as<T, bool> ||          // np.bool
                 std::same_as<T, std::int8_t> ||   // np.int8
                 std::same_as<T, std::int16_t> ||  // np.int16
                 std::same_as<T, std::int32_t> ||  // np.int32
@@ -48,13 +49,27 @@ concept OptionalDType = DType<T> || std::same_as<T, void>;
 /// supported by Python's `struct` library.
 /// See https://docs.python.org/3/library/struct.html for more information.
 enum class FormatCharacter : char {
-    f = 'f',  // float
-    d = 'd',  // double
-    i = 'i',  // int
-    b = 'b',  // signed char
-    h = 'h',  // signed short
-    l = 'l',  // signed long
-    Q = 'Q',  // signed long long
+    float_ = 'f',
+    double_ = 'd',
+    bool_ = '?',
+    int_ = 'i',
+    signedchar_ = 'b',
+    signedshort_ = 'h',
+    signedlong_ = 'l',
+    signedlonglong_ = 'Q',
 };
+
+/// Get the format character associated with a supported DType.
+template <DType T>
+constexpr FormatCharacter format_of() {
+    if constexpr (std::same_as<T, float>) return FormatCharacter::float_;
+    if constexpr (std::same_as<T, double>) return FormatCharacter::double_;
+    if constexpr (std::same_as<T, bool>) return FormatCharacter::bool_;
+    if constexpr (std::same_as<T, int>) return FormatCharacter::int_;
+    if constexpr (std::same_as<T, signed char>) return FormatCharacter::signedchar_;
+    if constexpr (std::same_as<T, signed short>) return FormatCharacter::signedshort_;
+    if constexpr (std::same_as<T, signed long>) return FormatCharacter::signedlong_;
+    if constexpr (std::same_as<T, signed long long>) return FormatCharacter::signedlonglong_;
+}
 
 }  // namespace dwave::optimization

--- a/releasenotes/notes/bool-iterator-7a49134458f91e50.yaml
+++ b/releasenotes/notes/bool-iterator-7a49134458f91e50.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add support for ``bool`` dtype to the C++ ``BufferIterator``.

--- a/tests/cpp/test_iterators.cpp
+++ b/tests/cpp/test_iterators.cpp
@@ -12,6 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -25,6 +26,7 @@ using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
+// note: we don't test bool here because it's a bit of an edge case
 TEMPLATE_TEST_CASE("BufferIterator - templated", "",  //
                    float, double, std::int8_t, std::int16_t, std::int32_t, std::int64_t) {
     // Check that we can interpret buffers of each type as a double
@@ -90,6 +92,25 @@ TEMPLATE_TEST_CASE("BufferIterator - templated", "",  //
 
             CHECK_THAT(std::ranges::subrange(it, it + 5), RangeEquals({0, 2, 4, 6, 8}));
         }
+    }
+}
+
+TEST_CASE("BufferIterator - bool") {
+    GIVEN("An array of bools") {
+        std::array<bool, 5> buffer{false, true, false, false, true};
+
+        auto it = BufferIterator<double, bool>(buffer.data());
+
+        CHECK_THAT(std::ranges::subrange(it, it + 5), RangeEquals({0, 1, 0, 0, 1}));
+    }
+
+    GIVEN("An array of doubles") {
+        std::array<double, 10> buffer{0, 1, 2, 3, 0, 1, 2, 3, 0, 1};
+
+        auto it = BufferIterator<bool, double>(buffer.data());
+
+        CHECK_THAT(std::ranges::subrange(it, it + 10),
+                   RangeEquals({false, true, true, true, false, true, true, true, false, true}));
     }
 }
 


### PR DESCRIPTION
Still a ways to go before we can have truly types arrays, but we need this for boolean arrays.

It does have the side effect that we'll need to do something about the `std::vector<bool>` overload.