### PR TITLE
Fix potential out-of-bounds access in ReduceNode implementation

### DIFF
--- a/dwave/optimization/src/nodes/reduce.cpp
+++ b/dwave/optimization/src/nodes/reduce.cpp
@@ -381,9 +381,10 @@ std::vector<ssize_t> drop_axes(std::ranges::sized_range auto&& range,
     std::vector<ssize_t> out;
 
     auto axes_it = axes.begin();
+    const auto axes_end = axes.end();
     auto range_it = std::ranges::begin(range);
     for (ssize_t dim = 0, stop = std::ranges::size(range); dim < stop; ++dim, ++range_it) {
-        if (dim == *axes_it) {
+        if (axes_it != axes_end && dim == *axes_it) {
             // skipped axis, this relies on axes being sorted and unique
             ++axes_it;
         } else {


### PR DESCRIPTION
Unfortunately this is hard to unittest because the previous behavior was undefined and it's a private function.

Valgrind seems happy and many runs locally pass. It also makes sense that it would fix the errors we saw in https://github.com/dwavesystems/dwave-optimization/pull/416 and https://github.com/dwavesystems/dwave-optimization/pull/402. So I am inclined to not bend over backwards to add tests.