### PR TITLE
Update xcode version in CI from 26.4.0 to 26.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
 
   python-macOS:
     macos:
-      xcode: 26.4.0  # latest as of April 2026
+      xcode: 26.4.1  # latest as of April 2026
 
     parameters:
       cibw-arch:
@@ -229,7 +229,7 @@ jobs:
 
   cpp-macOS:
     macos:
-      xcode: 26.4.0  # latest as of April 2026
+      xcode: 26.4.1  # latest as of April 2026
 
     steps:
       - checkout


### PR DESCRIPTION
I cannot find any public announcements but it seems like they yanked 26.4.0 support when [they released 26.4.1](https://discuss.circleci.com/t/xcode-26-4-1-released/54542). Our fault for using the latest :smile: 


See https://github.com/dwavesystems/dwave-optimization/pull/522#issuecomment-4314605230
Previous xcode change: https://github.com/dwavesystems/dwave-optimization/pull/520