### PR TITLE
Cache `SizeInfo` on `TransposeNode`

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/manipulation.hpp
@@ -503,6 +503,9 @@ class TransposeNode : public ArrayNode {
     ssize_t size() const override;
     ssize_t size(const State& state) const override;
 
+    /// @copydoc Array::sizeinfo()
+    SizeInfo sizeinfo() const override;
+
     /// @copydoc Array::min()
     double min() const override;
 
@@ -539,6 +542,7 @@ class TransposeNode : public ArrayNode {
     const std::unique_ptr<ssize_t[]> strides_;
     const bool contiguous_;
     const ValuesInfo values_info_;
+    const SizeInfo sizeinfo_;
 
     ArrayNode* predeccesor_check_(ArrayNode* array_ptr) const;
     Update convert_predecessor_update_(Update update) const;

--- a/dwave/optimization/src/nodes/manipulation.cpp
+++ b/dwave/optimization/src/nodes/manipulation.cpp
@@ -250,7 +250,8 @@ void BroadcastToNode::propagate(State& state) const {
             assert(([&]() {
                        std::vector<ssize_t> multi_index =
                                unravel_index(update.index, array_ptr_->shape());
-                       multi_index.insert(multi_index.begin(), this->ndim() - array_ptr_->ndim(), 0);
+                       multi_index.insert(multi_index.begin(), this->ndim() - array_ptr_->ndim(),
+                                          0);
                        const ssize_t assert_index = ravel_multi_index(multi_index, this->shape());
                        return assert_index == index;
                    })() &&
@@ -1478,7 +1479,8 @@ TransposeNode::TransposeNode(ArrayNode* array_ptr)
           shape_(reverse_span_helper(array_ptr->shape(), ndim_)),
           strides_(reverse_span_helper(array_ptr->strides(), ndim_)),
           contiguous_(is_contiguous(ndim_, shape_.get(), strides_.get())),
-          values_info_(array_ptr) {
+          values_info_(array_ptr),
+          sizeinfo_(array_ptr_->sizeinfo()) {
     add_predecessor(array_ptr);
 }
 
@@ -1510,6 +1512,8 @@ std::span<const ssize_t> TransposeNode::strides() const {
 ssize_t TransposeNode::size() const { return array_ptr_->size(); }
 
 ssize_t TransposeNode::size(const State& state) const { return array_ptr_->size(state); }
+
+SizeInfo TransposeNode::sizeinfo() const { return this->sizeinfo_; }
 
 double TransposeNode::min() const { return values_info_.min; }
 

--- a/releasenotes/notes/transposenode_cache_sizeinfo-effe6b1f270ad9f9.yaml
+++ b/releasenotes/notes/transposenode_cache_sizeinfo-effe6b1f270ad9f9.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    `Transpose` symbol can infer its size from its predecessor's size.

--- a/tests/cpp/nodes/test_manipulation.cpp
+++ b/tests/cpp/nodes/test_manipulation.cpp
@@ -1622,6 +1622,7 @@ TEST_CASE("TransposeNode") {
             CHECK(transpose_ptr->max() == vec_ptr->max());
             CHECK(transpose_ptr->integral() == vec_ptr->integral());
             CHECK(transpose_ptr->contiguous() == vec_ptr->contiguous());
+            CHECK(transpose_ptr->sizeinfo() == vec_ptr->sizeinfo());
         }
 
         WHEN("We initialize an empty state") {
@@ -1697,6 +1698,7 @@ TEST_CASE("TransposeNode") {
             CHECK(transpose_ptr->max() == i_ptr->max());
             CHECK(transpose_ptr->integral() == i_ptr->integral());
             CHECK(transpose_ptr->contiguous() == i_ptr->contiguous());
+            CHECK(transpose_ptr->sizeinfo() == i_ptr->sizeinfo());
         }
 
         WHEN("We initialize a state") {
@@ -1756,6 +1758,7 @@ TEST_CASE("TransposeNode") {
             CHECK(transpose_ptr->max() == array_ptr->max());
             CHECK(transpose_ptr->integral() == array_ptr->integral());
             CHECK(!transpose_ptr->contiguous());
+            CHECK(transpose_ptr->sizeinfo() == array_ptr->sizeinfo());
         }
 
         WHEN("We initialize a state") {
@@ -1822,6 +1825,7 @@ TEST_CASE("TransposeNode") {
             CHECK_THAT(transpose_ptr_2->strides(), RangeEquals({24, 8}));
             CHECK_THAT(transpose_ptr_2->shape(), RangeEquals({2, 3}));
             CHECK(transpose_ptr_2->contiguous());
+            CHECK(transpose_ptr_2->sizeinfo() == array_ptr->sizeinfo());
         }
 
         WHEN("We initialize a state") {
@@ -1894,6 +1898,7 @@ TEST_CASE("TransposeNode") {
             CHECK(transpose_ptr->max() == array_ptr->max());
             CHECK(transpose_ptr->integral() == array_ptr->integral());
             CHECK(!transpose_ptr->contiguous());
+            CHECK(transpose_ptr->sizeinfo() == array_ptr->sizeinfo());
         }
 
         WHEN("We initialize a state") {

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -3959,6 +3959,14 @@ class TestTranspose(utils.SymbolTests):
         with model.lock():
             yield transpose
 
+    def test_sizeinfo_awareness(self):
+        model = Model()
+        s = model.set(10)
+        x = dwave.optimization.symbols.Transpose(s)
+        y = dwave.optimization.symbols.Transpose(s)
+        # only possible if both `x` and `y` know their size is derived from `s`.
+        z = y + x
+
     def test(self):
         from dwave.optimization.symbols import Transpose
         model = Model()


### PR DESCRIPTION
`TransposeNode` is now smart enough to know that it's size is simply it's predecessor's size.