### PR TITLE
Improve `ReduceNode::reduce_()`

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/reduce.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/reduce.hpp
@@ -115,6 +115,10 @@ class ReduceNode : public ArrayOutputMixin<ArrayNode> {
     // it to the correct `index` in the ReduceNode buffer. This method
     // determines the correct buffer `index` given an `update.index`.
     ssize_t convert_predecessor_index_(ssize_t index) const;
+
+    // During `reduce_()` we need to convert from a flat index of this
+    // node to a flat index of the predecessor node.
+    ssize_t convert_to_predecessor_index_(ssize_t index) const;
 };
 
 using AllNode = ReduceNode<std::logical_and<double>>;


### PR DESCRIPTION
Replace the calls to `unravel_index() + insert() + ravel_multi_index()` by an optimized method similar to #425.

This PR offers a speedup when the iterator to the `ReduceNodes` predecessor is *not* shaped. That is,
```cpp
array_ptr_->begin(state).shaped() == false.
```
Furthermore! It only actually yields a speedup when an `update` results in the whole reduction being recalculated, i.e. the `update` results in `ReductionFlag::invalid`. This is invoked [here](https://github.com/dwavesystems/dwave-optimization/blob/main/dwave/optimization/src/nodes/reduce.cpp#L153) in `prepare_diff()` after defining 
```cpp
state_ptr->prepare_diff([&](const ssize_t idx) { return this->reduce_(state, idx); });
```
in [`propagate()`](https://github.com/dwavesystems/dwave-optimization/blob/main/dwave/optimization/src/nodes/reduce.cpp#L705-L766).

Unclear if this improvement is worth it. Points to consider:

1. This PR adds a non-trivial amount of code in the form of `convert_to_predecessor_index_()`
2. `convert_to_predecessor_index_()` and `convert_predecessor_index_()` are very similar and *could* be combined into one mildly confusing function. I kept them separate for readabilities sake.
3. The speedup appears to be so-so (`18%` speedup for this case). I tried to come up with a benchmark where each `update` results in  whole reduction recalculation. Below is my benchmark (**better benchmark wanted, happy to implement suggestions**). The predecessor is a integer array that starts with all zeros. During each update, I change one index to a 1, `propagate()`, then `revert()`. With a `MinNode` this combo results in a whole recalculation (as desired and manually verified) each `update`.

```cpp
// Copyright 2025 D-Wave
//
//    Licensed under the Apache License, Version 2.0 (the "License");
//    you may not use this file except in compliance with the License.
//    You may obtain a copy of the License at
//
//        http://www.apache.org/licenses/LICENSE-2.0
//
//    Unless required by applicable law or agreed to in writing, software
//    distributed under the License is distributed on an "AS IS" BASIS,
//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
//    See the License for the specific language governing permissions and
//    limitations under the License.

#include <catch2/benchmark/catch_benchmark.hpp>
#include <initializer_list>
#include <string>

#include "catch2/catch_test_macros.hpp"
#include "dwave-optimization/graph.hpp"
#include "dwave-optimization/nodes/numbers.hpp"
#include "dwave-optimization/nodes/reduce.hpp"

namespace dwave::optimization {

TEST_CASE("Benchmark ReduceNode") {
    const ssize_t num_elements = 10 * 10 * 10 * 10;
    const ssize_t lower_bound = 0.0;
    const ssize_t upper_bound = 1.0;

    //// -- setup and init DAG
    auto graph = Graph();
    auto array_ptr = graph.emplace_node<IntegerNode>(std::initializer_list<ssize_t>{10, 10, 10, 10},
                                                     lower_bound, upper_bound);
    auto sum_ptr = graph.emplace_node<MinNode>(array_ptr, std::initializer_list<ssize_t>{1, 2});
    // all values of array_ptr will be set to the lower_bound == 0.0.
    auto state = graph.initialize_state();
    REQUIRE(array_ptr->view(state).begin().shaped() == false);
    //// -- setup and init DAG

    //// -- distributions and random number generator
    auto rng = std::default_random_engine(667);
    auto index_dist = std::uniform_int_distribution<>(0, num_elements - 1);
    //// -- distributions and random number generator

    //// -- perform random updates
    const ssize_t num_iters = 100000;
    BENCHMARK("(1 update) x (" + std::to_string(num_iters) + " iterations)") {
        for (ssize_t iteration = 0; iteration < num_iters; iteration++) {
            // assign a random index 1
            array_ptr->set_value(state, index_dist(rng), 1);
            graph.propagate(state);
            graph.revert(state);
        }
    };
    //// -- perform random updates
}

}  // namespace dwave::optimization
```
The raw benchmarking results are as follows.
```
-------------------------------------------------------------------------------
Benchmark ReduceNode (main branch)
-------------------------------------------------------------------------------
benchmark name                       samples       iterations    est run time
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
(1 update) x (100,000 iterations)              100             1     47.3562 s 
                                        492.396 ms    489.499 ms    495.572 ms 
                                        15.4869 ms    13.7242 ms    17.7486 ms 
===============================================================================

-------------------------------------------------------------------------------
Benchmark ReduceNode (PR branch)
-------------------------------------------------------------------------------
benchmark name                       samples       iterations    est run time
                                     mean          low mean      high mean
                                     std dev       low std dev   high std dev
-------------------------------------------------------------------------------
(1 update) x (100,000 iterations)              100             1     41.1447 s 
                                        417.353 ms    415.671 ms    419.284 ms 
                                        9.22296 ms    8.16642 ms    10.3859 ms 
===============================================================================
```