### PR TITLE
Reduce `SoftMaxNode` memory in state data constructor

### DIFF
--- a/dwave/optimization/src/nodes/softmax.cpp
+++ b/dwave/optimization/src/nodes/softmax.cpp
@@ -24,13 +24,12 @@
 namespace dwave::optimization {
 
 struct SoftMaxNodeDataHelper_ {
-    SoftMaxNodeDataHelper_(std::vector<double> input) {
+    SoftMaxNodeDataHelper_(std::vector<double> input) : values(std::move(input)) {
         // Compute softmax.
         denominator = 0.0;
-        for (ssize_t i = 0, stop = input.size(); i < stop; ++i) {
-            double exp_val = std::exp(input[i]);
-            values.push_back(exp_val);
-            denominator += exp_val;
+        for (double& val : values) {
+            val = std::exp(val);
+            denominator += val;
         }
         for (double& val : values) {
             val /= denominator;


### PR DESCRIPTION
The `SoftMaxNode` constructor takes a `std::vector<double>` as an argument. This vector can be reused in initialization as opposed to copying its values.