### PR TITLE
Add missing release note for Roll symbol

### DIFF
--- a/releasenotes/notes/Roll-release-note-8baedd0d475ed5a0.yaml
+++ b/releasenotes/notes/Roll-release-note-8baedd0d475ed5a0.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add ``Roll`` symbol and corresponding ``roll()`` function. See `#423 <https://github.com/dwavesystems/dwave-optimization/issues/423>`_.


### PR DESCRIPTION
Should have been included in https://github.com/dwavesystems/dwave-optimization/pull/430
See also https://github.com/dwavesystems/dwave-optimization/issues/423