### PR TITLE
feat: Get start index from the node

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
@@ -242,7 +242,7 @@ class BasicIndexingNode : public ArrayNode {
     // Infer the indices used to create the node.
     std::vector<slice_or_int> infer_indices() const;
 
-    // Compute the flattened source indicices into the source array this view points to.
+    // Compute the flattened source indices into the source array this view points to.
     // For static (non-dynamic arrays)
     std::vector<ssize_t> flat_source_indices() const;
 

--- a/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
@@ -242,6 +242,10 @@ class BasicIndexingNode : public ArrayNode {
     // Infer the indices used to create the node.
     std::vector<slice_or_int> infer_indices() const;
 
+    // Compute the flattened source indicices into the source array this view points to.
+    // For static (non-dynamic arrays)
+    std::vector<ssize_t> flat_source_indices() const;
+
  private:
     // Private constructor using an intermediate object
     struct IndexParser_;

--- a/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
@@ -242,9 +242,7 @@ class BasicIndexingNode : public ArrayNode {
     // Infer the indices used to create the node.
     std::vector<slice_or_int> infer_indices() const;
 
-    // Compute the flattened source indices into the source array this view points to.
-    // For static (non-dynamic arrays)
-    std::vector<ssize_t> flat_source_indices() const;
+    ssize_t start() const { return start_; }
 
  private:
     // Private constructor using an intermediate object

--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -1520,7 +1520,7 @@ std::vector<BasicIndexingNode::slice_or_int> BasicIndexingNode::infer_indices() 
 }
 
 std::vector<ssize_t> BasicIndexingNode::flat_source_indices() const {
-    assert(!dynamic() && "does not support dynamic arrays")
+    assert(!dynamic() && "does not support dynamic arrays");
     const ssize_t view_ndim = ndim();
     const auto view_shape = shape();
     const auto view_strides = strides();

--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -1519,48 +1519,6 @@ std::vector<BasicIndexingNode::slice_or_int> BasicIndexingNode::infer_indices() 
     return indices;
 }
 
-std::vector<ssize_t> BasicIndexingNode::flat_source_indices() const {
-    assert(!dynamic() && "does not support dynamic arrays");
-    const ssize_t view_ndim = ndim();
-    const auto view_shape = shape();
-    const auto view_strides = strides();
-    const ssize_t total_size = size();
-
-    if (total_size == 0){
-        return {};
-    }
-
-    std::vector<ssize_t> flat_indices;
-    flat_indices.reserve(total_size);
-
-    // Convert strides from bytes to element counts
-    std::vector<ssize_t> elem_strides(view_ndim);
-    for(ssize_t d = 0; d < view_ndim; ++d){
-        elem_strides[d] = view_strides[d] / static_cast<ssize_t>(sizeof(double));
-    }
-
-    //Multi-dimensional index counter (row major iteration)
-    std::vector<ssize_t> multi_idx(view_ndim);
-
-    for (ssize_t i = 0; i < total_size; ++i){
-        ssize_t offset = start_;
-        for (ssize_t d = 0; d < view_ndim; ++d){
-            offset += multi_idx[d] * elem_strides[d];
-        }
-        flat_indices.push_back(offset);
-
-        // Increment multi idx in row major order (last dim first)
-        for (ssize_t d = view_ndim - 1; d >= 0; --d){
-            ++multi_idx[d];
-            if(multi_idx[d] < view_shape[d]){
-                break;
-            }
-            multi_idx[d] = 0;
-        }
-    }
-    return flat_indices;
-}
-
 void BasicIndexingNode::initialize_state(State& state) const {
     // we're a view, so we don't really need state other than for the updates
     emplace_data_ptr<BasicIndexingNodeData>(state, this);

--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -1519,6 +1519,48 @@ std::vector<BasicIndexingNode::slice_or_int> BasicIndexingNode::infer_indices() 
     return indices;
 }
 
+std::vector<ssize_t> BasicIndexingNode::flat_source_indices() const {
+    assert(!dynamic() && "does not support dynamic arrays")
+    const ssize_t view_ndim = ndim();
+    const auto view_shape = shape();
+    const auto view_strides = strides();
+    const ssize_t total_size = size();
+
+    if (total_size == 0){
+        return {};
+    }
+
+    std::vector<ssize_t> flat_indices;
+    flat_indices.reserve(total_size);
+
+    // Convert strides from bytes to element counts
+    std::vector<ssize_t> elem_strides(view_ndim);
+    for(ssize_t d = 0; d < view_ndim; ++d){
+        elem_strides[d] = view_strides[d] / static_cast<ssize_t>(sizeof(double));
+    }
+
+    //Multi-dimensional index counter (row major iteration)
+    std::vector<ssize_t> multi_idx(view_ndim);
+
+    for (ssize_t i = 0; i < total_size; ++i){
+        ssize_t offset = start_;
+        for (ssize_t d = 0; d < view_ndim; ++d){
+            offset += multi_idx[d] * elem_strides[d];
+        }
+        flat_indices.push_back(offset);
+
+        // Increment multi idx in row major order (last dim first)
+        for (ssize_t d = view_ndim - 1; d >= 0; --d){
+            ++multi_idx[d];
+            if(multi_idx[d] < view_shape[d]){
+                break;
+            }
+            multi_idx[d] = 0;
+        }
+    }
+    return flat_indices;
+}
+
 void BasicIndexingNode::initialize_state(State& state) const {
     // we're a view, so we don't really need state other than for the updates
     emplace_data_ptr<BasicIndexingNodeData>(state, this);

--- a/releasenotes/notes/add-basic-indexing-node-start-index-e8e32c6bb1a8f67c.yaml
+++ b/releasenotes/notes/add-basic-indexing-node-start-index-e8e32c6bb1a8f67c.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added a new method to the basic indexing node that returns the start index,
+    representing the start of the view within the source array.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR conforms to our contributor guide.
https://github.com/dwavesystems/dwave-optimization/blob/main/CONTRIBUTING.rst
-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Implements a function that returns the start index (the start of the view in the source array)

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://github.com/dwavesystems/dwave-ocean-sdk/blob/master/docs/ocean/ai_policy.rst -->
No AI tools used.
