### PR TITLE
Add `type_list_union`

### DIFF
--- a/dwave/optimization/include/dwave-optimization/type_list.hpp
+++ b/dwave/optimization/include/dwave-optimization/type_list.hpp
@@ -48,6 +48,49 @@
 
 namespace dwave::optimization {
 
+template <typename Type, typename... Types>
+struct type_list;
+
+namespace {
+/// Helper struct for taking the union of two or more ``type_list``s
+template <typename type_list_x, typename type_list_y, typename... remaining_type_lists>
+struct type_list_union;
+
+template <typename type_list_x, typename type_list_y>
+struct type_list_union<type_list_x, type_list_y> {
+ private:
+    template <typename tl, typename type_tuple, typename U>
+    struct union_;
+
+    template <typename tl, typename type_tuple, std::size_t i>
+    struct union_<tl, type_tuple, std::index_sequence<i>> {
+        using value = tl::template add<std::tuple_element_t<i, type_tuple>>;
+    };
+
+    template <typename tl, typename type_tuple, std::size_t i, std::size_t... remaining_indices>
+    struct union_<tl, type_tuple, std::index_sequence<i, remaining_indices...>> {
+        using added = tl::template add<std::tuple_element_t<i, type_tuple>>;
+        using value = std::conditional_t<
+            sizeof...(remaining_indices) == 0,
+            added,
+            typename union_<added, type_tuple, std::index_sequence<remaining_indices...>>::value>;
+    };
+
+ public:
+    using value = union_<
+        type_list_x,
+        typename type_list_y::template to<std::tuple>,
+        std::make_index_sequence<type_list_y::size()>>::value;
+};
+
+template <typename type_list_x, typename type_list_y, typename... remaining_type_lists>
+struct type_list_union {
+    using value = type_list_union<
+        typename type_list_union<type_list_x, type_list_y>::value,
+        remaining_type_lists...>::value;
+};
+}  // Anonymous namespace
+
 /// A ``type_list`` encodes a collection of types.
 template <typename Type, typename... Types>
 struct type_list {
@@ -103,7 +146,7 @@ struct type_list {
     }
 
     template <typename OtherTypeList>
-    static constexpr bool is_same() {
+    static constexpr bool equals() {
         return issubset<OtherTypeList>() and
                OtherTypeList::template issubset<type_list<Type, Types...>>();
     }
@@ -168,43 +211,19 @@ struct type_list {
     /// ``std::tuple``.
     template <template <typename...> class U>
     using to = U<Type, Types...>;
+
+    /// Take the union of two or more ``type_list``s, producing a new
+    /// ``type_list``. We would call this ``union()`` but it is a reserved
+    /// key-word.
+    template <typename type_list_y, typename... remaining_type_lists>
+    using update =
+        type_list_union<type_list<Type, Types...>, type_list_y, remaining_type_lists...>::value;
+
+    /// An alternative to ``::update<>`` (also takes the union of the given
+    /// ``type_list``s). "Vereinigung" is the original German word for the
+    /// concept of the set union, coined by Georg Cantor.
+    template <typename type_list_y, typename... remaining_type_lists>
+    using vereinigung = update<type_list<Type, Types...>, type_list_y, remaining_type_lists...>;
 };
-
-/// Take the union of two or more ``type_list``s, producing a new ``type_list``
-template <typename x, typename y, typename... zs>
-struct type_list_union;
-
-template <typename x, typename y>
-struct type_list_union<x, y> {
- private:
-    template <typename tl, typename type_tuple, typename U>
-    struct union_;
-
-    template <typename tl, typename type_tuple, std::size_t i>
-    struct union_<tl, type_tuple, std::index_sequence<i>> {
-        using value = tl::template add<std::tuple_element_t<i, type_tuple>>;
-    };
-
-    template <typename tl, typename type_tuple, std::size_t i, std::size_t... remaining_indices>
-    struct union_<tl, type_tuple, std::index_sequence<i, remaining_indices...>> {
-        using added = tl::template add<std::tuple_element_t<i, type_tuple>>;
-        using value = std::conditional_t<
-            sizeof...(remaining_indices) == 0,
-            added,
-            typename union_<added, type_tuple, std::index_sequence<remaining_indices...>>::value>;
-    };
-
- public:
-    using value =
-        union_<x, typename y::template to<std::tuple>, std::make_index_sequence<y::size()>>::value;
-};
-
-template <typename x, typename y, typename... zs>
-struct type_list_union {
-    using value = type_list_union<typename type_list_union<x, y>::value, zs...>::value;
-};
-
-template <typename x, typename y, typename... zs>
-using type_list_union_v = type_list_union<x, y, zs...>::value;
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/include/dwave-optimization/type_list.hpp
+++ b/dwave/optimization/include/dwave-optimization/type_list.hpp
@@ -42,6 +42,7 @@
 
 #include <memory>
 #include <type_traits>
+#include <typeinfo>
 #include <utility>
 #include <variant>
 
@@ -86,6 +87,11 @@ struct type_list {
         return false;
     }
 
+    /// Add a new type to the type list iff it is not a duplicate
+    template <typename T>
+    using add =
+        std::conditional_t<contains<T>(), type_list<Type, Types...>, type_list<Type, Types..., T>>;
+
     /// Return the number of times that ``T`` appears in the ``type_list``.
     template <typename T>
     static constexpr std::size_t count() {
@@ -94,6 +100,12 @@ struct type_list {
             return count + type_list<Types...>::template count<T>();
         }
         return count;
+    }
+
+    template <typename OtherTypeList>
+    static constexpr bool is_same() {
+        return issubset<OtherTypeList>() and
+               OtherTypeList::template issubset<type_list<Type, Types...>>();
     }
 
     /// Return whether every type in the ``type_list`` is present in ``OtherTypeList``.
@@ -157,5 +169,42 @@ struct type_list {
     template <template <typename...> class U>
     using to = U<Type, Types...>;
 };
+
+/// Take the union of two or more ``type_list``s, producing a new ``type_list``
+template <typename x, typename y, typename... zs>
+struct type_list_union;
+
+template <typename x, typename y>
+struct type_list_union<x, y> {
+ private:
+    template <typename tl, typename type_tuple, typename U>
+    struct union_;
+
+    template <typename tl, typename type_tuple, std::size_t i>
+    struct union_<tl, type_tuple, std::index_sequence<i>> {
+        using value = tl::template add<std::tuple_element_t<i, type_tuple>>;
+    };
+
+    template <typename tl, typename type_tuple, std::size_t i, std::size_t... remaining_indices>
+    struct union_<tl, type_tuple, std::index_sequence<i, remaining_indices...>> {
+        using added = tl::template add<std::tuple_element_t<i, type_tuple>>;
+        using value = std::conditional_t<
+            sizeof...(remaining_indices) == 0,
+            added,
+            typename union_<added, type_tuple, std::index_sequence<remaining_indices...>>::value>;
+    };
+
+ public:
+    using value =
+        union_<x, typename y::template to<std::tuple>, std::make_index_sequence<y::size()>>::value;
+};
+
+template <typename x, typename y, typename... zs>
+struct type_list_union {
+    using value = type_list_union<typename type_list_union<x, y>::value, zs...>::value;
+};
+
+template <typename x, typename y, typename... zs>
+using type_list_union_v = type_list_union<x, y, zs...>::value;
 
 }  // namespace dwave::optimization

--- a/releasenotes/notes/add-type_list_union-9465f17e156f5481.yaml
+++ b/releasenotes/notes/add-type_list_union-9465f17e156f5481.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add C++ ``type_list_union`` and ``type_list_union_v`` templated structs
+    that make it easy to take the union of two or more ``type_list``s. Also
+    implement ``type_list::add`` to "add" a new type into the type list and
+    ``type_list::is_same()` to check if two type lists are equivalent.

--- a/releasenotes/notes/add-type_list_union-9465f17e156f5481.yaml
+++ b/releasenotes/notes/add-type_list_union-9465f17e156f5481.yaml
@@ -1,7 +1,8 @@
 ---
 features:
   - |
-    Add C++ ``type_list_union`` and ``type_list_union_v`` templated structs
-    that make it easy to take the union of two or more ``type_list``s. Also
-    implement ``type_list::add`` to "add" a new type into the type list and
-    ``type_list::is_same()` to check if two type lists are equivalent.
+    Add C++ ``type_list::add`` (which adds a new type to the type list),
+    ``type_list::equals`` (which can check if two type lists are contain the
+    same types) and ``type_list::update``/``type_list::vereinigung`` which
+    allow you to take the union of two or more type lists (similar to Python's
+    ``set.update()``.

--- a/tests/cpp/test_type_list.cpp
+++ b/tests/cpp/test_type_list.cpp
@@ -53,16 +53,16 @@ TEST_CASE("Test type_list") {
         using w = type_list<float, double>;
 
         using u_v_expected = type_list<int, float>;
-        static_assert(type_list_union_v<u, v>::template is_same<u_v_expected>());
+        static_assert(u::vereinigung<v>::template equals<u_v_expected>());
 
         using v_u_expected = type_list<int, float>;
-        static_assert(type_list_union_v<v, u>::template is_same<v_u_expected>());
+        static_assert(v::vereinigung<u>::template equals<v_u_expected>());
 
         using u_w_expected = type_list<int, float, double>;
-        static_assert(type_list_union_v<u, w>::template is_same<u_w_expected>());
+        static_assert(u::vereinigung<w>::template equals<u_w_expected>());
 
         using u_v_w_expected = type_list<int, float, double>;
-        static_assert(type_list_union_v<u, v, w>::template is_same<u_v_w_expected>());
+        static_assert(u::vereinigung<v, w>::template equals<u_v_w_expected>());
     }
 
     SECTION("type_list<...>::check() with pointers") {

--- a/tests/cpp/test_type_list.cpp
+++ b/tests/cpp/test_type_list.cpp
@@ -47,6 +47,24 @@ TEST_CASE("Test type_list") {
         static_assert(type_list<float, float*>::remove_pointer::count<float>() == 2);
     }
 
+    SECTION("type_list_union static asserts") {
+        using u = type_list<int, float>;
+        using v = type_list<float>;
+        using w = type_list<float, double>;
+
+        using u_v_expected = type_list<int, float>;
+        static_assert(type_list_union_v<u, v>::template is_same<u_v_expected>());
+
+        using v_u_expected = type_list<int, float>;
+        static_assert(type_list_union_v<v, u>::template is_same<v_u_expected>());
+
+        using u_w_expected = type_list<int, float, double>;
+        static_assert(type_list_union_v<u, w>::template is_same<u_w_expected>());
+
+        using u_v_w_expected = type_list<int, float, double>;
+        static_assert(type_list_union_v<u, v, w>::template is_same<u_v_w_expected>());
+    }
+
     SECTION("type_list<...>::check() with pointers") {
         struct PolymorphicBase {
             virtual ~PolymorphicBase() = default;


### PR DESCRIPTION
#### What does this implement/fix?
This PR implements `type_list_union` and `type_list_union_v`, which allow you to take the union of two or more `type_list`s to aggregate lists of types. It also implements `type_list::add` and `type_list::is_same` helper methods.

#### AI Generation Disclosure

No AI tools used