### PR TITLE
Address implicit conversion warning

### DIFF
--- a/tests/cpp/nodes/test_manipulation.cpp
+++ b/tests/cpp/nodes/test_manipulation.cpp
@@ -1554,7 +1554,7 @@ TEST_CASE("SizeNode") {
 
                 // these should always be true
                 CHECK(len.min() >= 0);
-                CHECK(len.max() <= std::numeric_limits<ssize_t>::max());
+                CHECK(len.max() <= static_cast<double>(std::numeric_limits<ssize_t>::max()));
 
                 // These should be one less than the min/max of the original set node
                 CHECK(len.min() == 1.0);


### PR DESCRIPTION
Previously got the following warning:
```
warning: implicit conversion from 'type' (aka 'long') to 'double'
changes value from 9223372036854775807 to 9223372036854775808
[-Wimplicit-const-int-float-conversion] 1557 |
CHECK(len.max() <= std::numeric_limits<ssize_t>::max());
```