### PR TITLE
Reduce `SoftMaxNode` memory and reduce copying

### DIFF
--- a/dwave/optimization/src/nodes/set_routines.cpp
+++ b/dwave/optimization/src/nodes/set_routines.cpp
@@ -31,7 +31,7 @@ struct IsInNodeSetData {
 };
 
 struct IsInNodeDataHelper_ {
-    IsInNodeDataHelper_(std::vector<double> element, std::vector<double> test_elements) {
+    IsInNodeDataHelper_(std::vector<double>&& element, std::vector<double>&& test_elements) {
         element_isin.reserve(element.size());
 
         for (const double& val : test_elements) {
@@ -50,7 +50,7 @@ struct IsInNodeDataHelper_ {
 };
 
 struct IsInNodeData : public ArrayNodeStateData {
-    IsInNodeData(std::vector<double> element, std::vector<double> test_elements)
+    IsInNodeData(std::vector<double>&& element, std::vector<double>&& test_elements)
             : IsInNodeData(IsInNodeDataHelper_(std::move(element), std::move(test_elements))) {}
     IsInNodeData(IsInNodeDataHelper_&& helper)
             : ArrayNodeStateData(std::move(helper.element_isin)),

--- a/dwave/optimization/src/nodes/softmax.cpp
+++ b/dwave/optimization/src/nodes/softmax.cpp
@@ -24,13 +24,12 @@
 namespace dwave::optimization {
 
 struct SoftMaxNodeDataHelper_ {
-    SoftMaxNodeDataHelper_(std::vector<double> input) {
+    SoftMaxNodeDataHelper_(std::vector<double>&& input) : values(std::move(input)) {
         // Compute softmax.
         denominator = 0.0;
-        for (ssize_t i = 0, stop = input.size(); i < stop; ++i) {
-            double exp_val = std::exp(input[i]);
-            values.push_back(exp_val);
-            denominator += exp_val;
+        for (ssize_t i = 0, stop = values.size(); i < stop; ++i) {
+            values[i] = std::exp(values[i]);
+            denominator += values[i];
         }
         for (double& val : values) {
             val /= denominator;
@@ -45,7 +44,7 @@ struct SoftMaxNodeDataHelper_ {
 };
 
 struct SoftMaxNodeStateData : public ArrayNodeStateData {
-    SoftMaxNodeStateData(std::vector<double> input)
+    SoftMaxNodeStateData(std::vector<double>&& input)
             : SoftMaxNodeStateData(SoftMaxNodeDataHelper_(std::move(input))) {}
 
     SoftMaxNodeStateData(SoftMaxNodeDataHelper_&& helper)

--- a/dwave/optimization/src/nodes/sorting.cpp
+++ b/dwave/optimization/src/nodes/sorting.cpp
@@ -23,7 +23,7 @@ namespace dwave::optimization {
 /// ArgSortNode
 
 struct ArgSortNodeDataHelper_ {
-    ArgSortNodeDataHelper_(std::vector<double> values) {
+    ArgSortNodeDataHelper_(std::vector<double>&& values) {
         for (ssize_t index = 0, stop = values.size(); index < stop; index++) {
             order.emplace(values[index], index);
         }
@@ -38,7 +38,7 @@ struct ArgSortNodeDataHelper_ {
 };
 
 struct ArgSortNodeData : public ArrayNodeStateData {
-    ArgSortNodeData(std::vector<double> values)
+    ArgSortNodeData(std::vector<double>&& values)
             : ArgSortNodeData(ArgSortNodeDataHelper_(std::move(values))) {}
     ArgSortNodeData(ArgSortNodeDataHelper_&& helper)
             : ArrayNodeStateData(std::move(helper.indices)), order(std::move(helper.order)) {}


### PR DESCRIPTION
`SoftMaxNode`, `IsInNode`, and `ArgSortNode` all use the same method to store state dependent data on the node. This method originally copied a rvalue reference as opposed to accepting a rvalue reference.

The `SoftMaxNode` constructor takes a `std::vector<double>` as an argument. This vector can be reused in initialization as opposed to copying its values.