### PR TITLE
Prevent nodes added to NaryOp after it has successors

### DIFF
--- a/dwave/optimization/src/nodes/naryop.cpp
+++ b/dwave/optimization/src/nodes/naryop.cpp
@@ -164,6 +164,9 @@ NaryOpNode<BinaryOp>::NaryOpNode(std::span<ArrayNode*> node_ptrs)
 
 template <class BinaryOp>
 void NaryOpNode<BinaryOp>::add_node(ArrayNode* node_ptr, bool recompute_statistics) {
+    if (!this->successors().empty()) {
+        throw std::logic_error("cannot add predecessors to a NaryOp that already has successors");
+    }
     if (this->topological_index() >= 0 && node_ptr->topological_index() >= 0 &&
         this->topological_index() < node_ptr->topological_index()) {
         throw std::logic_error("this operation would invalidate the topological ordering");

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -3060,6 +3060,9 @@ cdef class NaryAdd(ArraySymbol):
         return x
 
     def __iadd__(self, rhs):
+        if not self.node_ptr.successors().empty():
+            return super().__iadd__(rhs)
+
         try:
             rhs = _as_array_symbol(self.model, rhs)
             self.ptr.add_node((<ArraySymbol>rhs).array_ptr)
@@ -3196,6 +3199,9 @@ cdef class NaryMultiply(ArraySymbol):
         return x
 
     def __imul__(self, rhs):
+        if not self.node_ptr.successors().empty():
+            return super().__imul__(rhs)
+
         try:
             rhs = _as_array_symbol(self.model, rhs)
             self.ptr.add_node((<ArraySymbol>rhs).array_ptr)

--- a/tests/cpp/nodes/test_naryop.cpp
+++ b/tests/cpp/nodes/test_naryop.cpp
@@ -15,6 +15,7 @@
 #include "catch2/catch_template_test_macros.hpp"
 #include "catch2/catch_test_macros.hpp"
 #include "dwave-optimization/graph.hpp"
+#include "dwave-optimization/nodes/binaryop.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
 #include "dwave-optimization/nodes/indexing.hpp"
@@ -60,6 +61,15 @@ TEMPLATE_TEST_CASE("NaryOpNode", "", functional::max<double>, functional::min<do
 
             // we can cast to a non-const ptr if we're not const
             CHECK(static_cast<Array*>(p_ptr->operands()[0]) == static_cast<Array*>(a_ptr));
+        }
+
+        WHEN("We add a successor to the NaryOp") {
+            auto e_ptr = graph.emplace_node<ConstantNode>(9);
+            graph.emplace_node<AddNode>(p_ptr, e_ptr);
+
+            THEN("We can no longer add predecessors to the NaryOp") {
+                CHECK_THROWS_AS(p_ptr->add_node(e_ptr), std::logic_error);
+            }
         }
 
         WHEN("We make a state") {

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -2425,6 +2425,7 @@ class TestNaryAdd(utils.NaryOpTests):
     def test_iadd(self):
         model = Model()
         x: dwave.optimization.model.ArraySymbol = model.binary()  # typing is for mypy
+        binary = x
         a = model.constant(5)
         b = model.constant(4)
 
@@ -2437,6 +2438,17 @@ class TestNaryAdd(utils.NaryOpTests):
 
         x += 5
         self.assertIs(x, y)  # subsequent should be in-place
+
+        # Now we test adding an indexing node that depends on the output range
+        i = model.constant(np.arange(20))[x]
+        x += 1000000000
+        self.assertIsNot(x, y)
+
+        with model.lock():
+            model.states.resize(1)
+            binary.set_state(0, 0)
+            self.assertEqual(x.state(), 1000000000 + 14)
+            self.assertEqual(i.state(), 14)
 
     def test_mismatched_shape(self):
         model = Model()
@@ -2490,6 +2502,7 @@ class TestNaryMultiply(utils.NaryOpTests):
     def test_imul(self):
         model = Model()
         x: dwave.optimization.model.ArraySymbol = model.binary()  # typing is for mypy
+        binary = x
         a = model.constant(5)
         b = model.constant(4)
 
@@ -2502,6 +2515,17 @@ class TestNaryMultiply(utils.NaryOpTests):
 
         x *= 5
         self.assertIs(x, y)  # subsequent should be in-place
+
+        # Now we test adding an indexing node that depends on the output range
+        i = model.constant(np.arange(101))[x]
+        x *= 10
+        self.assertIsNot(x, y)
+
+        with model.lock():
+            model.states.resize(1)
+            binary.set_state(0, 1)
+            self.assertEqual(x.state(), 1000)
+            self.assertEqual(i.state(), 100)
 
     def test_mismatched_shape(self):
         model = Model()


### PR DESCRIPTION
Fixes #379 