### PR TITLE
Build with Cython 3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "cython~=3.1.0",
+    "cython~=3.2.0",
     "meson-python~=0.18.0",
 ]
 build-backend = 'mesonpy'
@@ -50,7 +50,7 @@ dev = [
     "numpy==2.3.3; python_version >= '3.11'",
 
     # Build requirements
-    "cython~=3.1.0",
+    "cython~=3.2.0",
     "meson-python~=0.18.0",
     "meson~=1.9.0",
     "ninja~=1.13.0",


### PR DESCRIPTION
Dependency update to use [Cython 3.2.x](https://cython.readthedocs.io/en/latest/src/changes.html#id1).