### PR TITLE
`IsInNode` StateData fixes

### DIFF
--- a/dwave/optimization/src/nodes/set_routines.cpp
+++ b/dwave/optimization/src/nodes/set_routines.cpp
@@ -183,7 +183,13 @@ void IsInNode::propagate(State& state) const {
     // that are new or fully removed
     for (const auto& [key, assignment] : node_data->add_or_rm_test_elements) {
         auto set_data_it = node_data->set_data.find(key);
-        // find() should be successful since we need to remove the index
+        // We erased this data in rm_index(), nothing to do.
+        if (set_data_it == node_data->set_data.end()) {
+            assert(not assignment);
+            continue;
+        }
+
+        // find() should be successful since we have not yet removed the index.
         assert(set_data_it != node_data->set_data.end());
         // Vector containing indices of `element` with value `key`
         const std::vector<ssize_t>& indices_vec = set_data_it->second.element_indices;

--- a/dwave/optimization/src/nodes/set_routines.cpp
+++ b/dwave/optimization/src/nodes/set_routines.cpp
@@ -78,7 +78,12 @@ double const* IsInNode::buff(const State& state) const {
     return data_ptr<IsInNodeData>(state)->buff();
 }
 
-void IsInNode::commit(State& state) const { data_ptr<IsInNodeData>(state)->commit(); }
+void IsInNode::commit(State &state) const {
+  IsInNodeData *node_data = data_ptr<IsInNodeData>(state);
+  node_data->element_updates.clear();
+  node_data->test_element_updates.clear();
+  node_data->commit();
+}
 
 std::span<const Update> IsInNode::diff(const State& state) const {
     return data_ptr<IsInNodeData>(state)->diff();

--- a/dwave/optimization/src/nodes/set_routines.cpp
+++ b/dwave/optimization/src/nodes/set_routines.cpp
@@ -78,11 +78,29 @@ double const* IsInNode::buff(const State& state) const {
     return data_ptr<IsInNodeData>(state)->buff();
 }
 
+bool set_data_is_correct(State& state, const Array *element_ptr, IsInNodeData& node_data) {
+    for (ssize_t i = 0, stop = element_ptr->size(state); i < stop; ++i) {
+        const double value = element_ptr->view(state)[i];
+
+        auto set_data_it = node_data.set_data.find(value);
+        if (set_data_it == node_data.set_data.end()) return false;
+
+        // Vector containing indices of `element` with value `key`
+        std::vector<ssize_t>& indices_vec = set_data_it->second.element_indices;
+        auto index_ptr = std::find(indices_vec.begin(), indices_vec.end(), i);
+        if (index_ptr == indices_vec.end()) return false;
+
+        if (*index_ptr != i) return false;
+    }
+    return true;
+}
+
 void IsInNode::commit(State &state) const {
-  IsInNodeData *node_data = data_ptr<IsInNodeData>(state);
-  node_data->element_updates.clear();
-  node_data->test_element_updates.clear();
-  node_data->commit();
+    IsInNodeData *node_data = data_ptr<IsInNodeData>(state);
+    node_data->element_updates.clear();
+    node_data->test_element_updates.clear();
+    node_data->commit();
+    assert(set_data_is_correct(state, element_ptr_, *node_data));
 }
 
 std::span<const Update> IsInNode::diff(const State& state) const {
@@ -209,6 +227,7 @@ void IsInNode::propagate(State& state) const {
     if (element_ptr_->size_diff(state) != 0) {
         node_data->trim_to(element_ptr_->size(state));
     }
+    assert(set_data_is_correct(state, element_ptr_, *node_data));
 }
 
 void IsInNode::revert(State& state) const {
@@ -245,6 +264,7 @@ void IsInNode::revert(State& state) const {
     node_data->element_updates.clear();
     node_data->test_element_updates.clear();
     node_data->revert();
+    assert(set_data_is_correct(state, element_ptr_, *node_data));
 }
 
 std::span<const ssize_t> IsInNode::shape(const State& state) const {

--- a/releasenotes/notes/isinnode_fix_commit_and_statedata-230276cf2c90369b.yaml
+++ b/releasenotes/notes/isinnode_fix_commit_and_statedata-230276cf2c90369b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+      ``IsInNode`` previously did not clear cached state data during
+      ``commit()``, causing future propagation-and-reverts to encounter
+      memory issues. The implementation has been fixed.

--- a/tests/cpp/nodes/test_set_routines.cpp
+++ b/tests/cpp/nodes/test_set_routines.cpp
@@ -184,5 +184,50 @@ TEST_CASE("IsInNode") {
             }
         }
     }
+
+    GIVEN("Two integer nodes and an isin node") {
+        auto i1_ptr = graph.emplace_node<IntegerNode>(2);
+        auto i2_ptr = graph.emplace_node<IntegerNode>(2);
+
+        auto isin_ptr = graph.emplace_node<IsInNode>(i1_ptr, i2_ptr);
+
+        graph.emplace_node<ArrayValidationNode>(isin_ptr);
+
+        WHEN("We initialize a state") {
+            auto state = graph.empty_state();
+            i1_ptr->initialize_state(state, {1, 3});
+            i2_ptr->initialize_state(state, {1, 2});
+
+            graph.initialize_state(state);
+
+            REQUIRE_THAT(isin_ptr->view(state), RangeEquals({1.0, 0.0}));
+
+            AND_WHEN("We make some changes to element integer node and propagate") {
+                i1_ptr->exchange(state, 0, 1); // should be [3, 1] now
+                REQUIRE(i1_ptr->view(state)[0] == 3.0);
+                REQUIRE(i1_ptr->view(state)[1] == 1.0);
+                graph.propagate(state);
+                REQUIRE_THAT(isin_ptr->view(state), RangeEquals({0.0, 1.0}));
+
+                AND_WHEN("We commit then revert") {
+                    graph.commit(state);
+                    graph.revert(state);
+
+                    AND_WHEN("We make some changes to element integer node and propagate") {
+                        i1_ptr->set_value(state, 0, 1); // should be [1, 1] now
+                        REQUIRE(i1_ptr->view(state)[0] == 1.0);
+                        REQUIRE(i1_ptr->view(state)[1] == 1.0);
+
+                        graph.propagate(state);
+
+                        THEN("The isin state is correct") {
+                            CHECK_THAT(isin_ptr->view(state), RangeEquals({1.0, 1.0}));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }
 }  // namespace dwave::optimization

--- a/tests/cpp/nodes/test_set_routines.cpp
+++ b/tests/cpp/nodes/test_set_routines.cpp
@@ -229,5 +229,40 @@ TEST_CASE("IsInNode") {
         }
     }
 
-}
+    GIVEN("Two dynamic set nodes and an isin node") {
+            auto set1_ptr = graph.emplace_node<SetNode>(6);
+            auto set2_ptr = graph.emplace_node<SetNode>(6);
+            auto isin_ptr = graph.emplace_node<IsInNode>(set1_ptr, set2_ptr);
+            graph.emplace_node<ArrayValidationNode>(isin_ptr);
+
+            CHECK(isin_ptr->size() == -1);
+
+            WHEN("We initialize a state") {
+                auto state = graph.initialize_state();
+
+                AND_WHEN("We assign the set nodes and propagate") {
+                    set1_ptr->assign(state, std::vector<double>{2});
+                    set2_ptr->assign(state, std::vector<double>{2});
+                    graph.propagate(state);
+
+                    THEN("The isin's state is correct") {
+                        CHECK_THAT(isin_ptr->view(state), RangeEquals({1.0}));
+                    }
+
+                    AND_WHEN("We commit, shrink the state of both set nodes, and propagate") {
+                        graph.commit(state);
+
+                        set1_ptr->shrink(state);
+                        set2_ptr->shrink(state);
+
+                        graph.propagate(state);
+
+                        THEN("The isin's state is correct") {
+                            CHECK(isin_ptr->view(state).size() == 0);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }  // namespace dwave::optimization

--- a/tests/cpp/nodes/test_set_routines.cpp
+++ b/tests/cpp/nodes/test_set_routines.cpp
@@ -211,6 +211,7 @@ TEST_CASE("IsInNode") {
 
                 AND_WHEN("We commit then revert") {
                     graph.commit(state);
+                    graph.propagate(state);
                     graph.revert(state);
 
                     AND_WHEN("We make some changes to element integer node and propagate") {


### PR DESCRIPTION
#### What does this implement/fix?
`IsInNode` previously did not clear cached state data during `commit()`, causing future propagation-and-reverts to encounter memory issues. The implementation has been fixed. 

#### AI Generation Disclosure

No AI tools used
