### PR TITLE
"State-less" descendants

### DIFF
--- a/dwave/optimization/include/dwave-optimization/graph.hpp
+++ b/dwave/optimization/include/dwave-optimization/graph.hpp
@@ -96,6 +96,7 @@ class Graph {
     // Get the descendants of the source nodes, that is, all nodes that can be visited starting from
     // the sources.
     static std::vector<const Node*> descendants(State& state, std::vector<const Node*> sources);
+    std::vector<const Node*> descendants(std::vector<const Node*> sources) const;
 
     /// Call propagate on every `Node` in the `Graph`.
     void propagate(State& state) const;

--- a/dwave/optimization/src/graph.cpp
+++ b/dwave/optimization/src/graph.cpp
@@ -237,6 +237,28 @@ std::vector<const Node*> Graph::descendants(State& state, std::vector<const Node
     return sources;
 }
 
+std::vector<const Node*> Graph::descendants(std::vector<const Node*> sources) const {
+    // Same as above, just need a vector to mark visited nodes
+    std::vector<bool> marks(num_nodes(), false);
+
+    // Perform BFS starting from the sources
+    ssize_t exploration_index = 0;
+    while (exploration_index != static_cast<ssize_t>(sources.size())) {
+        const Node* n_ptr = sources[exploration_index++];
+        for (Node* m_ptr : n_ptr->successors()) {
+            if (marks[m_ptr->topological_index()]) continue;
+
+            marks[m_ptr->topological_index()] = true;
+            sources.emplace_back(m_ptr);
+        }
+    }
+    // Sort the nodes according to topological number
+    std::sort(sources.begin(), sources.end(), [](const Node* n_ptr, const Node* m_ptr) {
+        return n_ptr->topological_index() < m_ptr->topological_index();
+    });
+    return sources;
+}
+
 void Graph::propagate(State& state) const {
     std::ranges::for_each(nodes(), [&state](const auto& ptr) { ptr->propagate(state); });
 }

--- a/dwave/optimization/src/graph.cpp
+++ b/dwave/optimization/src/graph.cpp
@@ -238,25 +238,11 @@ std::vector<const Node*> Graph::descendants(State& state, std::vector<const Node
 }
 
 std::vector<const Node*> Graph::descendants(std::vector<const Node*> sources) const {
-    // Same as above, just need a vector to mark visited nodes
-    std::vector<bool> marks(num_nodes(), false);
-
-    // Perform BFS starting from the sources
-    ssize_t exploration_index = 0;
-    while (exploration_index != static_cast<ssize_t>(sources.size())) {
-        const Node* n_ptr = sources[exploration_index++];
-        for (Node* m_ptr : n_ptr->successors()) {
-            if (marks[m_ptr->topological_index()]) continue;
-
-            marks[m_ptr->topological_index()] = true;
-            sources.emplace_back(m_ptr);
-        }
+    State state;
+    for (ssize_t i = 0, stop = num_nodes(); i < stop; ++i) {
+        state.emplace_back(std::make_unique<NodeStateData>());
     }
-    // Sort the nodes according to topological number
-    std::sort(sources.begin(), sources.end(), [](const Node* n_ptr, const Node* m_ptr) {
-        return n_ptr->topological_index() < m_ptr->topological_index();
-    });
-    return sources;
+    return descendants(state, sources);
 }
 
 void Graph::propagate(State& state) const {

--- a/tests/cpp/test_graph.cpp
+++ b/tests/cpp/test_graph.cpp
@@ -13,6 +13,7 @@
 //    limitations under the License.
 
 #include "catch2/catch_test_macros.hpp"
+#include "catch2/matchers/catch_matchers_all.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes.hpp"
 
@@ -227,17 +228,19 @@ TEST_CASE("Graph constructors, assignment operators, and swapping") {
     }
 }
 
-TEST_CASE("Graph::commit(), Graph::propagate(), and Graph::revert") {
+TEST_CASE("Graph::commit(), Graph::descendants(), Graph::propagate(), and Graph::revert") {
+    auto graph = Graph();
+    auto x_ptr = graph.emplace_node<BinaryNode>();
+    auto y_ptr = graph.emplace_node<BinaryNode>();
+    auto z_ptr = graph.emplace_node<AddNode>(x_ptr, y_ptr);
+    graph.set_objective(z_ptr);
+    auto state = graph.initialize_state();
+
+    SECTION("Find descendants") {
+        auto descendants = graph.descendants({x_ptr});
+        CHECK_THAT(descendants, Catch::Matchers::RangeEquals(std::vector<Node*>{x_ptr, z_ptr}));
+    }
     SECTION("Propagate all") {
-        auto graph = Graph();
-
-        auto x_ptr = graph.emplace_node<BinaryNode>();
-        auto y_ptr = graph.emplace_node<BinaryNode>();
-        auto z_ptr = graph.emplace_node<AddNode>(x_ptr, y_ptr);
-        graph.set_objective(z_ptr);
-
-        auto state = graph.initialize_state();
-
         CHECK(x_ptr->view(state).front() == 0);
         CHECK(y_ptr->view(state).front() == 0);
         CHECK(z_ptr->view(state).front() == 0);


### PR DESCRIPTION
Add overload of `Graph::descendants` that does not require a `state` argument