### PR TITLE
Use xcode 26.2.0 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@5.0.0
-  macos: circleci/macos@2.5
+  win: circleci/windows@5.1  # latest as of Jan 2026
+  macos: circleci/macos@2.5  # latest as of Jan 2026
 
 commands:
   run-cibuildwheel:


### PR DESCRIPTION
Began as a failing case for https://github.com/dwavesystems/dwave-optimization/pull/450, but also we needed to do this anyway because [the macos.m1.medium.gen1 resource class is deprecated](https://circleci.com/changelog/deprecation-of-mac-m1-and-m2-resource-classes/). Nicely, it seems we don't have to explicitly specify the resource class anymore. It uses the `medium` one by default which is the cheaper one.