### PR TITLE
Fix potential issue with expression input init in AccumulateZipNode

### DIFF
--- a/dwave/optimization/src/nodes/lambda.cpp
+++ b/dwave/optimization/src/nodes/lambda.cpp
@@ -241,9 +241,14 @@ void AccumulateZipNode::initialize_state(State& state) const {
         iterators.push_back(array_ptr->begin(state));
     }
 
-    // Initialize the inputs
+    // Initialize the inputs. This ensures that we can call `assign()` on the input
+    // nodes in loop below (or in future propagations, if predecessors are dynamic
+    // and start empty).
     for (const auto inp : expression_ptr_->inputs()) {
-        double val = inp->min();
+        // This is just an initial value to set the state up, it will be immediately
+        // overwritten. Choose a value close to zero instead of using min/max directly
+        // in case they are unbounded (set to +/-inf).
+        double val = std::clamp(0.0, inp->min(), inp->max());
         inp->initialize_state(reg, std::span(&val, 1));
     }
 

--- a/releasenotes/notes/fix-AccumulateZip-expression-input-initialization-a48a45b701f4d46c.yaml
+++ b/releasenotes/notes/fix-AccumulateZip-expression-input-initialization-a48a45b701f4d46c.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix an issue with ``AccumulateZip`` when given an expression that contains
+    unbounded input symbols. For some expressions, this would result in
+    malformed data being propagated through the expression on initialization,
+    which could then affect all subsequent propagations.


### PR DESCRIPTION
Previously AccumulateZip would initialize the inputs in an expression their `min()` value, but since it is common that we have unbounded inputs (i.e. `min()` returns `-inf`) this could result in NaNs being created/propagated in the expression during evaluation, causing other issues. This is fixed by just initializing the inputs close to 0.