### PR TITLE
Improve / Rename `BroadcastToNode::reindex()`

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
@@ -80,7 +80,7 @@ class BroadcastToNode : public ArrayNode {
  private:
     /// Translate a linear index of the predecessor into a linear index of the
     /// BroadcastToNode.
-    ssize_t reindex(ssize_t index) const;
+    ssize_t convert_predecessor_index_(ssize_t index) const;
 
     ArrayNode* array_ptr_;
 


### PR DESCRIPTION
Replace the calls to `unravel_index() + insert() + ravel_multi_index()` by an optimized method similar to #416.

The previous implementation was of the form:
```cpp
std::vector<ssize_t> multi_index = unravel_index(update.index, array_ptr_->shape());
multi_index.insert(multi_index.begin(), this->ndim() - array_ptr_->ndim(), 0);
const ssize_t index = ravel_multi_index(multi_index, this->shape());
```
Note that in `ravel_multi_index()` each `multi index` is scaled by a `multiplier`. The `insert()` on the 2nd line above contributes nothing to `index` since each value inserted is `0`.

I benchmarked this `PR` against `main` and saw a `~1.5 - 2` x speedup during `propagate()`.

```cpp
// Copyright 2025 D-Wave
//
//    Licensed under the Apache License, Version 2.0 (the "License");
//    you may not use this file except in compliance with the License.
//    You may obtain a copy of the License at
//
//        http://www.apache.org/licenses/LICENSE-2.0
//
//    Unless required by applicable law or agreed to in writing, software
//    distributed under the License is distributed on an "AS IS" BASIS,
//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
//    See the License for the specific language governing permissions and
//    limitations under the License.

#include <vector>

#include <catch2/benchmark/catch_benchmark.hpp>
#include "catch2/catch_test_macros.hpp"
#include "dwave-optimization/nodes/manipulation.hpp"
#include "dwave-optimization/nodes/numbers.hpp"

namespace dwave::optimization {

TEST_CASE("Benchmark BroadcastToNode") {
    const ssize_t num_elements = 2 * 10 * 10 * 10 * 10;
    const ssize_t lower_bound = -5.0;
    const ssize_t upper_bound = 5.0;
    const std::vector<ssize_t> update_size = {1, 20, 100, 500};

    //// -- setup and init DAG
    auto graph = Graph();
    auto array_ptr = graph.emplace_node<IntegerNode>(std::initializer_list<ssize_t>{num_elements},
                                                     lower_bound, upper_bound);
    auto broadcastto_ptr =
            graph.emplace_node<BroadcastToNode>(array_ptr, std::vector<ssize_t>{2, num_elements});
    auto state = graph.initialize_state();
    //// -- setup and init DAG

    /// distributions and random # generator
    auto rng = std::default_random_engine(667);
    auto index_dist = std::uniform_int_distribution<>(0, num_elements - 1);
    auto values_domain = std::uniform_int_distribution<>(lower_bound, upper_bound);
    /// distributions and random # generator

    //// -- perform random updates
    const ssize_t num_iters = 500;
    for (ssize_t update_size : update_size) {
        BENCHMARK("(" + std::to_string(update_size) + " updates) x (" + std::to_string(num_iters) +
                  " iterations)") {
            for (ssize_t iteration = 0; iteration < num_iters; iteration++) {
                for (ssize_t update = 0; update < update_size; update++) {
                    // assign a random value to a random index
                    array_ptr->set_value(state, index_dist(rng), values_domain(rng));
                }
                graph.propagate(state);
                graph.commit(state);
            }
        };
    }
    //// -- perform random updates
}

}  // namespace dwave::optimization
```