### PR TITLE
Update clang-format to organize #include statements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,7 +40,7 @@ PenaltyReturnTypeOnItsOwnLine: 1000
 IncludeCategories:
   - Regex: '<[^.>]+>'
     Priority: 1
-  - Regex: '<catch2.+\.hpp>'
+  - Regex: '<(catch2|cblas).*\.(h|hpp)>'
     Priority: 3
   - Regex: '<.+\.(h|hpp)>'
     Priority: 2

--- a/.clang-format
+++ b/.clang-format
@@ -29,4 +29,21 @@ RequiresClausePosition: SingleLine
 
 # Prevent putting the return type on its own line most of the time
 PenaltyReturnTypeOnItsOwnLine: 1000
+
+# Our header order should be
+# 1) The "main" include, i.e., the corresponding .hpp file to a .cpp file. clang-format
+#    handles that separately
+# 2) All includes with <> without an extension, i.e., the std
+# 3) All includes with <> with an extension, e.g., #include <sys/types.h>
+# 4) 3rd party includes, i.e., catch2
+# 5) All includes with ""
+IncludeCategories:
+  - Regex: '<[^.>]+>'
+    Priority: 1
+  - Regex: '<catch2.+\.hpp>'
+    Priority: 3
+  - Regex: '<.+\.(h|hpp)>'
+    Priority: 2
+  - Regex: '".+"'
+    Priority: 4
 ...

--- a/dwave/optimization/src/nodes/linear_algebra.cpp
+++ b/dwave/optimization/src/nodes/linear_algebra.cpp
@@ -18,15 +18,15 @@
 #include <array>
 #include <ranges>
 
+#if __has_include(<openblas_config.h>) and __has_include(<cblas.h>)
+#include <cblas.h>
+#define HAS_BLAS_
+#endif
+
 #include "../functional_.hpp"
 #include "_state.hpp"
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/state.hpp"
-
-#if __has_include(<openblas_config.h>) and __has_include(<cblas.h>)
-#include "cblas.h"
-#define HAS_BLAS_
-#endif
 
 namespace dwave::optimization {
 

--- a/tests/cpp/nodes/indexing/test_advanced.cpp
+++ b/tests/cpp/nodes/indexing/test_advanced.cpp
@@ -12,9 +12,10 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/generators/catch_generators.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"

--- a/tests/cpp/nodes/indexing/test_basic.cpp
+++ b/tests/cpp/nodes/indexing/test_basic.cpp
@@ -12,9 +12,10 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/generators/catch_generators.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"

--- a/tests/cpp/nodes/test_binaryop.cpp
+++ b/tests/cpp/nodes/test_binaryop.cpp
@@ -12,9 +12,10 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_template_test_macros.hpp"
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_range_equals.hpp"
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/binaryop.hpp"
 #include "dwave-optimization/nodes/collections.hpp"

--- a/tests/cpp/nodes/test_collections.cpp
+++ b/tests/cpp/nodes/test_collections.cpp
@@ -15,8 +15,9 @@
 #include <set>
 #include <unordered_set>
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/testing.hpp"

--- a/tests/cpp/nodes/test_constants.cpp
+++ b/tests/cpp/nodes/test_constants.cpp
@@ -12,8 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
 

--- a/tests/cpp/nodes/test_flow.cpp
+++ b/tests/cpp/nodes/test_flow.cpp
@@ -14,13 +14,13 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
-#include <dwave-optimization/graph.hpp>
-#include <dwave-optimization/nodes/collections.hpp>
-#include <dwave-optimization/nodes/flow.hpp>
-#include <dwave-optimization/nodes/numbers.hpp>
-#include <dwave-optimization/nodes/testing.hpp>
 
+#include "dwave-optimization/graph.hpp"
+#include "dwave-optimization/nodes/collections.hpp"
+#include "dwave-optimization/nodes/flow.hpp"
 #include "dwave-optimization/nodes/indexing.hpp"
+#include "dwave-optimization/nodes/numbers.hpp"
+#include "dwave-optimization/nodes/testing.hpp"
 
 using Catch::Matchers::RangeEquals;
 

--- a/tests/cpp/nodes/test_inputs.cpp
+++ b/tests/cpp/nodes/test_inputs.cpp
@@ -14,13 +14,14 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
-#include <dwave-optimization/graph.hpp>
-#include <dwave-optimization/nodes/collections.hpp>
-#include <dwave-optimization/nodes/constants.hpp>
-#include <dwave-optimization/nodes/flow.hpp>
-#include <dwave-optimization/nodes/inputs.hpp>
-#include <dwave-optimization/nodes/numbers.hpp>
-#include <dwave-optimization/nodes/testing.hpp>
+
+#include "dwave-optimization/graph.hpp"
+#include "dwave-optimization/nodes/collections.hpp"
+#include "dwave-optimization/nodes/constants.hpp"
+#include "dwave-optimization/nodes/flow.hpp"
+#include "dwave-optimization/nodes/inputs.hpp"
+#include "dwave-optimization/nodes/numbers.hpp"
+#include "dwave-optimization/nodes/testing.hpp"
 
 using Catch::Matchers::RangeEquals;
 

--- a/tests/cpp/nodes/test_interpolation.cpp
+++ b/tests/cpp/nodes/test_interpolation.cpp
@@ -12,7 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
+#include <catch2/catch_test_macros.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
 #include "dwave-optimization/nodes/interpolation.hpp"

--- a/tests/cpp/nodes/test_lambda.cpp
+++ b/tests/cpp/nodes/test_lambda.cpp
@@ -13,17 +13,17 @@
 //    limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <dwave-optimization/graph.hpp>
-#include <dwave-optimization/nodes/collections.hpp>
-#include <dwave-optimization/nodes/constants.hpp>
-#include <dwave-optimization/nodes/flow.hpp>
-#include <dwave-optimization/nodes/inputs.hpp>
-#include <dwave-optimization/nodes/lambda.hpp>
-#include <dwave-optimization/nodes/numbers.hpp>
-#include <dwave-optimization/nodes/reduce.hpp>
-#include <dwave-optimization/nodes/testing.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
 
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include "dwave-optimization/graph.hpp"
+#include "dwave-optimization/nodes/collections.hpp"
+#include "dwave-optimization/nodes/constants.hpp"
+#include "dwave-optimization/nodes/flow.hpp"
+#include "dwave-optimization/nodes/inputs.hpp"
+#include "dwave-optimization/nodes/lambda.hpp"
+#include "dwave-optimization/nodes/numbers.hpp"
+#include "dwave-optimization/nodes/reduce.hpp"
+#include "dwave-optimization/nodes/testing.hpp"
 
 namespace dwave::optimization {
 

--- a/tests/cpp/nodes/test_linear_algebra.cpp
+++ b/tests/cpp/nodes/test_linear_algebra.cpp
@@ -12,10 +12,11 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+#include <vector>
+
 #include <catch2/benchmark/catch_benchmark_all.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
-#include <vector>
 
 #include "dwave-optimization/nodes/binaryop.hpp"
 #include "dwave-optimization/nodes/collections.hpp"

--- a/tests/cpp/nodes/test_lp.cpp
+++ b/tests/cpp/nodes/test_lp.cpp
@@ -14,8 +14,9 @@
 
 #include <vector>
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_floating_point.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
 #include "dwave-optimization/nodes.hpp"
 
 using namespace Catch::Matchers;

--- a/tests/cpp/nodes/test_manipulation.cpp
+++ b/tests/cpp/nodes/test_manipulation.cpp
@@ -16,8 +16,9 @@
 #include <stdexcept>
 #include <vector>
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_range_equals.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
 #include "dwave-optimization/nodes/binaryop.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"

--- a/tests/cpp/nodes/test_naryop.cpp
+++ b/tests/cpp/nodes/test_naryop.cpp
@@ -12,8 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_template_test_macros.hpp"
-#include "catch2/catch_test_macros.hpp"
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/binaryop.hpp"
 #include "dwave-optimization/nodes/collections.hpp"

--- a/tests/cpp/nodes/test_numbers.cpp
+++ b/tests/cpp/nodes/test_numbers.cpp
@@ -16,10 +16,11 @@
 #include <initializer_list>
 #include <optional>
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
-#include "catch2/matchers/catch_matchers_range_equals.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"
 

--- a/tests/cpp/nodes/test_quadratic_model.cpp
+++ b/tests/cpp/nodes/test_quadratic_model.cpp
@@ -12,8 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"

--- a/tests/cpp/nodes/test_reduce.cpp
+++ b/tests/cpp/nodes/test_reduce.cpp
@@ -12,10 +12,11 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_template_test_macros.hpp"
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/generators/catch_generators.hpp"
-#include "catch2/matchers/catch_matchers_range_equals.hpp"
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"

--- a/tests/cpp/nodes/test_set_routines.cpp
+++ b/tests/cpp/nodes/test_set_routines.cpp
@@ -12,10 +12,11 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
+#include <vector>
+
 #include <catch2/benchmark/catch_benchmark_all.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_all.hpp>
-#include <vector>
 
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"

--- a/tests/cpp/nodes/test_softmax.cpp
+++ b/tests/cpp/nodes/test_softmax.cpp
@@ -12,8 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_floating_point.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
 #include "dwave-optimization/nodes/constants.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"
 #include "dwave-optimization/nodes/softmax.hpp"

--- a/tests/cpp/nodes/test_unaryop.cpp
+++ b/tests/cpp/nodes/test_unaryop.cpp
@@ -12,9 +12,10 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_template_test_macros.hpp"
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_range_equals.hpp"
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -14,8 +14,9 @@
 
 #include <sstream>
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/state.hpp"
 

--- a/tests/cpp/test_double_kahan.cpp
+++ b/tests/cpp/test_double_kahan.cpp
@@ -12,8 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
 #include "double_kahan.hpp"
 
 using Catch::Matchers::RangeEquals;

--- a/tests/cpp/test_fraction.cpp
+++ b/tests/cpp/test_fraction.cpp
@@ -12,8 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
 #include "dwave-optimization/fraction.hpp"
 
 using Catch::Matchers::RangeEquals;

--- a/tests/cpp/test_functional.cpp
+++ b/tests/cpp/test_functional.cpp
@@ -12,8 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_template_test_macros.hpp"
-#include "catch2/catch_test_macros.hpp"
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+
 #include "dwave-optimization/functional.hpp"
 
 namespace dwave::optimization::functional {

--- a/tests/cpp/test_functional_.cpp
+++ b/tests/cpp/test_functional_.cpp
@@ -12,9 +12,10 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_template_test_macros.hpp"
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/generators/catch_generators.hpp"
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
 #include "functional_.hpp"
 
 namespace dwave::optimization::functional_ {

--- a/tests/cpp/test_graph.cpp
+++ b/tests/cpp/test_graph.cpp
@@ -12,8 +12,9 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes.hpp"
 

--- a/tests/cpp/test_iterators.cpp
+++ b/tests/cpp/test_iterators.cpp
@@ -18,12 +18,13 @@
 #include <random>
 #include <vector>
 
-#include "catch2/benchmark/catch_benchmark_all.hpp"
-#include "catch2/catch_template_test_macros.hpp"
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/generators/catch_generators.hpp"
-#include "catch2/generators/catch_generators_random.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include <catch2/benchmark/catch_benchmark_all.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/generators/catch_generators_random.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
 #include "dwave-optimization/iterators.hpp"
 
 using Catch::Generators::RandomIntegerGenerator;

--- a/tests/cpp/test_simplex.cpp
+++ b/tests/cpp/test_simplex.cpp
@@ -14,8 +14,9 @@
 
 #include <algorithm>
 
-#include "catch2/catch_test_macros.hpp"
-#include "catch2/matchers/catch_matchers_all.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
 #include "simplex.hpp"
 
 namespace dwave::optimization {

--- a/tests/cpp/test_type_list.cpp
+++ b/tests/cpp/test_type_list.cpp
@@ -12,7 +12,8 @@
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
 
-#include "catch2/catch_test_macros.hpp"
+#include <catch2/catch_test_macros.hpp>
+
 #include "dwave-optimization/type_list.hpp"
 
 namespace dwave::optimization {


### PR DESCRIPTION
We were kind of all over the place with our `#include` statements. This PR adopts the convention that `""` includes are for internal libraries. All "third-party" `#include`s now use `<>`. I also added some categories so we get nice readable separation.

#### AI Generation Disclosure
No AI used. I found all the clang-format options via stackoverflow like god intended.
