### PR TITLE
Drop typing.Optional

### DIFF
--- a/dwave/optimization/_model.pyi
+++ b/dwave/optimization/_model.pyi
@@ -45,7 +45,7 @@ class _Graph:
         cls: typing.Type[_GraphSubclass],
         file: typing.Union[bytes, os.PathLike, str, typing.BinaryIO],
         *,
-        substitute: typing.Optional[collections.abc.Mapping[str, collections.abc.Callable]] = None,
+        substitute: None | collections.abc.Mapping[str, collections.abc.Callable] = None,
         ) -> _GraphSubclass: ...
 
     def into_file(
@@ -54,7 +54,7 @@ class _Graph:
         *,
         max_num_states: int = 0,
         only_decision: bool = False,
-        version: typing.Optional[tuple[int, int]] = None
+        version: None | tuple[int, int] = None
         ): ...
 
     def is_locked(self) -> bool: ...
@@ -145,7 +145,7 @@ class ArraySymbol(Symbol):
     def resize(
         self,
         shape: _ShapeLike,
-        fill_value: typing.Optional[float] = None,
+        fill_value: None | float = None,
     ) -> symbols.Resize: ...
     def shape(self) -> tuple[int, ...]: ...
     def size(self) -> typing.Union[int, symbols.Size]: ...

--- a/dwave/optimization/generators.py
+++ b/dwave/optimization/generators.py
@@ -52,7 +52,7 @@ def _require(argname: str,
              array_like: numpy.typing.ArrayLike,
              *,
              dtype: numpy.typing.DTypeLike = None,
-             ndim: typing.Optional[int] = None,
+             ndim: None | int = None,
              nonnegative: bool = False,
              positive: bool = False,
              square: bool = False
@@ -226,10 +226,10 @@ def bin_packing(weights: numpy.typing.ArrayLike,
 def capacitated_vehicle_routing(demand: numpy.typing.ArrayLike,
                                 number_of_vehicles: int,
                                 vehicle_capacity: float,
-                                distances: typing.Optional[numpy.typing.ArrayLike] = None,
-                                locations_x: typing.Optional[numpy.typing.ArrayLike] = None,
-                                locations_y: typing.Optional[numpy.typing.ArrayLike] = None,
-                                depot_x_y: typing.Optional[numpy.typing.ArrayLike] = None
+                                distances: None | numpy.typing.ArrayLike = None,
+                                locations_x: None | numpy.typing.ArrayLike = None,
+                                locations_y: None | numpy.typing.ArrayLike = None,
+                                depot_x_y: None | numpy.typing.ArrayLike = None
                                 ) -> Model:
     r"""Generate a model encoding a capacitated vehicle routing problem.
 
@@ -766,7 +766,7 @@ def flow_shop_scheduling(processing_times: numpy.typing.ArrayLike) -> Model:
 
 def job_shop_scheduling(times: numpy.typing.ArrayLike, machines: numpy.typing.ArrayLike,
                         *,
-                        upper_bound: typing.Optional[int] = None,
+                        upper_bound: None | int = None,
                         ) -> Model:
     """Generate a model encoding a job-shop scheduling problem.
 

--- a/dwave/optimization/mathematical.py
+++ b/dwave/optimization/mathematical.py
@@ -947,15 +947,15 @@ def less_equal(x1: ArraySymbolLike, x2: ArraySymbolLike) -> LessEqual:
 
 def linprog(
         c: ArraySymbol,
-        A_ub: typing.Optional[ArraySymbol] = None,  # alias for A
-        b_ub: typing.Optional[ArraySymbol] = None,
-        A_eq: typing.Optional[ArraySymbol] = None,
-        b_eq: typing.Optional[ArraySymbol] = None,
+        A_ub: None | ArraySymbol = None,  # alias for A
+        b_ub: None | ArraySymbol = None,
+        A_eq: None | ArraySymbol = None,
+        b_eq: None | ArraySymbol = None,
         *,  # the args up until here match SciPy's linprog() which accepts them positionally
-        b_lb: typing.Optional[ArraySymbol] = None,
-        A: typing.Optional[ArraySymbol] = None,
-        lb: typing.Optional[ArraySymbol] = None,
-        ub: typing.Optional[ArraySymbol] = None,
+        b_lb: None | ArraySymbol = None,
+        A: None | ArraySymbol = None,
+        lb: None | ArraySymbol = None,
+        ub: None | ArraySymbol = None,
         ) -> LPResult:
     r"""Solve a :term:`linear program` defined by the input array symbol(s).
 
@@ -1598,7 +1598,7 @@ def put(array: ArraySymbol, indices: ArraySymbol, values: ArraySymbol) -> Put:
 def resize(
         array: ArraySymbol,
         shape: typing.Union[int, collections.abc.Sequence[int]],
-        fill_value: typing.Optional[float] = None,
+        fill_value: None | float = None,
 ) -> Resize:
     """Return a new :class:`~dwave.optimization.symbols.Resize` symbol with the given shape.
 

--- a/dwave/optimization/model.py
+++ b/dwave/optimization/model.py
@@ -136,7 +136,7 @@ class Model(_Graph):
         self.states = States(self)
 
     @property
-    def objective(self) -> typing.Optional[ArraySymbol]:
+    def objective(self) -> None | ArraySymbol:
         """Objective to be minimized.
 
         Examples:
@@ -163,9 +163,9 @@ class Model(_Graph):
     def objective(self, value: ArraySymbol):
         self.minimize(value)
 
-    def binary(self, shape: typing.Optional[_ShapeLike] = None,
-               lower_bound: typing.Optional[np.typing.ArrayLike] = None,
-               upper_bound: typing.Optional[np.typing.ArrayLike] = None) -> BinaryVariable:
+    def binary(self, shape: None | _ShapeLike = None,
+               lower_bound: None | np.typing.ArrayLike = None,
+               upper_bound: None | np.typing.ArrayLike = None) -> BinaryVariable:
         r"""Create a binary symbol as a decision variable.
 
         Args:
@@ -424,9 +424,9 @@ class Model(_Graph):
     def input(
         self,
         shape: tuple[int, ...] = (),
-        lower_bound: typing.Optional[float] = -float("inf"),
-        upper_bound: typing.Optional[float] = float("inf"),
-        integral: typing.Optional[bool] = None,
+        lower_bound: None | float = -float("inf"),
+        upper_bound: None | float = float("inf"),
+        integral: None | bool = None,
     ) -> Input:
         """Create an "input" symbol.
 
@@ -475,9 +475,9 @@ class Model(_Graph):
 
     def integer(
             self,
-            shape: typing.Optional[_ShapeLike] = None,
-            lower_bound: typing.Optional[numpy.typing.ArrayLike] = None,
-            upper_bound: typing.Optional[numpy.typing.ArrayLike] = None,
+            shape: None | _ShapeLike = None,
+            lower_bound: None | numpy.typing.ArrayLike = None,
+            upper_bound: None | numpy.typing.ArrayLike = None,
             ) -> IntegerVariable:
         r"""Create an integer symbol as a decision variable.
 
@@ -633,7 +633,7 @@ class Model(_Graph):
     def set(self,
             n: int,
             min_size: int = 0,
-            max_size: typing.Optional[int] = None,
+            max_size: None | int = None,
             ) -> SetVariable:
         """Create a set symbol as a decision variable.
 

--- a/dwave/optimization/states.pyi
+++ b/dwave/optimization/states.pyi
@@ -39,7 +39,7 @@ class States:
         self,
         file: typing.Union[bytes, os.PathLike, str, typing.BinaryIO],
         *,
-        version: typing.Optional[tuple[int, int]] = None,
+        version: None | tuple[int, int] = None,
         ): ...
 
     def _reset_intermediate_states(self): ...

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -82,7 +82,7 @@ class TestSerialization(unittest.TestCase):
             test_model.states.from_file(os.path.join(directory, "states", name + ".nl"))
             self.assertModelEqual(base_model, test_model)
 
-    def save(self, directory: str, version: typing.Optional[tuple[int, int]]):
+    def save(self, directory: str, version: None | tuple[int, int]):
         """Save all models to the given directory with the given serialization version."""
         os.makedirs(os.path.join(directory, "model"), exist_ok=True)
         os.makedirs(os.path.join(directory, "states"), exist_ok=True)


### PR DESCRIPTION
Purely aesthetic commit, but now that we've dropped Python 3.9 we can use the `None | arg` syntax in-place of `typing.Optional[arg]`.

Inspired by a comment on #462 