### PR TITLE
Enforce `const state` in `NumberNode::get_value()`

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
@@ -133,7 +133,7 @@ class NumberNode : public ArrayOutputMixin<ArrayNode>, public DecisionNode {
     ) const;
 
     // Return the value of index i in a given state.
-    double get_value(State& state, ssize_t i) const;
+    double get_value(const State& state, ssize_t i) const;
 
     // Lower bound of value in a given index.
     double lower_bound(ssize_t index) const;

--- a/dwave/optimization/src/nodes/numbers.cpp
+++ b/dwave/optimization/src/nodes/numbers.cpp
@@ -574,7 +574,7 @@ void NumberNode::exchange(
     }
 }
 
-double NumberNode::get_value(State& state, ssize_t i) const {
+double NumberNode::get_value(const State& state, ssize_t i) const {
     return data_ptr_<NumberNodeStateData>(state)->get(i);
 }
 

--- a/releasenotes/notes/numbernode_get_value_const_state-6b993d01b0cb4199.yaml
+++ b/releasenotes/notes/numbernode_get_value_const_state-6b993d01b0cb4199.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Modified ``NumberNode::get_value()`` arguments so that it accepts a ``const
+    state`` as opposed to a non-const ``state``.


### PR DESCRIPTION
Modified ``NumberNode::get_value()`` arguments so that it accepts a ``const state`` as opposed to a non-const ``state``.

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://github.com/dwavesystems/dwave-ocean-sdk/blob/master/docs/ocean/ai_policy.rst -->
No AI tools used.