### PR TITLE
Add minimal interval implementation

### DIFF
--- a/dwave/optimization/include/dwave-optimization/interval.hpp
+++ b/dwave/optimization/include/dwave-optimization/interval.hpp
@@ -175,7 +175,7 @@ requires(not std::is_const_v<T>) class interval {
         return out;
     }
 
-    bool contains(DType auto&& value) const {
+    bool contains(auto&& value) const {
         // dev note: numeric issues
         return infimum_ <= value and value <= supremum_;
     }
@@ -218,7 +218,7 @@ requires(not std::is_const_v<T>) class interval {
         return 0;
     }
     std::ptrdiff_t size() const noexcept requires(std::integral<T>) {
-        if (supremum_ >= infimum_) return static_cast<std::ptrdiff_t>(supremum_) - infimum_;
+        if (supremum_ >= infimum_) return static_cast<std::ptrdiff_t>(supremum_) - infimum_ + 1;
         return 0;
     }
 

--- a/dwave/optimization/include/dwave-optimization/interval.hpp
+++ b/dwave/optimization/include/dwave-optimization/interval.hpp
@@ -1,0 +1,90 @@
+// Copyright 2026 D-Wave
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+
+#include "dwave-optimization/common.hpp"  // for ssize_t
+#include "dwave-optimization/typing.hpp"
+
+namespace dwave::optimization {
+
+// dev note: true interval arithmetic requires "outward" rounding. For right
+// now I am ignoring this in the interest of getting an API solidified, but
+// we should support it ASAP. I have marked the places we need to make changes
+// with a "numeric issues" comment for easy future reference.
+
+template <DType T>
+class interval {
+ public:
+    interval() noexcept : infimum(1), supremum(0) {};
+
+    // todo: note
+    interval(T value) noexcept : interval(value, value) {}
+
+    interval(T infimum, T supremum) noexcept : infimum(infimum), supremum(supremum) {}
+
+    static interval unbounded() {
+        using limits = std::numeric_limits<T>;
+        if constexpr (limits::has_infinity) {
+            return interval(-limits::infinity(), limits::infinity());
+        } else {
+            return interval(limits::lowest(), limits::max());
+        }
+    }
+
+    /// An interval evalutes to `true` if it is not empty.
+    explicit operator bool() const noexcept { return infimum <= supremum; }
+
+    bool operator==(const interval& rhs) const {
+        return infimum == rhs.infimum and supremum == rhs.supremum;
+    }
+
+    interval& operator|=(DType auto scalar) { return *this |= interval<decltype(scalar)>(scalar); }
+    template <DType U>
+    interval& operator|=(const interval<U>& rhs) {
+        // dev note: numeric issues
+        if constexpr (std::floating_point<U> and std::integral<T>) {
+            infimum = std::min<T>(infimum, std::floor(rhs.infimum));
+            supremum = std::max<T>(supremum, std::ceil(rhs.supremum));
+        } else {
+            infimum = std::min<T>(infimum, rhs.infimum);
+            supremum = std::max<T>(supremum, rhs.supremum);
+        }
+        return *this;
+    }
+
+    bool contains(auto&& value) const {
+        // dev note: numeric issues
+        return infimum <= value and value <= supremum;
+    }
+
+    /// The size of the interval is the max(supremum - infimum, 0)
+    double size() const noexcept requires(std::floating_point<T>) {
+        if (supremum >= infimum) return static_cast<double>(supremum) - infimum;
+        return 0;
+    }
+    std::ptrdiff_t size() const noexcept requires(std::integral<T>) {
+        if (supremum >= infimum) return static_cast<std::ptrdiff_t>(supremum) - infimum;
+        return 0;
+    }
+
+    T infimum;
+    T supremum;
+};
+
+}  // namespace dwave::optimization

--- a/dwave/optimization/include/dwave-optimization/interval.hpp
+++ b/dwave/optimization/include/dwave-optimization/interval.hpp
@@ -43,8 +43,7 @@ requires(not std::is_const_v<T>) class interval {
     interval& operator=(const interval&) = default;
     interval& operator=(interval&&) = default;
 
-    // todo: note the difference between interval<int>(.5, .5) and interval<int>(interval<float>(.5,
-    // .5))
+    // todo: note the difference between interval<int>(.5, .5) and union operations
     explicit interval(T value) noexcept : interval(value, value) {}
     interval(T infimum, T supremum) noexcept : infimum_(infimum), supremum_(supremum) {
         assert(not std::isnan(infimum_) and "infimum must not be nan");
@@ -52,24 +51,17 @@ requires(not std::is_const_v<T>) class interval {
     }
 
     template <DType U>
-    explicit(std::integral<T> != std::integral<U>) interval(const interval<U>& rhs) : interval() {
-        *this = rhs;
-    }
+    explicit(std::integral<T> != std::integral<U>) interval(const interval<U>& rhs) :
+        infimum_(rhs.infimum()), supremum_(rhs.supremum()) {}
     template <DType U>
-    explicit(std::integral<T> != std::integral<U>) interval(interval<U>&& rhs) : interval() {
-        *this = rhs;
-    }
+    explicit(std::integral<T> != std::integral<U>) interval(interval<U>&& rhs) :
+        infimum_(rhs.infimum()), supremum_(rhs.supremum()) {}
 
     template <DType U>
     interval& operator=(const interval<U>& rhs) {
         // dev note: numeric issues
-        if constexpr (std::floating_point<U> and std::integral<T>) {
-            infimum_ = std::floor(rhs.infimum());
-            supremum_ = std::ceil(rhs.supremum());
-        } else {
-            infimum_ = rhs.infimum();
-            supremum_ = rhs.supremum();
-        }
+        infimum_ = rhs.infimum();
+        supremum_ = rhs.supremum();
         return *this;
     }
 
@@ -80,6 +72,44 @@ requires(not std::is_const_v<T>) class interval {
         return infimum_ == rhs.infimum_ and supremum_ == rhs.supremum_;
     }
 
+    interval operator-() const { return interval(-supremum_, -infimum_); }
+
+    template <DType U>
+    interval& operator&=(const interval<U>& rhs) {
+        // if lhs is an empty interval than the result is also empty
+        if (not static_cast<bool>(*this)) return *this;
+
+        // if rhs is an empty interval, then set lhs to rhs (making lhs empty)
+        if (not static_cast<bool>(rhs)) {
+            // if lhs is an empty interval, then set it to rhs (which we know is not empty)
+            if constexpr (std::integral<T> and std::floating_point<U>) {
+                infimum_ = std::floor(rhs.infimum());
+                supremum_ = std::ceil(rhs.supremum());
+            } else {
+                infimum_ = rhs.infimum();
+                supremum_ = rhs.supremum();
+            }
+        } else {
+            // otherwise, adjust our interval to be the union
+            if constexpr (std::integral<T> and std::floating_point<U>) {
+                infimum_ = std::max<T>(infimum_, std::floor(rhs.infimum()));
+                supremum_ = std::min<T>(supremum_, std::ceil(rhs.supremum()));
+            } else {
+                infimum_ = std::max<T>(infimum_, rhs.infimum());
+                supremum_ = std::min<T>(supremum_, rhs.supremum());
+            }
+        }
+
+        return *this;
+    }
+
+    template <DType U>
+    friend auto operator&(interval lhs, const interval<U>& rhs) {
+        interval<decltype(T() + U())> out(std::move(lhs));
+        out &= rhs;
+        return out;
+    }
+
     interval& operator|=(DType auto scalar) { return *this |= interval<decltype(scalar)>(scalar); }
 
     template <DType U>
@@ -87,18 +117,27 @@ requires(not std::is_const_v<T>) class interval {
         // if rhs is an empty interval, do nothing
         if (not static_cast<bool>(rhs)) return *this;
 
-        // if lhs is an empty interval, then set it to rhs (which we know is not empty)
-        if (not static_cast<bool>(*this)) return *this = rhs;
-
-        // otherwise, adjust our interval to also contain the other.
         // dev note: numeric issues
-        if constexpr (std::integral<T> and std::floating_point<U>) {
-            infimum_ = std::min<T>(infimum_, std::floor(rhs.infimum()));
-            supremum_ = std::max<T>(supremum_, std::ceil(rhs.supremum()));
+        if (not static_cast<bool>(*this)) {
+            // if lhs is an empty interval, then set it to rhs (which we know is not empty)
+            if constexpr (std::integral<T> and std::floating_point<U>) {
+                infimum_ = std::floor(rhs.infimum());
+                supremum_ = std::ceil(rhs.supremum());
+            } else {
+                infimum_ = rhs.infimum();
+                supremum_ = rhs.supremum();
+            }
         } else {
-            infimum_ = std::min<T>(infimum_, rhs.infimum());
-            supremum_ = std::max<T>(supremum_, rhs.supremum());
+            // otherwise, adjust our interval to also contain the other.
+            if constexpr (std::integral<T> and std::floating_point<U>) {
+                infimum_ = std::min<T>(infimum_, std::floor(rhs.infimum()));
+                supremum_ = std::max<T>(supremum_, std::ceil(rhs.supremum()));
+            } else {
+                infimum_ = std::min<T>(infimum_, rhs.infimum());
+                supremum_ = std::max<T>(supremum_, rhs.supremum());
+            }
         }
+
         return *this;
     }
 
@@ -163,6 +202,15 @@ requires(not std::is_const_v<T>) class interval {
     }
 
     const T& infimum() const noexcept { return infimum_; }
+
+    static interval nonnegative() {
+        using limits = std::numeric_limits<T>;
+        if constexpr (limits::has_infinity) {
+            return interval(0, limits::infinity());
+        } else {
+            return interval(0, limits::max());
+        }
+    }
 
     /// The size of the interval is the max(supremum_ - infimum_, 0)
     double size() const noexcept requires(std::floating_point<T>) {

--- a/dwave/optimization/include/dwave-optimization/interval.hpp
+++ b/dwave/optimization/include/dwave-optimization/interval.hpp
@@ -17,6 +17,8 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <iosfwd>
+#include <type_traits>
 
 #include "dwave-optimization/common.hpp"  // for ssize_t
 #include "dwave-optimization/typing.hpp"
@@ -24,19 +26,155 @@
 namespace dwave::optimization {
 
 // dev note: true interval arithmetic requires "outward" rounding. For right
-// now I am ignoring this in the interest of getting an API solidified, but
+// now I am ignoring this and focusing on getting the API solidified, but
 // we should support it ASAP. I have marked the places we need to make changes
 // with a "numeric issues" comment for easy future reference.
 
 template <DType T>
-class interval {
+requires(not std::is_const_v<T>) class interval {
  public:
-    interval() noexcept : infimum(1), supremum(0) {};
+    // by default we construct an empty interval
+    interval() = default;
 
-    // todo: note
-    interval(T value) noexcept : interval(value, value) {}
+    // rule of five stuff all works the way you'd expect
+    interval(const interval&) = default;
+    interval(interval&&) = default;
+    ~interval() = default;
+    interval& operator=(const interval&) = default;
+    interval& operator=(interval&&) = default;
 
-    interval(T infimum, T supremum) noexcept : infimum(infimum), supremum(supremum) {}
+    // todo: note the difference between interval<int>(.5, .5) and interval<int>(interval<float>(.5,
+    // .5))
+    explicit interval(T value) noexcept : interval(value, value) {}
+    interval(T infimum, T supremum) noexcept : infimum_(infimum), supremum_(supremum) {
+        assert(not std::isnan(infimum_) and "infimum must not be nan");
+        assert(not std::isnan(supremum_) and "supremum must not be nan");
+    }
+
+    template <DType U>
+    explicit(std::integral<T> != std::integral<U>) interval(const interval<U>& rhs) : interval() {
+        *this = rhs;
+    }
+    template <DType U>
+    explicit(std::integral<T> != std::integral<U>) interval(interval<U>&& rhs) : interval() {
+        *this = rhs;
+    }
+
+    template <DType U>
+    interval& operator=(const interval<U>& rhs) {
+        // dev note: numeric issues
+        if constexpr (std::floating_point<U> and std::integral<T>) {
+            infimum_ = std::floor(rhs.infimum());
+            supremum_ = std::ceil(rhs.supremum());
+        } else {
+            infimum_ = rhs.infimum();
+            supremum_ = rhs.supremum();
+        }
+        return *this;
+    }
+
+    /// An interval evalutes to `true` if it is not empty.
+    explicit operator bool() const noexcept { return infimum_ <= supremum_; }
+
+    bool operator==(const interval& rhs) const {
+        return infimum_ == rhs.infimum_ and supremum_ == rhs.supremum_;
+    }
+
+    interval& operator|=(DType auto scalar) { return *this |= interval<decltype(scalar)>(scalar); }
+
+    template <DType U>
+    interval& operator|=(const interval<U>& rhs) {
+        // if rhs is an empty interval, do nothing
+        if (not static_cast<bool>(rhs)) return *this;
+
+        // if lhs is an empty interval, then set it to rhs (which we know is not empty)
+        if (not static_cast<bool>(*this)) return *this = rhs;
+
+        // otherwise, adjust our interval to also contain the other.
+        // dev note: numeric issues
+        if constexpr (std::integral<T> and std::floating_point<U>) {
+            infimum_ = std::min<T>(infimum_, std::floor(rhs.infimum()));
+            supremum_ = std::max<T>(supremum_, std::ceil(rhs.supremum()));
+        } else {
+            infimum_ = std::min<T>(infimum_, rhs.infimum());
+            supremum_ = std::max<T>(supremum_, rhs.supremum());
+        }
+        return *this;
+    }
+
+    template <DType U>
+    friend auto operator|(interval lhs, const interval<U>& rhs) {
+        interval<decltype(T() + U())> out(std::move(lhs));
+        out |= rhs;
+        return out;
+    }
+
+    template <DType U>
+    interval& operator+=(const interval<U>& rhs) {
+        // if lhs is an empty interval than the result is also empty
+        if (not static_cast<bool>(*this)) return *this;
+
+        // if rhs is an empty interval, then set lhs to rhs (making lhs empty)
+        if (not static_cast<bool>(rhs)) return *this = rhs;
+
+        // neither are empty! So add everything
+        // dev note: numeric issues
+        if constexpr (std::integral<T> and std::floating_point<U>) {
+            infimum_ += std::floor(rhs.infimum());
+            supremum_ += std::ceil(rhs.supremum());
+        } else {
+            infimum_ += rhs.infimum();
+            supremum_ += rhs.supremum();
+        }
+        return *this;
+    }
+
+    template <DType U>
+    friend auto operator+(interval lhs, const interval<U>& rhs) {
+        interval<decltype(T() + U())> out(std::move(lhs));
+        out += rhs;
+        return out;
+    }
+
+    bool contains(DType auto&& value) const {
+        // dev note: numeric issues
+        return infimum_ <= value and value <= supremum_;
+    }
+
+    // Implement the get() to support the structured binding. It's not OK to
+    // overload std functions so this needs to be found via ADL.
+    // Unfortunately that prevents interval from satisfying the tuple-like
+    // concept. Why can't we have nice things C++?? See note below for
+    // more details.
+    template <std::size_t I>
+    friend const T& get(const interval& in) noexcept requires(I <= 1) {
+        if constexpr (I == 0) return in.infimum_;
+        if constexpr (I == 1) return in.supremum_;
+    }
+    template <std::size_t I>
+    friend T&& get(interval&& in) noexcept requires(I <= 1) {
+        if constexpr (I == 0) return std::move(in.infimum_);
+        if constexpr (I == 1) return std::move(in.supremum_);
+    }
+    template <std::size_t I>
+    friend const T&& get(const interval&& in) noexcept requires(I <= 1) {
+        if constexpr (I == 0) return std::move(in.infimum_);
+        if constexpr (I == 1) return std::move(in.supremum_);
+    }
+
+    const T& infimum() const noexcept { return infimum_; }
+
+    /// The size of the interval is the max(supremum_ - infimum_, 0)
+    double size() const noexcept requires(std::floating_point<T>) {
+        if (supremum_ >= infimum_) return static_cast<double>(supremum_) - infimum_;
+        return 0;
+    }
+    std::ptrdiff_t size() const noexcept requires(std::integral<T>) {
+        if (supremum_ >= infimum_) return static_cast<std::ptrdiff_t>(supremum_) - infimum_;
+        return 0;
+    }
+
+    const T& supremum() const noexcept { return supremum_; }
 
     static interval unbounded() {
         using limits = std::numeric_limits<T>;
@@ -47,44 +185,34 @@ class interval {
         }
     }
 
-    /// An interval evalutes to `true` if it is not empty.
-    explicit operator bool() const noexcept { return infimum <= supremum; }
-
-    bool operator==(const interval& rhs) const {
-        return infimum == rhs.infimum and supremum == rhs.supremum;
-    }
-
-    interval& operator|=(DType auto scalar) { return *this |= interval<decltype(scalar)>(scalar); }
-    template <DType U>
-    interval& operator|=(const interval<U>& rhs) {
-        // dev note: numeric issues
-        if constexpr (std::floating_point<U> and std::integral<T>) {
-            infimum = std::min<T>(infimum, std::floor(rhs.infimum));
-            supremum = std::max<T>(supremum, std::ceil(rhs.supremum));
-        } else {
-            infimum = std::min<T>(infimum, rhs.infimum);
-            supremum = std::max<T>(supremum, rhs.supremum);
-        }
-        return *this;
-    }
-
-    bool contains(auto&& value) const {
-        // dev note: numeric issues
-        return infimum <= value and value <= supremum;
-    }
-
-    /// The size of the interval is the max(supremum - infimum, 0)
-    double size() const noexcept requires(std::floating_point<T>) {
-        if (supremum >= infimum) return static_cast<double>(supremum) - infimum;
-        return 0;
-    }
-    std::ptrdiff_t size() const noexcept requires(std::integral<T>) {
-        if (supremum >= infimum) return static_cast<std::ptrdiff_t>(supremum) - infimum;
-        return 0;
-    }
-
-    T infimum;
-    T supremum;
+ private:
+    T infimum_ = 1;
+    T supremum_ = 0;
 };
 
+std::ostream& operator<<(std::ostream& os, const interval<std::int64_t>& rhs);
+std::ostream& operator<<(std::ostream& os, const interval<double>& rhs);
+
 }  // namespace dwave::optimization
+
+// Do a lot of convoluted stuff to support structured binding.
+// Unfortunately this doesn't support the full tuple-like concept that would let us work
+// out of the box with a lot of nice methods.
+// See https://stackoverflow.com/questions/79660771/stdapply-to-a-custom-tuple-like-type
+// See https://lists.isocpp.org/std-discussion/2021/09/1438.php
+namespace std {
+
+template <dwave::optimization::DType T>
+struct tuple_size<dwave::optimization::interval<T>> : integral_constant<size_t, 2> {};
+
+template <dwave::optimization::DType T>
+struct tuple_element<0, dwave::optimization::interval<T>> {
+    using type = T;
+};
+
+template <dwave::optimization::DType T>
+struct tuple_element<1, dwave::optimization::interval<T>> {
+    using type = T;
+};
+
+}  // namespace std

--- a/dwave/optimization/src/functional_.hpp
+++ b/dwave/optimization/src/functional_.hpp
@@ -97,14 +97,21 @@ template <DType T>
 struct Abs : UnaryFunctionMixin<Abs<T>> {
     using result_type = T;
 
-    constexpr T operator()(DType auto&& x) const noexcept {
-        return std::abs(x);
-    }
+    constexpr T operator()(DType auto&& x) const noexcept { return std::abs(x); }
 
-    template<DType U>
+    template <DType U>
     interval<T> operator()(const interval<U>& in) const noexcept {
         // first get the absolute value, using the type of the input interval
         return static_cast<interval<T>>((-in | in) & interval<U>::nonnegative());
+    }
+
+    template <DType U>
+    interval<T> inverse(const interval<U>& in) const noexcept {
+        assert(
+            (interval<U>::nonnegative() | in) == in and
+            "argument for inverse of abs should be nonnegative"
+        );
+        return in | -in;
     }
 };
 

--- a/dwave/optimization/src/functional_.hpp
+++ b/dwave/optimization/src/functional_.hpp
@@ -24,8 +24,11 @@
 
 #pragma once
 
+#include <cmath>
+
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/functional.hpp"
+#include "dwave-optimization/interval.hpp"
 #include "dwave-optimization/typing.hpp"
 
 namespace dwave::optimization::functional_ {
@@ -84,6 +87,24 @@ struct BinaryFunctionMixin {
     template <std::ranges::range Range, DType T>
     static auto reduce(Range&& range, T initial) {
         return reduce(std::forward<Range>(range), std::optional<T>(initial));
+    }
+};
+
+template <typename UnaryFunction>
+struct UnaryFunctionMixin {};
+
+template <DType T>
+struct Abs : UnaryFunctionMixin<Abs<T>> {
+    using result_type = T;
+
+    constexpr T operator()(DType auto&& x) const noexcept {
+        return std::abs(x);
+    }
+
+    template<DType U>
+    interval<T> operator()(const interval<U>& in) const noexcept {
+        // first get the absolute value, using the type of the input interval
+        return static_cast<interval<T>>((-in | in) & interval<U>::nonnegative());
     }
 };
 

--- a/dwave/optimization/src/interval.cpp
+++ b/dwave/optimization/src/interval.cpp
@@ -13,7 +13,18 @@
 //    limitations under the License.
 
 #include "dwave-optimization/interval.hpp"
+#include "dwave-optimization/common.hpp"  // for ssize_t
+#include "dwave-optimization/typing.hpp"
+
+#include <iostream>
 
 namespace dwave::optimization {
+
+std::ostream& operator<<(std::ostream& os, const interval<std::int64_t>& rhs) {
+    return os << "[" << rhs.infimum() << ", " << rhs.supremum() << "]";
+}
+std::ostream& operator<<(std::ostream& os, const interval<double>& rhs) {
+    return os << "[" << rhs.infimum() << ", " << rhs.supremum() << "]";
+}
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/src/interval.cpp
+++ b/dwave/optimization/src/interval.cpp
@@ -1,0 +1,19 @@
+// Copyright 2026 D-Wave
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include "dwave-optimization/interval.hpp"
+
+namespace dwave::optimization {
+
+}  // namespace dwave::optimization

--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,7 @@ dwave_optimization_src = [
     'dwave/optimization/src/array.cpp',
     'dwave/optimization/src/fraction.cpp',
     'dwave/optimization/src/graph.cpp',
+    'dwave/optimization/src/interval.cpp',
     'dwave/optimization/src/simplex.cpp',
 ]
 

--- a/releasenotes/notes/feature-cpp-interval-232c1ed8d06f7fec.yaml
+++ b/releasenotes/notes/feature-cpp-interval-232c1ed8d06f7fec.yaml
@@ -1,0 +1,3 @@
+---
+features:
+  - Add C++ ``interval<T>()`` class for interval arithmetic.

--- a/tests/cpp/meson.build
+++ b/tests/cpp/meson.build
@@ -35,6 +35,7 @@ tests_all = executable(
         'test_functional.cpp',
         'test_functional_.cpp',
         'test_graph.cpp',
+        'test_interval.cpp',
         'test_iterators.cpp',
         'test_simplex.cpp',
         'test_type_list.cpp',

--- a/tests/cpp/test_functional_.cpp
+++ b/tests/cpp/test_functional_.cpp
@@ -12,12 +12,42 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_template_test_macros.hpp"
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/generators/catch_generators.hpp"
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include "dwave-optimization/interval.hpp"
 #include "functional_.hpp"
 
 namespace dwave::optimization::functional_ {
+
+TEST_CASE("Abs") {
+    SECTION(".operator(...)") {
+        SECTION("Abs<double>") {
+            const Abs<double> op;
+
+            CHECK(op(1.5) == 1.5);
+            CHECK(op(-1) == 1);
+            CHECK(op(static_cast<const double>(1.5)) == 1.5);
+
+            CHECK(op(interval(-1, 1)) == interval<double>(0, 1));
+            CHECK(op(interval(-12.5, 1.)) == interval<double>(0, 12.5));
+        }
+        SECTION("Abs<int>") {
+            const Abs<int> op;
+
+            CHECK(op(1.999) == 1);  // going to int truncates
+            CHECK(op(-1.999) == 1);  // going to int truncates
+            CHECK(op(-1) == 1);
+            CHECK(op(static_cast<const double>(-1.9999999)) == 1);
+
+            CHECK(op(interval(-1, 1)) == interval<int>(0, 1));
+
+            // because abs itself truncates, we want our bounds to also be truncated
+            CHECK(op(interval(-12.5, 1.)) == interval<int>(0, 12));
+        }
+    }
+}
 
 TEST_CASE("Add") {
     static_assert(Add<double>::associative);

--- a/tests/cpp/test_interval.cpp
+++ b/tests/cpp/test_interval.cpp
@@ -1,0 +1,69 @@
+// Copyright 2026 D-Wave
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include "dwave-optimization/interval.hpp"
+
+namespace dwave::optimization {
+
+TEMPLATE_TEST_CASE(
+    "interval",
+    "",
+    float,
+    double,
+    bool,
+    std::int8_t,
+    std::int16_t,
+    std::int32_t,
+    std::int64_t
+) {
+    GIVEN("a default-constructed interval") {
+        auto in = interval<TestType>();
+
+        CHECK(not static_cast<bool>(in));
+        CHECK(in.size() == 0);
+    }
+
+    GIVEN("an interval containing only the value 0") {
+        auto in = interval<TestType>(0);
+
+        CHECK(static_cast<bool>(in));
+        CHECK(in.size() == 0);
+        CHECK(in.contains(0));
+        CHECK(not in.contains(1));
+        CHECK(not in.contains(std::numeric_limits<double>::epsilon()));
+
+        auto [inf, sup] = in;
+        STATIC_REQUIRE(std::same_as<decltype(inf), TestType>);
+        STATIC_REQUIRE(std::same_as<decltype(sup), TestType>);
+        CHECK(inf == 0);
+        CHECK(sup == 0);
+    }
+}
+
+TEST_CASE("interval") {
+    SECTION("union operations") {
+        auto in = interval<int>();
+        in |= .5;
+        CHECK(in == interval<int>(0, 1));
+        in |= -5;
+        CHECK(in == interval<int>(-5, 1));
+    }
+    // CHECK((interval<int>() | static_cast<float>(.5)) == interval<float>(0, 1));
+}
+
+}  // namespace dwave::optimization

--- a/tests/cpp/test_interval.cpp
+++ b/tests/cpp/test_interval.cpp
@@ -15,8 +15,11 @@
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/interval.hpp"
+
+using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 
@@ -46,24 +49,73 @@ TEMPLATE_TEST_CASE(
         CHECK(in.contains(0));
         CHECK(not in.contains(1));
         CHECK(not in.contains(std::numeric_limits<double>::epsilon()));
+    }
 
-        auto [inf, sup] = in;
-        STATIC_REQUIRE(std::same_as<decltype(inf), TestType>);
-        STATIC_REQUIRE(std::same_as<decltype(sup), TestType>);
-        CHECK(inf == 0);
-        CHECK(sup == 0);
+    SECTION("get<...>(interval)") {
+        SECTION("const rvalue") {
+            const interval<TestType> in{0, 1};
+            const TestType&& inf = get<0>(std::move(in));
+            CHECK(inf == 0);
+        }
+    }
+
+    SECTION("printing") {
+        std::stringstream ss;
+        ss << interval<TestType>(0, 1);
+        CHECK(ss.str() == "[0, 1]");
+    }
+
+    SECTION("structured binding") {
+        SECTION("const reference") {
+            auto in = interval<TestType>(0, 1);
+            const auto& [inf, sup] = in;
+            STATIC_REQUIRE(std::same_as<decltype(inf), const TestType>);
+            STATIC_REQUIRE(std::same_as<decltype(sup), const TestType>);
+            CHECK(inf == 0);
+            CHECK(sup == 1);
+        }
+
+        SECTION("rvalue") {
+            auto in = interval<TestType>(0, 1);
+            auto [inf, sup] = in;
+            STATIC_REQUIRE(std::same_as<decltype(inf), TestType>);
+            STATIC_REQUIRE(std::same_as<decltype(sup), TestType>);
+            CHECK(inf == 0);
+            CHECK(sup == 1);
+        }
+
+        SECTION("const rvalue") {
+            const auto in = interval<TestType>(0, 1);
+
+            auto&& [inf, sup] = in;
+            STATIC_REQUIRE(std::same_as<decltype(inf), const TestType>);
+            STATIC_REQUIRE(std::same_as<decltype(sup), const TestType>);
+            CHECK(inf == 0);
+            CHECK(sup == 1);
+        }
     }
 }
 
 TEST_CASE("interval") {
-    SECTION("union operations") {
+    SECTION("addition") {
+        CHECK((interval<int>(0, 3) + interval<float>(.5, .5)) == interval<float>(.5, 3.5));
+    }
+
+    SECTION("union") {
         auto in = interval<int>();
         in |= .5;
         CHECK(in == interval<int>(0, 1));
         in |= -5;
         CHECK(in == interval<int>(-5, 1));
+
+        CHECK((interval<int>(0, 1) | interval<double>(.5, 1.5)) == interval<double>(0, 1.5));
+        CHECK((interval<float>(0, 1) | interval<double>(.5, 1.5)) == interval<double>(0, 1.5));
+        CHECK((interval<float>(0, 1.5) | interval<bool>(0, 1)) == interval<float>(0, 1.5));
     }
-    // CHECK((interval<int>() | static_cast<float>(.5)) == interval<float>(0, 1));
+
+    SECTION("Copy construction") {
+        CHECK(interval<int>(interval<float>(.2, .8)) == interval<int>(0, 1));
+    }
 }
 
 }  // namespace dwave::optimization

--- a/tests/cpp/test_interval.cpp
+++ b/tests/cpp/test_interval.cpp
@@ -114,7 +114,8 @@ TEST_CASE("interval") {
     }
 
     SECTION("Copy construction") {
-        CHECK(interval<int>(interval<float>(.2, .8)) == interval<int>(0, 1));
+        // truncates
+        CHECK(interval<int>(interval<float>(.2, .8)) == interval<int>(0, 0));
     }
 }
 


### PR DESCRIPTION
This does not add [outward rounding](https://standards.ieee.org/ieee/1788/4431/), which we definitely want/need in the long run. But I wanted to get a minimal API up.

Next step is to replace or integrate into the existing `ValuesInfo` class, maybe with something like `std::variant<interval<double>, interval<ssize_t>>`.

#### AI Generation Disclosure
No AI used.