### PR TITLE
Fix issue with Clang 17

### DIFF
--- a/dwave/optimization/src/array.cpp
+++ b/dwave/optimization/src/array.cpp
@@ -265,7 +265,7 @@ std::vector<ssize_t> broadcast_shapes(const std::span<const ssize_t> lhs,
     assert(sit == shape.rend());
 
     // Check that we haven't put a dynamic axis anywhere except axis 0
-    if (std::ranges::any_of(shape | std::views::drop(1), std::signbit<ssize_t>)) {
+    if (std::ranges::any_of(shape | std::views::drop(1), [](const auto& val) { return val < 0; })) {
         throw std::invalid_argument("operands could not be broadcast together with shapes " +
                                     shape_to_string(lhs) + " " + shape_to_string(rhs));
     }


### PR DESCRIPTION
Previously was unable to build the dev environment on Mac OSX with clang 17.0.0. Appears to have passed previous CircleCi tests because the tests were running clang 15.0.0.