### PR TITLE
Remove `BinaryNode::set()` and `unset()`

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
@@ -220,12 +220,6 @@ class BinaryNode : public IntegerNode {
 
     // Flip the value (0 -> 1 or 1 -> 0) at index i in the given state.
     void flip(State& state, ssize_t i) const;
-
-    // Set the value at index i to `true` in the given state.
-    void set(State& state, ssize_t i) const;
-
-    // Set the at index i to `false` in the given state.
-    void unset(State& state, ssize_t i) const;
 };
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/src/nodes/numbers.cpp
+++ b/dwave/optimization/src/nodes/numbers.cpp
@@ -336,20 +336,4 @@ void BinaryNode::flip(State& state, ssize_t i) const {
     ptr->set(i, !ptr->get(i));
 }
 
-void BinaryNode::set(State& state, ssize_t i) const {
-    // We expect the set to obey the index-wise bounds.
-    assert(upper_bound(i) == 1.0);
-    // Assert that i is a valid index occurs in data_ptr->set().
-    // Set occurs IFF `value` != buffer[i] .
-    data_ptr<ArrayNodeStateData>(state)->set(i, 1.0);
-}
-
-void BinaryNode::unset(State& state, ssize_t i) const {
-    // We expect the set to obey the index-wise bounds.
-    assert(lower_bound(i) == 0.0);
-    // Assert that i is a valid index occurs in data_ptr->set().
-    // Set occurs IFF `value` != buffer[i] .
-    data_ptr<ArrayNodeStateData>(state)->set(i, 0.0);
-}
-
 }  // namespace dwave::optimization

--- a/releasenotes/notes/remove_binarynode_set_and_unset_methods-cd0aa37e0b2a27ed.yaml
+++ b/releasenotes/notes/remove_binarynode_set_and_unset_methods-cd0aa37e0b2a27ed.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    Remove mutate methods `set()` and `unset()` from `BinaryNode`.

--- a/tests/cpp/nodes/test_numbers.cpp
+++ b/tests/cpp/nodes/test_numbers.cpp
@@ -106,42 +106,42 @@ TEST_CASE("BinaryNode") {
                     vec_d[i] = !vec_d[i];
                 }
 
-                THEN("Elments are flipped properly") {
+                THEN("Elements are flipped properly") {
                     CHECK_THAT(ptr->view(state), RangeEquals(vec_d));
                     CHECK(static_cast<ssize_t>(ptr->diff(state).size()) == ptr->size());
                 }
             }
 
-            WHEN("We set all the elements") {
+            WHEN("We set all the elements to 1") {
                 int set_count_ground = 0;
                 for (int i = 0, stop = ptr->size(); i < stop; ++i) {
                     // Note, index-wise bounds are all [0,1]
-                    ptr->set(state, i);
+                    ptr->set_value(state, i, 1);
                     set_count_ground += !vec_d[i];
                 }
 
-                THEN("Elments are set properly") {
+                THEN("Elements are set properly") {
                     CHECK(std::ranges::all_of(ptr->view(state), [](int i) { return i == 1; }));
                 }
 
-                THEN("The number of elements set equals the number of initially unset elements") {
+                THEN("The number of effective changes is correct") {
                     CHECK(static_cast<int>(ptr->diff(state).size()) == set_count_ground);
                 }
             }
 
-            WHEN("We unset all the elements") {
+            WHEN("We set all the elements to 0") {
                 int unset_count_ground = 0;
                 for (int i = 0, stop = ptr->size(); i < stop; ++i) {
                     // Note, index-wise bounds are all [0,1]
-                    ptr->unset(state, i);
+                    ptr->set_value(state, i, 0);
                     unset_count_ground += vec_d[i];
                 }
 
-                THEN("Elments are unset properly") {
+                THEN("Elements are set properly") {
                     CHECK(std::ranges::all_of(ptr->view(state), [](int i) { return i == 0; }));
                 }
 
-                THEN("The number of elements unset equals the number of initially set elements") {
+                THEN("The number of effective changes is correct") {
                     CHECK(static_cast<int>(ptr->diff(state).size()) == unset_count_ground);
                 }
             }
@@ -231,45 +231,45 @@ TEST_CASE("BinaryNode") {
                     vec_d[i] = !vec_d[i];
                 }
 
-                THEN("Elments are flipped properly") {
+                THEN("Elements are flipped properly") {
                     CHECK(std::ranges::equal(ptr->view(state), vec_d));
                 }
 
-                THEN("The number of elements set equals the number of initially unset elements") {
+                THEN("The number of effective flips is correct") {
                     CHECK(static_cast<ssize_t>(ptr->diff(state).size()) == ptr->size());
                 }
             }
 
-            WHEN("We set all the elements") {
+            WHEN("We set all the elements to 1") {
                 int set_count_ground = 0;
                 for (int i = 0, stop = ptr->size(); i < stop; ++i) {
                     // Note, index-wise bounds are all [0,1]
-                    ptr->set(state, i);
+                    ptr->set_value(state, i, 1);
                     set_count_ground += !vec_d[i];
                 }
 
-                THEN("Elments are set properly") {
+                THEN("Elements are set properly") {
                     CHECK(std::ranges::all_of(ptr->view(state), [](int i) { return i == 1; }));
                 }
 
-                THEN("The number of elements set equals the number of initially unset elements") {
+                THEN("The number of effective changes is correct") {
                     CHECK(static_cast<int>(ptr->diff(state).size()) == set_count_ground);
                 }
             }
 
-            WHEN("We unset all the elements") {
+            WHEN("We set all the elements to 0") {
                 int unset_count_ground = 0;
                 for (int i = 0, stop = ptr->size(); i < stop; ++i) {
                     // Note, index-wise bounds are all [0,1]
-                    ptr->unset(state, i);
+                    ptr->set_value(state, i, 0);
                     unset_count_ground += vec_d[i];
                 }
 
-                THEN("Elments are unset properly") {
+                THEN("Elements are set properly") {
                     CHECK(std::ranges::all_of(ptr->view(state), [](int i) { return i == 0; }));
                 }
 
-                THEN("The number of elements unset equals the number of initially set elements") {
+                THEN("The number of effective changes is correct") {
                     CHECK(static_cast<int>(ptr->diff(state).size()) == unset_count_ground);
                 }
             }
@@ -332,10 +332,10 @@ TEST_CASE("BinaryNode") {
             }
         }
 
-        AND_WHEN("We set the state at the indices using set()") {
+        AND_WHEN("We set the state at the indices using set_value()") {
             auto state = graph.initialize_state();
             // Note, index-wise bounds are [[0,1], [0,1], [1,1]]
-            bnode_ptr->set(state, 1);
+            bnode_ptr->set_value(state, 1, 1);
 
             THEN("The values at index 0 and 1 are correct") {
                 CHECK(bnode_ptr->get_value(state, 0) == 0.0);  // Default value
@@ -352,17 +352,17 @@ TEST_CASE("BinaryNode") {
                     CHECK(bnode_ptr->get_value(state, 1) == 0.0);
                 }
 
-                THEN("We can perform an unset()") {
+                THEN("We set an index to 0") {
                     // Note, index-wise bounds are [[0,1], [0,1], [1,1]]
                     CHECK(bnode_ptr->get_value(state, 1) == 1.0);
-                    bnode_ptr->unset(state, 1);
+                    bnode_ptr->set_value(state, 1, 0);
                     CHECK(bnode_ptr->get_value(state, 1) == 0.0);
                 }
 
-                THEN("We can perform a set()") {
+                THEN("We set an index to 1") {
                     // Note, index-wise bounds are [[0,1], [0,1], [1,1]]
                     CHECK(bnode_ptr->get_value(state, 0) == 0.0);
-                    bnode_ptr->set(state, 0);
+                    bnode_ptr->set_value(state, 0, 1);
                     CHECK(bnode_ptr->get_value(state, 0) == 1.0);
                 }
 

--- a/tests/cpp/nodes/test_quadratic_model.cpp
+++ b/tests/cpp/nodes/test_quadratic_model.cpp
@@ -129,7 +129,7 @@ TEST_CASE("QuadraticModelNode") {
             WHEN("We update the elements of the binary node and propagate") {
                 // Change to {1, 1, 1, 1, 1}
                 for (int i = 0; i < binary_node_ptr->size(); i++) {
-                    binary_node_ptr->set(state, i);
+                    binary_node_ptr->set_value(state, i, 1);
                 }
 
                 binary_node_ptr->propagate(state);
@@ -143,7 +143,7 @@ TEST_CASE("QuadraticModelNode") {
                     // Change to {0, 0, 0, 0, 0}
                     binary_node_ptr->commit(state);
                     for (int i = 0; i < binary_node_ptr->size(); i++) {
-                        binary_node_ptr->unset(state, i);
+                        binary_node_ptr->set_value(state, i, 0);
                     }
 
                     binary_node_ptr->propagate(state);
@@ -158,10 +158,10 @@ TEST_CASE("QuadraticModelNode") {
             WHEN("We update the binary node many times with relatively small effective change") {
                 // Change to {1, 1, 1, 1, 1}
                 for (int i = 0; i < binary_node_ptr->size(); i++) {
-                    binary_node_ptr->set(state, i);
-                    binary_node_ptr->unset(state, i);
+                    binary_node_ptr->set_value(state, i, 1);
+                    binary_node_ptr->set_value(state, i, 0);
                     binary_node_ptr->flip(state, i);
-                    binary_node_ptr->set(state, i);
+                    binary_node_ptr->set_value(state, i, 1);
                 }
 
                 binary_node_ptr->propagate(state);


### PR DESCRIPTION
This functionality is already supported by `IntegerNode::set_value()`. It would be convenient to have fewer mutate methods to check when adding new features.