### PR TITLE
Fix ReduceNode's bounds setting when it has a dynamic but empty predecessor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
             python -m build \
               -Ccompile-args="-v" \
               -Csetup-args="-Dwerror=true"
+            rm -r dist
 
       - run:
           name: build and install with -Werror and without -NDEBUG
@@ -82,7 +83,8 @@ jobs:
             . env/bin/activate
             python -m build \
               -Ccompile-args="-v" \
-              -Csetup-args="-Db_ndebug=true" \
+              -Csetup-args="-Dbuildtype=debug" \
+              -Csetup-args="-Dbuild-tests=disabled" \
               -Csetup-args="-Dwerror=true"
             pip install dist/dwave*optimization*.whl --force
 

--- a/dwave/optimization/src/nodes/reduce.cpp
+++ b/dwave/optimization/src/nodes/reduce.cpp
@@ -540,7 +540,13 @@ ValuesInfo values_info(const Array* array_ptr, std::span<const ssize_t> axes,
     // with bounds.
     //
 
-    assert(not(max_size.has_value() and *max_size == 0));  // shouldn't be possible to get here
+    if (max_size.has_value() and *max_size == 0) {
+        // If our array is always empty (can happen that arrays think they are dynamic when
+        // they are empty by construction), then our initial value is our bounds.
+        assert(initial.has_value());  // previous check should have caught this
+        auto init = typename decltype(ufunc)::result_type(*initial);
+        return ValuesInfo(init, init, is_integer(init));
+    }
 
     // Get the bounds at each of the smallest and largest sizes we can be
     ValuesInfo min_bounds = ufunc.result_bounds(array_bounds, std::max<ssize_t>(min_size, 1));

--- a/releasenotes/notes/fix-Reduce-empty-dynamic-predecessor-86e93c9d071605d8.yaml
+++ b/releasenotes/notes/fix-Reduce-empty-dynamic-predecessor-86e93c9d071605d8.yaml
@@ -1,0 +1,3 @@
+---
+fixes:
+  - Fix ``Reduce`` symbol's bounds when given a dynamic predecessor that is always empty.


### PR DESCRIPTION
Also, we weren't actually running the tests with debug symbols before. Otherwise the existing tests would have caught this error.

Incidentally, the resulting behavior with and without the code change is the same, but just removing the offending assert would hit other asserts later. It just all so happened to work out which is why our non-debug tests were passing.