### PR TITLE
Add example of iterating over DisjointLists symbol to docstring

### DIFF
--- a/dwave/optimization/model.py
+++ b/dwave/optimization/model.py
@@ -381,12 +381,15 @@ class Model(_Graph):
             10
             >>> disjoint_lists.num_disjoint_lists()
             4
-            >>> for i, disjoint_list in enumerate(disjoint_lists):
-            ...     print(f"Type of element {i}: {type(disjoint_list)}")
-            Type of element 0: <class 'dwave.optimization.symbols.collections.DisjointList'>
-            Type of element 1: <class 'dwave.optimization.symbols.collections.DisjointList'>
-            Type of element 2: <class 'dwave.optimization.symbols.collections.DisjointList'>
-            Type of element 3: <class 'dwave.optimization.symbols.collections.DisjointList'>
+            >>> with model.lock():
+            ...    model.states.resize(1)
+            ...    disjoint_lists.set_state(0, [[0, 1, 2], [3, 5, 6], [4], [7, 8, 9]])
+            ...    for i, disjoint_list in enumerate(disjoint_lists):
+            ...        print(f"Element {i}: {disjoint_list.state(0)}")
+            Element 0: [0. 1. 2.]
+            Element 1: [3. 5. 6.]
+            Element 2: [4.]
+            Element 3: [7. 8. 9.]
         """
         from dwave.optimization.symbols import DisjointLists, DisjointList  # avoid circular import
         disjoint_lists = DisjointLists(self, primary_set_size, num_disjoint_lists)

--- a/dwave/optimization/symbols/collections.pyx
+++ b/dwave/optimization/symbols/collections.pyx
@@ -399,7 +399,7 @@ cdef class DisjointLists(Symbol):
     """Disjoint-lists decision-variable symbol.
 
     See Also:
-        :meth:`~dwave.optimization.model.Model.disjoint_lists`: equivalent method.
+        :meth:`~dwave.optimization.model.Model.disjoint_lists_symbol`: equivalent method.
     """
     def __init__(
         self, _Graph model, Py_ssize_t primary_set_size, Py_ssize_t num_disjoint_lists


### PR DESCRIPTION
Adds an example of iterating over DisjointLists symbol to the `model.disjoint_lists_symbol` docstring, similar to what is in the `DisjointLists.set_state` docstring