### PR TITLE
Include `<cassert>` in `state.hpp`

### DIFF
--- a/dwave/optimization/include/dwave-optimization/state.hpp
+++ b/dwave/optimization/include/dwave-optimization/state.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <vector>
+#include <cassert>
 
 namespace dwave::optimization {
 

--- a/releasenotes/notes/fix-include-cassert-4f0065b9224b3711.yaml
+++ b/releasenotes/notes/fix-include-cassert-4f0065b9224b3711.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Include ``<cassert>`` in the ``state.hpp`` header.


### PR DESCRIPTION
Some compiler might not be smart enough to compile other files ahead and may incur in an error
```bash
error: ‘assert’ was not declared in this scope
```

#### AI Generation Disclosure
No AI tools used
