### PR TITLE
Remove unneeded files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include pyproject.toml
-recursive-include dwave/optimization/include *.hpp *.h
-recursive-include dwave/optimization/src *.hpp *.cpp
-recursive-include dwave/optimization *.pyx *.pxd

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[pycodestyle]
-max-line-length = 100


### PR DESCRIPTION
`MANIFEST.in` is not needed for meson builds.
`setup.cfg` was just for pycodestyle support. They're weird about `pyproject.toml` support but maintaining a separate file just for that tools seems unnecessary.
`.gitmodules` is harmless, but we don't currently have any submodules and are likely to use meson subpackages where possible in the future so I think it's fine to drop.