### PR TITLE
Allow permutation on sub-matrix

### DIFF
--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -1931,7 +1931,7 @@ std::span<const ssize_t> BasicIndexingNode::shape(const State& state) const {
 // PermutationNode ************************************************************
 
 PermutationNode::PermutationNode(ArrayNode* array_ptr, ArrayNode* order_ptr) :
-    ArrayOutputMixin(array_ptr->shape()),
+    ArrayOutputMixin({order_ptr->size(), order_ptr->size()}),
     array_ptr_(array_ptr),
     order_ptr_(order_ptr),
     values_info_(array_ptr_) {
@@ -1960,7 +1960,7 @@ PermutationNode::PermutationNode(ArrayNode* array_ptr, ArrayNode* order_ptr) :
         throw std::invalid_argument("order must be a 1d array");
     }
 
-    if (array_shape[0] != order_ptr_->size()) {
+    if (array_shape[0] < order_ptr_->size()) {
         throw std::invalid_argument("array shape and order size mismatch");
     }
     if (order_ptr_->max() > array_ptr_->size()) {

--- a/releasenotes/notes/submatrix-permutation-5736d18e59f225c8.yaml
+++ b/releasenotes/notes/submatrix-permutation-5736d18e59f225c8.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Allow constructing a submatrix permutation.

--- a/tests/cpp/meson.build
+++ b/tests/cpp/meson.build
@@ -9,6 +9,7 @@ tests_all = executable(
     [
         'nodes/indexing/test_advanced.cpp',
         'nodes/indexing/test_basic.cpp',
+        'nodes/indexing/test_permutation.cpp',
         'nodes/test_binaryop.cpp',
         'nodes/test_collections.cpp',
         'nodes/test_constants.cpp',

--- a/tests/cpp/nodes/indexing/test_permutation.cpp
+++ b/tests/cpp/nodes/indexing/test_permutation.cpp
@@ -1,0 +1,179 @@
+// Copyright 2026 D-Wave
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+
+#include "dwave-optimization/graph.hpp"
+#include "dwave-optimization/nodes/collections.hpp"
+#include "dwave-optimization/nodes/constants.hpp"
+#include "dwave-optimization/nodes/indexing.hpp"
+#include "dwave-optimization/nodes/testing.hpp"
+
+using Catch::Matchers::RangeEquals;
+
+namespace dwave::optimization {
+
+TEST_CASE("PermutationNode") {
+    auto graph = Graph();
+
+    GIVEN("A 2d NxN matrix and an order array") {
+        std::vector<double> values = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+        auto arr_ptr =
+            graph.emplace_node<ConstantNode>(values, std::initializer_list<ssize_t>{3, 3});
+
+        std::vector<double> order = {2, 1, 0};
+        auto i_ptr = graph.emplace_node<ConstantNode>(order);
+
+        WHEN("We permute the matrix by the order") {
+            auto out_ptr = graph.emplace_node<PermutationNode>(arr_ptr, i_ptr);
+
+            THEN("We get the shape we expect") {
+                CHECK(out_ptr->size() == 9);
+                CHECK_THAT(out_ptr->shape(), RangeEquals({3, 3}));
+            }
+
+            THEN("We see the predecessors we expect") {
+                CHECK(
+                    std::ranges::equal(
+                        out_ptr->predecessors(), std::vector<Node*>{arr_ptr, i_ptr}
+                    )
+                );
+            }
+
+            THEN("We see the min/max/integral we expect") {
+                CHECK(out_ptr->min() == 0);
+                CHECK(out_ptr->max() == 8);
+                CHECK(out_ptr->integral());
+            }
+
+            AND_WHEN("We create a state") {
+                auto state = graph.initialize_state();
+
+                THEN("We can read out the state of the nodes") {
+                    CHECK(std::ranges::equal(arr_ptr->view(state), values));
+                    CHECK_THAT(i_ptr->view(state), RangeEquals({2, 1, 0}));
+                    CHECK_THAT(out_ptr->view(state), RangeEquals({8, 7, 6, 5, 4, 3, 2, 1, 0}));
+                }
+            }
+        }
+    }
+
+    GIVEN("A 2d NxN matrix and an order array of size smaller than first dimension") {
+        std::vector<double> values = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+        auto arr_ptr =
+            graph.emplace_node<ConstantNode>(values, std::initializer_list<ssize_t>{3, 3});
+
+        std::vector<double> order = {0, 1};
+        auto i_ptr = graph.emplace_node<ConstantNode>(order);
+
+        WHEN("We permute the matrix by the order") {
+            auto out_ptr = graph.emplace_node<PermutationNode>(arr_ptr, i_ptr);
+
+            THEN("We get the shape we expect") {
+                CHECK(out_ptr->size() == 4);
+                CHECK_THAT(out_ptr->shape(), RangeEquals({2, 2}));
+            }
+
+            THEN("We see the predecessors we expect") {
+                CHECK(
+                    std::ranges::equal(
+                        out_ptr->predecessors(), std::vector<Node*>{arr_ptr, i_ptr}
+                    )
+                );
+            }
+
+            THEN("We see the min/max/integral we expect") {
+                CHECK(out_ptr->min() == 0);
+                CHECK(out_ptr->max() == 8);
+                CHECK(out_ptr->integral());
+            }
+
+            AND_WHEN("We create a state") {
+                auto state = graph.initialize_state();
+
+                THEN("We can read out the state of the nodes") {
+                    CHECK(std::ranges::equal(arr_ptr->view(state), values));
+                    CHECK_THAT(i_ptr->view(state), RangeEquals({0, 1}));
+                    CHECK_THAT(out_ptr->view(state), RangeEquals({0, 1, 3, 4}));
+                }
+            }
+        }
+    }
+
+    GIVEN("A 2d NxN matrix and a list of size smaller than first dimension") {
+        std::vector<double> values = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+        auto arr_ptr =
+            graph.emplace_node<ConstantNode>(values, std::initializer_list<ssize_t>{3, 3});
+
+        auto list_ptr = graph.emplace_node<ListNode>(3, 2, 2);
+
+        WHEN("We permute the matrix by the order") {
+            auto out_ptr = graph.emplace_node<PermutationNode>(arr_ptr, list_ptr);
+
+            THEN("We get the shape we expect") {
+                CHECK(out_ptr->size() == 4);
+                CHECK_THAT(out_ptr->shape(), RangeEquals({2, 2}));
+            }
+
+            AND_WHEN("We create a state") {
+                auto state = graph.empty_state();
+                std::vector<double> order{0, 1};
+                list_ptr->initialize_state(state, order);
+                graph.initialize_state(state);
+
+                THEN("We can read out the state of the nodes") {
+                    CHECK(std::ranges::equal(arr_ptr->view(state), values));
+                    CHECK_THAT(list_ptr->view(state), RangeEquals({0, 1}));
+                    CHECK_THAT(out_ptr->view(state), RangeEquals({0, 1, 3, 4}));
+                }
+
+                AND_WHEN("We mutate the list") {
+                    list_ptr->exchange(state, 0, 1);
+                    graph.propagate(state, graph.descendants(state, {list_ptr}));
+
+                    THEN("The state is updated") {
+                        CHECK_THAT(out_ptr->view(state), RangeEquals({4, 3, 1, 0}));
+                    }
+
+                    AND_WHEN("We commit") {
+                        graph.commit(state, graph.descendants(state, {list_ptr}));
+
+                        THEN("The values stick, and the diff is cleared") {
+                            CHECK_THAT(out_ptr->view(state), RangeEquals({4, 3, 1, 0}));
+
+                            CHECK(out_ptr->size_diff(state) == 0);
+                            CHECK(out_ptr->diff(state).size() == 0);
+                        }
+                    }
+
+                    AND_WHEN("We revert") {
+                        graph.revert(state, graph.descendants(state, {list_ptr}));
+
+                        THEN("We're back to where we started") {
+                            CHECK_THAT(list_ptr->view(state), RangeEquals({0, 1}));
+                            CHECK_THAT(out_ptr->view(state), RangeEquals({0, 1, 3, 4}));
+
+                            CHECK(out_ptr->size_diff(state) == 0);
+                            CHECK(out_ptr->diff(state).size() == 0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+}  // namespace dwave::optimization

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -3469,9 +3469,12 @@ class TestPermutation(utils.SymbolTests):
         model = Model()
         A = model.constant(np.arange(25).reshape((5, 5)))
         x = model.list(5)
+        y = model.list(5, 3, 3)
         p = A[x, :][:, x]
+        p_submatrix = A[y, :][:, y]
         model.lock()
         yield p
+        yield p_submatrix
 
     def test(self):
         from dwave.optimization.symbols import Permutation
@@ -3480,9 +3483,12 @@ class TestPermutation(utils.SymbolTests):
 
         A = model.constant(np.arange(25).reshape((5, 5)))
         x = model.list(5)
+        y = model.list(5, 3, 3)
 
         self.assertIsInstance(A[x, :][:, x], Permutation)
         self.assertIsInstance(A[:, x][x, :], Permutation)
+        self.assertIsInstance(A[y, :][:, y], Permutation)
+        self.assertIsInstance(A[:, y][y, :], Permutation)
 
         b = model.constant(np.arange(30).reshape((5, 6)))
 


### PR DESCRIPTION
Allow constructing a permuted submatrix

#### What does this implement/fix?
Currently 
```python
model = Model()
x = model.list(3, 2, 2)
A = model.constant(np.arange(9).reshape((3,3)))
P = A[x, :][:, x]
```
fails to create the permuted (sub) matrix `P`. This PR allows that.

#### AI Generation Disclosure

No AI was used
