### PR TITLE
Fix modifying Model.objective directly

### DIFF
--- a/dwave/optimization/model.py
+++ b/dwave/optimization/model.py
@@ -119,28 +119,6 @@ class Model(_Graph):
         >>> model = flow_shop_scheduling(processing_times=processing_times)
     """
 
-    objective: typing.Optional[ArraySymbol]
-    """Objective to be minimized.
-
-    Examples:
-        This example prints the value of the objective of a model representing
-        the simple polynomial, :math:`y = i^2 - 4i`, for a state with value
-        :math:`i=2.0`.
-
-        >>> from dwave.optimization import Model
-        ...
-        >>> model = Model()
-        >>> i = model.integer(lower_bound=-5, upper_bound=5)
-        >>> c = model.constant(4)
-        >>> y = i**2 - c*i
-        >>> model.minimize(y)
-        >>> with model.lock():
-        ...     model.states.resize(1)
-        ...     i.set_state(0, 2.0)
-        ...     print(f"Objective = {model.objective.state(0)}")
-        Objective = -4.0
-    """
-
     states: States
     """States of the model.
 
@@ -154,8 +132,36 @@ class Model(_Graph):
     """
 
     def __init__(self):
-        self.objective = None
+        self._objective = None
         self.states = States(self)
+
+    @property
+    def objective(self) -> typing.Optional[ArraySymbol]:
+        """Objective to be minimized.
+
+        Examples:
+            This example prints the value of the objective of a model representing
+            the simple polynomial, :math:`y = i^2 - 4i`, for a state with value
+            :math:`i=2.0`.
+
+            >>> from dwave.optimization import Model
+            ...
+            >>> model = Model()
+            >>> i = model.integer(lower_bound=-5, upper_bound=5)
+            >>> c = model.constant(4)
+            >>> y = i**2 - c*i
+            >>> model.minimize(y)
+            >>> with model.lock():
+            ...     model.states.resize(1)
+            ...     i.set_state(0, 2.0)
+            ...     print(f"Objective = {model.objective.state(0)}")
+            Objective = -4.0
+        """
+        return self._objective
+
+    @objective.setter
+    def objective(self, value: ArraySymbol):
+        self.minimize(value)
 
     def binary(self, shape: typing.Optional[_ShapeLike] = None) -> BinaryVariable:
         r"""Create a binary symbol as a decision variable.
@@ -463,7 +469,7 @@ class Model(_Graph):
     def minimize(self, value: ArraySymbol):
         # inherit the docstring from _Graph
         super().minimize(value)
-        self.objective = value
+        self._objective = value
 
     # dev note: the typing is underspecified, but it would be quite complex to fully
     # specify the linear/quadratic so let's leave it alone for now.

--- a/releasenotes/notes/fix-objective-setter-684bf000b7a06e66.yaml
+++ b/releasenotes/notes/fix-objective-setter-684bf000b7a06e66.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix setting or mutating ``Model.objective``.
+    Until dwave-optimization 0.6.4, it was possible to set the objective of
+    a ``Model`` directly. However, in 0.6.4 and 0.6.5 doing so would result
+    in that change not being reflected in serialized models. This fix
+    restores support for setting or mutating ``Model.objective`` directly.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -361,6 +361,22 @@ class TestModel(unittest.TestCase):
         model.minimize(model.constant([[7]]))
         self.assertEqual(model.objective.state(), 7)
 
+    def test_objective(self):
+        model = Model()
+
+        x = model.list(5)
+        model.objective = x.sum()  # the same as minimize
+        model.objective += 1
+
+        # setting in this way should survive serialization
+        with model.to_file() as f:
+            copy = model.from_file(f)
+        self.assertIs(type(model.objective), type(copy.objective))
+
+        # It cannot be set to the wrong type
+        with self.assertRaises(TypeError):
+            model.objective = "hello"
+
     def test_remove_unused_symbols(self):
         with self.subTest("all unused"):
             model = Model()


### PR DESCRIPTION
Prior to https://github.com/dwavesystems/dwave-optimization/pull/179, `Model.objective` was readonly. After that PR it was possible to set or mutate the `model.objective`. And while that would not update the underlying C++ model, the serialization would read the Python attribute. That is until https://github.com/dwavesystems/dwave-optimization/pull/166 changed the behavior to read from the underlying graph.

This PR makes support for modifying `Model.objective` official.