### PR TITLE
Build in CI with uv

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
           name: run cibuildwheel
           shell: bash -eo pipefail
           command: |
-            python -m pip install --user cibuildwheel==<< parameters.cibw-version >>
+            python -m pip install --user cibuildwheel[uv]==<< parameters.cibw-version >>
             python -m cibuildwheel --output-dir dist
 
       - store_artifacts: &store-artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ skip = "pp* *musllinux*"
 # build step. There isn't (as of Dec 2025) a way to override the
 # build-system.requires so we need to build without isolation
 before-build = "pip install --group blas-build"
-build-frontend = { name = "build", args = ["--no-isolation"] }
+build-frontend = { name = "build[uv]", args = ["--no-isolation"] }
 
 before-test = "pip install --group test"
 test-command = "python -Werror -m unittest discover {project}/tests/"
@@ -122,7 +122,7 @@ repair-wheel-command = [
 # For Python3.12+, rather than building individual wheels we build an abi3
 # wheel. 313t and 314t do not support abi wheels yet.
 select = "cp31[!01]-*"  # uses fnmatch, will fail for 3.20+ but good enough for now
-build-frontend = { name = "build", args = ["-Csetup-args=-Dpython.allow_limited_api=true", "--no-isolation"] }
+build-frontend = { name = "build[uv]", args = ["-Csetup-args=-Dpython.allow_limited_api=true", "--no-isolation"] }
 inherit.repair-wheel-command = "append"
 repair-wheel-command = [
     "pip install abi3audit",


### PR DESCRIPTION
The bottleneck should be building the C++ libraries, but curious if this makes a noticeable difference for the wheel build time.