### PR TITLE
Basic indexing: only write to full cache on commit when necessary

### DIFF
--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -1329,8 +1329,10 @@ void BasicIndexingNode::commit(State& state) const {
     auto node_data = data_ptr<BasicIndexingNodeData>(state);
     node_data->diff.clear();
     node_data->previous_size = size(state);
-    // reset the cache
-    node_data->full_cache_.assign(begin(state), end(state));
+    if (dynamic() && axis0_slice_.value().start < 0) {
+        // Reset the cache (used in the case of a negative start and dynamic array)
+        node_data->full_cache_.assign(begin(state), end(state));
+    }
 }
 
 std::span<const Update> BasicIndexingNode::diff(const State& state) const {


### PR DESCRIPTION
`BasicIndexingNode::commit()` was copying the full output state to a cache on every commit, even though this is only necessary for a specific indexing case.