### PR TITLE
Try to speed up compilation time

### DIFF
--- a/dwave/optimization/include/dwave-optimization/array.hpp
+++ b/dwave/optimization/include/dwave-optimization/array.hpp
@@ -17,9 +17,8 @@
 #include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <cstdint>
 #include <functional>
-#include <iostream>
+#include <iosfwd>
 #include <limits>
 #include <memory>
 #include <numeric>
@@ -34,7 +33,6 @@
 #include "dwave-optimization/fraction.hpp"
 #include "dwave-optimization/iterators.hpp"
 #include "dwave-optimization/state.hpp"
-#include "dwave-optimization/typing.hpp"
 
 namespace dwave::optimization {
 

--- a/dwave/optimization/include/dwave-optimization/nodes/binaryop.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/binaryop.hpp
@@ -17,9 +17,7 @@
 #include <array>
 #include <cassert>
 #include <functional>
-#include <optional>
 #include <span>
-#include <utility>
 
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/functional.hpp"
@@ -81,6 +79,20 @@ class BinaryOpNode : public ArrayOutputMixin<ArrayNode> {
     const ValuesInfo values_info_;
     const SizeInfo sizeinfo_;
 };
+
+extern template class BinaryOpNode<std::plus<double>>;
+extern template class BinaryOpNode<std::logical_and<double>>;
+extern template class BinaryOpNode<std::divides<double>>;
+extern template class BinaryOpNode<std::equal_to<double>>;
+extern template class BinaryOpNode<std::less_equal<double>>;
+extern template class BinaryOpNode<functional::max<double>>;
+extern template class BinaryOpNode<functional::min<double>>;
+extern template class BinaryOpNode<functional::modulus<double>>;
+extern template class BinaryOpNode<std::multiplies<double>>;
+extern template class BinaryOpNode<std::logical_or<double>>;
+extern template class BinaryOpNode<functional::safe_divides<double>>;
+extern template class BinaryOpNode<std::minus<double>>;
+extern template class BinaryOpNode<functional::logical_xor<double>>;
 
 // We follow NumPy naming convention rather than C++ to distinguish between
 // binary operations and reduce operations.

--- a/dwave/optimization/include/dwave-optimization/nodes/flow.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/flow.hpp
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <span>
-#include <utility>
 
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/graph.hpp"

--- a/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/indexing.hpp
@@ -14,13 +14,8 @@
 
 #pragma once
 
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <optional>
-#include <stdexcept>
-#include <string>
-#include <utility>
 #include <variant>
 #include <vector>
 

--- a/dwave/optimization/include/dwave-optimization/nodes/inputs.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/inputs.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <span>
+
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/graph.hpp"
 

--- a/dwave/optimization/include/dwave-optimization/nodes/linear_algebra.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/linear_algebra.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
+#include <span>
 #include <string>
-#include <vector>
 
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/graph.hpp"

--- a/dwave/optimization/include/dwave-optimization/nodes/naryop.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/naryop.hpp
@@ -17,9 +17,7 @@
 #include <cassert>
 #include <concepts>
 #include <functional>
-#include <optional>
 #include <span>
-#include <utility>
 #include <vector>
 
 #include "dwave-optimization/array.hpp"
@@ -77,6 +75,11 @@ class NaryOpNode : public ArrayOutputMixin<ArrayNode> {
     // Note that this is not const as it may change as we add nodes
     ValuesInfo values_info_ = ValuesInfo(0, 0, true);
 };
+
+extern template class NaryOpNode<std::plus<double>>;
+extern template class NaryOpNode<functional::max<double>>;
+extern template class NaryOpNode<functional::min<double>>;
+extern template class NaryOpNode<std::multiplies<double>>;
 
 using NaryAddNode = NaryOpNode<std::plus<double>>;
 using NaryMaximumNode = NaryOpNode<functional::max<double>>;

--- a/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/numbers.hpp
@@ -17,7 +17,6 @@
 #include <optional>
 #include <ranges>
 #include <span>
-#include <utility>
 #include <vector>
 
 #include "dwave-optimization/array.hpp"

--- a/dwave/optimization/include/dwave-optimization/nodes/quadratic_model.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/quadratic_model.hpp
@@ -14,11 +14,7 @@
 
 #pragma once
 
-#include <algorithm>
-#include <memory>
-#include <ranges>
 #include <span>
-#include <utility>
 #include <vector>
 
 #include "dwave-optimization/array.hpp"

--- a/dwave/optimization/include/dwave-optimization/nodes/reduce.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/reduce.hpp
@@ -128,6 +128,13 @@ class ReduceNode : public ArrayOutputMixin<ArrayNode> {
     ssize_t convert_predecessor_index_(ssize_t index) const;
 };
 
+extern template class ReduceNode<std::logical_and<double>>;
+extern template class ReduceNode<std::logical_or<double>>;
+extern template class ReduceNode<functional::max<double>>;
+extern template class ReduceNode<functional::min<double>>;
+extern template class ReduceNode<std::multiplies<double>>;
+extern template class ReduceNode<std::plus<double>>;
+
 using AllNode = ReduceNode<std::logical_and<double>>;
 using AnyNode = ReduceNode<std::logical_or<double>>;
 using MaxNode = ReduceNode<functional::max<double>>;

--- a/dwave/optimization/include/dwave-optimization/nodes/softmax.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/softmax.hpp
@@ -14,9 +14,7 @@
 
 #pragma once
 
-#include <optional>
 #include <span>
-#include <utility>
 
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/graph.hpp"

--- a/dwave/optimization/include/dwave-optimization/nodes/sorting.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/sorting.hpp
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <span>
-#include <vector>
 
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/graph.hpp"

--- a/dwave/optimization/include/dwave-optimization/nodes/statistics.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/statistics.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <utility>
+
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/state.hpp"

--- a/dwave/optimization/include/dwave-optimization/nodes/unaryop.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/unaryop.hpp
@@ -16,9 +16,7 @@
 
 #include <cassert>
 #include <functional>
-#include <optional>
 #include <span>
-#include <utility>
 
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/functional.hpp"
@@ -76,6 +74,20 @@ class UnaryOpNode : public ArrayOutputMixin<ArrayNode> {
     const ValuesInfo values_info_;
     const SizeInfo sizeinfo_;
 };
+
+extern template class UnaryOpNode<functional::abs<double>>;
+extern template class UnaryOpNode<functional::cos<double>>;
+extern template class UnaryOpNode<functional::expit<double>>;
+extern template class UnaryOpNode<functional::exp<double>>;
+extern template class UnaryOpNode<functional::log<double>>;
+extern template class UnaryOpNode<functional::logical<double>>;
+extern template class UnaryOpNode<std::negate<double>>;
+extern template class UnaryOpNode<std::logical_not<double>>;
+extern template class UnaryOpNode<functional::rint<double>>;
+extern template class UnaryOpNode<functional::sin<double>>;
+extern template class UnaryOpNode<functional::square<double>>;
+extern template class UnaryOpNode<functional::square_root<double>>;
+extern template class UnaryOpNode<functional::tanh<double>>;
 
 using AbsoluteNode = UnaryOpNode<functional::abs<double>>;
 using CosNode = UnaryOpNode<functional::cos<double>>;

--- a/dwave/optimization/include/dwave-optimization/state.hpp
+++ b/dwave/optimization/include/dwave-optimization/state.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
+#include <cassert>
 #include <memory>
 #include <vector>
-#include <cassert>
 
 namespace dwave::optimization {
 

--- a/dwave/optimization/pch/pch.hpp
+++ b/dwave/optimization/pch/pch.hpp
@@ -1,0 +1,25 @@
+// Copyright 2026 D-Wave
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+// Some headers we wish to precompile to speed up compilation
+
+#include <algorithm>
+#include <functional>
+#include <numeric>
+#include <ranges>
+#include <span>
+
+#include "dwave-optimization/array.hpp"
+#include "dwave-optimization/graph.hpp"
+#include "dwave-optimization/iterators.hpp"

--- a/dwave/optimization/src/array.cpp
+++ b/dwave/optimization/src/array.cpp
@@ -15,6 +15,7 @@
 #include "dwave-optimization/array.hpp"
 
 #include <array>
+#include <iostream>
 #include <ranges>
 
 namespace dwave::optimization {

--- a/meson.build
+++ b/meson.build
@@ -95,6 +95,7 @@ if host_machine.system() == 'windows'
             sources: dwave_optimization_src,
             include_directories: dwave_optimization_include,
             dependencies: dwave_optimization_dependencies,
+            cpp_pch: 'dwave/optimization/pch/pch.hpp',
         ),
         include_directories: dwave_optimization_include
     )
@@ -108,6 +109,7 @@ else
             install: true,
             install_dir: py.get_install_dir(pure: false) / 'dwave/optimization/',
             dependencies: dwave_optimization_dependencies,
+            cpp_pch: 'dwave/optimization/pch/pch.hpp',
         ),
         include_directories: dwave_optimization_include
     )

--- a/tests/cpp/nodes/indexing/test_advanced.cpp
+++ b/tests/cpp/nodes/indexing/test_advanced.cpp
@@ -14,13 +14,12 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
 #include "dwave-optimization/nodes/indexing.hpp"
-#include "dwave-optimization/nodes/manipulation.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"
 #include "dwave-optimization/nodes/testing.hpp"
 

--- a/tests/cpp/nodes/indexing/test_basic.cpp
+++ b/tests/cpp/nodes/indexing/test_basic.cpp
@@ -14,7 +14,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"

--- a/tests/cpp/nodes/indexing/test_permutation.cpp
+++ b/tests/cpp/nodes/indexing/test_permutation.cpp
@@ -14,13 +14,12 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
 #include "dwave-optimization/nodes/indexing.hpp"
-#include "dwave-optimization/nodes/testing.hpp"
 
 using Catch::Matchers::RangeEquals;
 

--- a/tests/cpp/nodes/test_collections.cpp
+++ b/tests/cpp/nodes/test_collections.cpp
@@ -13,10 +13,9 @@
 //    limitations under the License.
 
 #include <set>
-#include <unordered_set>
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"

--- a/tests/cpp/nodes/test_constants.cpp
+++ b/tests/cpp/nodes/test_constants.cpp
@@ -13,7 +13,7 @@
 //    limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/constants.hpp"

--- a/tests/cpp/nodes/test_creation.cpp
+++ b/tests/cpp/nodes/test_creation.cpp
@@ -13,7 +13,7 @@
 //    limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/creation.hpp"

--- a/tests/cpp/nodes/test_flow.cpp
+++ b/tests/cpp/nodes/test_flow.cpp
@@ -13,7 +13,7 @@
 //    limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"

--- a/tests/cpp/nodes/test_inputs.cpp
+++ b/tests/cpp/nodes/test_inputs.cpp
@@ -13,12 +13,9 @@
 //    limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/graph.hpp"
-#include "dwave-optimization/nodes/collections.hpp"
-#include "dwave-optimization/nodes/constants.hpp"
-#include "dwave-optimization/nodes/flow.hpp"
 #include "dwave-optimization/nodes/inputs.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"
 #include "dwave-optimization/nodes/testing.hpp"

--- a/tests/cpp/nodes/test_lambda.cpp
+++ b/tests/cpp/nodes/test_lambda.cpp
@@ -13,12 +13,11 @@
 //    limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
-#include "dwave-optimization/nodes/flow.hpp"
 #include "dwave-optimization/nodes/inputs.hpp"
 #include "dwave-optimization/nodes/lambda.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"

--- a/tests/cpp/nodes/test_linear_algebra.cpp
+++ b/tests/cpp/nodes/test_linear_algebra.cpp
@@ -14,9 +14,8 @@
 
 #include <vector>
 
-#include <catch2/benchmark/catch_benchmark_all.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/nodes/binaryop.hpp"
 #include "dwave-optimization/nodes/collections.hpp"

--- a/tests/cpp/nodes/test_lp.cpp
+++ b/tests/cpp/nodes/test_lp.cpp
@@ -17,7 +17,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-#include "dwave-optimization/nodes.hpp"
+#include "dwave-optimization/nodes/constants.hpp"
+#include "dwave-optimization/nodes/lp.hpp"
+#include "dwave-optimization/nodes/numbers.hpp"
+#include "dwave-optimization/nodes/testing.hpp"
 
 using namespace Catch::Matchers;
 

--- a/tests/cpp/nodes/test_quadratic_model.cpp
+++ b/tests/cpp/nodes/test_quadratic_model.cpp
@@ -13,7 +13,7 @@
 //    limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/collections.hpp"

--- a/tests/cpp/nodes/test_set_routines.cpp
+++ b/tests/cpp/nodes/test_set_routines.cpp
@@ -16,7 +16,7 @@
 
 #include <catch2/benchmark/catch_benchmark_all.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"

--- a/tests/cpp/nodes/test_sorting.cpp
+++ b/tests/cpp/nodes/test_sorting.cpp
@@ -14,7 +14,7 @@
 
 #include <catch2/benchmark/catch_benchmark_all.hpp>
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -15,7 +15,7 @@
 #include <sstream>
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/array.hpp"
 #include "dwave-optimization/state.hpp"

--- a/tests/cpp/test_double_kahan.cpp
+++ b/tests/cpp/test_double_kahan.cpp
@@ -13,11 +13,8 @@
 //    limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
 
 #include "double_kahan.hpp"
-
-using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 

--- a/tests/cpp/test_fraction.cpp
+++ b/tests/cpp/test_fraction.cpp
@@ -13,11 +13,8 @@
 //    limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
 
 #include "dwave-optimization/fraction.hpp"
-
-using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {
 

--- a/tests/cpp/test_graph.cpp
+++ b/tests/cpp/test_graph.cpp
@@ -16,7 +16,12 @@
 #include <catch2/matchers/catch_matchers_all.hpp>
 
 #include "dwave-optimization/graph.hpp"
-#include "dwave-optimization/nodes.hpp"
+#include "dwave-optimization/nodes/binaryop.hpp"
+#include "dwave-optimization/nodes/collections.hpp"
+#include "dwave-optimization/nodes/constants.hpp"
+#include "dwave-optimization/nodes/numbers.hpp"
+#include "dwave-optimization/nodes/reduce.hpp"
+#include "dwave-optimization/nodes/unaryop.hpp"
 
 namespace dwave::optimization {
 

--- a/tests/cpp/test_iterators.cpp
+++ b/tests/cpp/test_iterators.cpp
@@ -15,7 +15,6 @@
 #include <array>
 #include <cstdint>
 #include <numeric>
-#include <random>
 #include <vector>
 
 #include <catch2/benchmark/catch_benchmark_all.hpp>
@@ -23,11 +22,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/generators/catch_generators_random.hpp>
-#include <catch2/matchers/catch_matchers_all.hpp>
+#include <catch2/matchers/catch_matchers_range_equals.hpp>
 
 #include "dwave-optimization/iterators.hpp"
 
-using Catch::Generators::RandomIntegerGenerator;
 using Catch::Matchers::RangeEquals;
 
 namespace dwave::optimization {


### PR DESCRIPTION
Try to speed up compilation time.

Took it from 1:37 to 1:25 on my system (compiling single threaded). The precompiled headers also broke my local clangd setup. I am not sure that they are really worth it :thinking: 

Fixing all the headers made no detectable change fwiw.

The other changes seem harmless to helpful.

#### AI Generation Disclosure
Claude suggested some of the changes. Specifically the precompiled headers
