### PR TITLE
Improve error message for dynamic `NumberNode`s.

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
@@ -114,6 +114,10 @@ class NumberNode : public ArrayOutputMixin<ArrayNode>, public DecisionNode {
         if (max_ < min_) {
             throw std::invalid_argument("Invalid range for number array provided");
         }
+
+        if ((shape.size() > 0) && (shape[0] < 0)) {
+            throw std::invalid_argument("NumberNode cannot have dynamic size.");
+        }
     }
 
     // Return truth statement: 'value is within the bounds of a given index'

--- a/releasenotes/notes/improve_error_for_dynamic_numbernodes-6bf2205ffd0bbd76.yaml
+++ b/releasenotes/notes/improve_error_for_dynamic_numbernodes-6bf2205ffd0bbd76.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Provide a meaningful error message when attempting to make a dynamic
+    NumberNode at the C++ level.

--- a/tests/cpp/nodes/test_numbers.cpp
+++ b/tests/cpp/nodes/test_numbers.cpp
@@ -12,6 +12,7 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+#include <initializer_list>
 #include <optional>
 
 #include "catch2/catch_test_macros.hpp"
@@ -438,6 +439,11 @@ TEST_CASE("BinaryNode") {
         REQUIRE_THROWS(graph.emplace_node<dwave::optimization::BinaryNode>(
                 2, std::vector<double>{0, 0}, std::vector<double>{1, -1}));
     }
+
+    GIVEN("Invalid dynamically sized BinaryNode") {
+        REQUIRE_THROWS_WITH(graph.emplace_node<BinaryNode>(std::initializer_list<ssize_t>{-1, 2}),
+                            "NumberNode cannot have dynamic size.");
+    }
 }
 
 TEST_CASE("IntegerNode") {
@@ -730,6 +736,11 @@ TEST_CASE("IntegerNode") {
                 }
             }
         }
+    }
+
+    GIVEN("Invalid dynamically sized IntegerNode") {
+        REQUIRE_THROWS_WITH(graph.emplace_node<IntegerNode>(std::initializer_list<ssize_t>{-1, 3}),
+                            "NumberNode cannot have dynamic size.");
     }
 }
 


### PR DESCRIPTION
As opposed to the following error message:
```
FAILED:
  {Unknown expression after the reported line}
due to unexpected exception with message:
  vector
```