### PR TITLE
Make `State` a class and add `Graph::mutated()`

### DIFF
--- a/dwave/optimization/include/dwave-optimization/graph.hpp
+++ b/dwave/optimization/include/dwave-optimization/graph.hpp
@@ -40,8 +40,6 @@ class Node;
 struct Decision {};
 
 class Graph {
-    friend class State;
-
  public:
     Graph() noexcept = default;
     ~Graph() noexcept = default;

--- a/dwave/optimization/include/dwave-optimization/graph.hpp
+++ b/dwave/optimization/include/dwave-optimization/graph.hpp
@@ -406,7 +406,7 @@ class Node {
     StateData* data_ptr_(State& state) const {
         const ssize_t index = topological_index();
         assert(index >= 0 and "must be topologically sorted");
-        assert(state.size() > static_cast<std::size_t>(index) and "unexpected state length");
+        assert(state.size() > index and "unexpected state length");
         assert(state[index] != nullptr and "uninitialized state");
 
         return static_cast<StateData*>(state[index].get());
@@ -415,7 +415,7 @@ class Node {
     const StateData* data_ptr_(const State& state) const {
         const ssize_t index = topological_index();
         assert(index >= 0 and "must be topologically sorted");
-        assert(state.size() > static_cast<std::size_t>(index) and "unexpected state length");
+        assert(state.size() > index and "unexpected state length");
         assert(state[index] != nullptr and "uninitialized state");
 
         return static_cast<const StateData*>(state[index].get());
@@ -425,7 +425,7 @@ class Node {
     void emplace_data_ptr_(State& state, Args&&... args) const {
         const ssize_t index = topological_index();
         assert(index >= 0 and "must be topologically sorted");
-        assert(state.size() > static_cast<std::size_t>(index) and "unexpected state length");
+        assert(state.size() > index and "unexpected state length");
         assert(state[index] == nullptr and "already initialized state");
 
         state[index] = std::make_unique<StateData>(std::forward<Args&&>(args)...);

--- a/dwave/optimization/include/dwave-optimization/graph.hpp
+++ b/dwave/optimization/include/dwave-optimization/graph.hpp
@@ -40,6 +40,8 @@ class Node;
 struct Decision {};
 
 class Graph {
+    friend class State;
+
  public:
     Graph() noexcept = default;
     ~Graph() noexcept = default;
@@ -115,6 +117,25 @@ class Graph {
     std::span<InputNode* const> inputs() noexcept { return inputs_; }
     std::span<const InputNode* const> inputs() const noexcept { return inputs_; }
 
+    /// Return the decision nodes that have been "mutated", meaning that they
+    /// have pending changes that must be propagated before committing or
+    /// reverting. Equivalently, the combined descendants of the returned nodes
+    /// are guaranteed to be a superset of the nodes that require having
+    /// `propagate()` and then `commit()` or `revert()` called on them.
+    ///
+    /// Notes:
+    ///  - Using this method in conjunction with `descendants()` and
+    ///  `propagate()`/`commit()`/`revert()` may be inefficient compared to
+    ///  doing these manually in the case where you know only some descendants
+    ///  of one or more of the decision nodes are relevant, e.g. only one of the
+    ///  `DisjointListNode` successors of `DisjointListsNode` has pending
+    ///  changes and the rest of the `DisjointListNode`s (and their descendants)
+    ///  can be ignored
+    ///  - This method will return the same nodes before and after calling
+    ///  `propagate()`. Only after committing/reverting will the returned list
+    ///  be empty again.
+    std::span<const DecisionNode*> mutated(State& state) const;
+
     /// All of the nodes in the graph.
     std::span<const std::unique_ptr<Node>> nodes() const { return nodes_; }
 
@@ -143,7 +164,7 @@ class Graph {
     void propagate(State& state) const;
 
     /// Call the propagate method on each node in changed. Note this does not call propagate on
-    /// the descendents of changed.
+    /// the descendants of changed.
     void propagate(State& state, std::span<const Node*> changed) const;
     void propagate(State& state, std::vector<const Node*>&& changed) const;
 

--- a/dwave/optimization/include/dwave-optimization/state.hpp
+++ b/dwave/optimization/include/dwave-optimization/state.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
+#include <cassert>
 #include <memory>
 #include <vector>
-#include <cassert>
 
 namespace dwave::optimization {
 
@@ -34,7 +34,42 @@ struct NodeStateData {
     bool mark = false;
 };
 
-using State = typename std::vector<std::unique_ptr<NodeStateData>>;
+// Foward declaration
+class DecisionNode;
+
+class State {
+    friend class Graph;
+
+ public:
+    template <typename... Args>
+    State(Args&&... args) : node_data_(std::forward<Args...>(args)...) {}
+
+    template <typename... Args>
+    void emplace_back(Args&&... args) {
+        node_data_.emplace_back(std::forward<Args...>(args)...);
+    }
+
+    template <typename index_type>
+    auto& operator[](index_type index) {
+        return node_data_[index];
+    }
+
+    template <typename index_type>
+    auto& operator[](index_type index) const {
+        return node_data_[index];
+    }
+
+    template <typename size_type>
+    void resize(size_type size) {
+        node_data_.resize(size);
+    }
+
+    size_t size() const { return node_data_.size(); }
+
+ private:
+    std::vector<std::unique_ptr<NodeStateData>> node_data_;
+    std::vector<const DecisionNode*> mutated_nodes_;
+};
 
 /// A generic base class for node checkpoints.
 struct NodeStateCheckpoint {

--- a/dwave/optimization/include/dwave-optimization/state.hpp
+++ b/dwave/optimization/include/dwave-optimization/state.hpp
@@ -34,20 +34,14 @@ struct NodeStateData {
     bool mark = false;
 };
 
-// Foward declaration
+// Foward declaration for storing the mutated decision nodes on State
 class DecisionNode;
 
 class State {
     friend class Graph;
 
  public:
-    template <typename... Args>
-    State(Args&&... args) : node_data_(std::forward<Args...>(args)...) {}
-
-    template <typename... Args>
-    void emplace_back(Args&&... args) {
-        node_data_.emplace_back(std::forward<Args...>(args)...);
-    }
+    State(ssize_t size = 0) : node_data_(size) {}
 
     template <typename index_type>
     auto& operator[](index_type index) {
@@ -59,12 +53,9 @@ class State {
         return node_data_[index];
     }
 
-    template <typename size_type>
-    void resize(size_type size) {
-        node_data_.resize(size);
-    }
+    void resize(ssize_t size) { node_data_.resize(size); }
 
-    size_t size() const { return node_data_.size(); }
+    ssize_t size() const { return node_data_.size(); }
 
  private:
     std::vector<std::unique_ptr<NodeStateData>> node_data_;

--- a/dwave/optimization/include/dwave-optimization/state.hpp
+++ b/dwave/optimization/include/dwave-optimization/state.hpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <vector>
 
+#include "dwave-optimization/common.hpp"
+
 namespace dwave::optimization {
 
 // Generic base class for encoding the state of the model. In general, nodes
@@ -41,7 +43,7 @@ class State {
     friend class Graph;
 
  public:
-    State(ssize_t size = 0) : node_data_(size) {}
+    State() {}
 
     template <typename index_type>
     auto& operator[](index_type index) {
@@ -58,6 +60,8 @@ class State {
     ssize_t size() const { return node_data_.size(); }
 
  private:
+    State(ssize_t size) : node_data_(size) {}
+
     std::vector<std::unique_ptr<NodeStateData>> node_data_;
     std::vector<const DecisionNode*> mutated_nodes_;
 };

--- a/dwave/optimization/src/graph.cpp
+++ b/dwave/optimization/src/graph.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include "dwave-optimization/array.hpp"
+#include "dwave-optimization/nodes/collections.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
 #include "dwave-optimization/nodes/inputs.hpp"
 
@@ -155,6 +156,34 @@ void Graph::initialize_state(State& state) const {
 void Graph::initialize_state(State& state) {
     topological_sort();
     static_cast<const Graph*>(this)->initialize_state(state);
+}
+
+std::span<const DecisionNode*> Graph::mutated(State& state) const {
+    state.mutated_nodes_.clear();
+    for (const DecisionNode* dec_ptr : decisions()) {
+        if (const ArrayNode* arr_ptr = dynamic_cast<const ArrayNode*>(dec_ptr); arr_ptr) {
+            if (not arr_ptr->diff(state).empty()) {
+                state.mutated_nodes_.push_back(dec_ptr);
+            }
+        } else if (
+            dynamic_cast<const DisjointListsNode*>(dec_ptr) or
+            dynamic_cast<const DisjointBitSetsNode*>(dec_ptr)
+        ) {
+            for (const Node* suc_ptr : dec_ptr->successors()) {
+                const ArrayNode* arr_ptr = dynamic_cast<const ArrayNode*>(suc_ptr);
+                assert(arr_ptr and "all successors should be array nodes");
+                if (not arr_ptr->diff(state).empty()) {
+                    state.mutated_nodes_.push_back(dec_ptr);
+                    break;
+                }
+            }
+        } else {
+            assert(false and "unknown decision node type");
+            unreachable();
+        }
+    }
+
+    return state.mutated_nodes_;
 }
 
 void Graph::pop_decision() {
@@ -493,7 +522,7 @@ ssize_t Graph::remove_unused_nodes(bool ignore_listeners) {
 
     for (auto& uptr : nodes_ | std::views::reverse) {
         if (uptr->topological_index_ == keep) continue;  // we marked these to keep
-        if (uptr->successors().size() > 0) continue;  // this node is used by other nodes
+        if (uptr->successors().size() > 0) continue;     // this node is used by other nodes
 
         // We have a node with no successors and that we haven't marked it as important.
         // So let's mark it to be dropped later.

--- a/dwave/optimization/src/graph.cpp
+++ b/dwave/optimization/src/graph.cpp
@@ -105,9 +105,9 @@ std::vector<const Node*> Graph::descendants(State& state, std::vector<const Node
 }
 
 std::vector<const Node*> Graph::descendants(std::vector<const Node*> sources) const {
-    State state;
+    State state(num_nodes());
     for (ssize_t i = 0, stop = num_nodes(); i < stop; ++i) {
-        state.emplace_back(std::make_unique<NodeStateData>());
+        state[i] = std::make_unique<NodeStateData>();
     }
     return descendants(state, sources);
 }
@@ -159,9 +159,14 @@ void Graph::initialize_state(State& state) {
 }
 
 std::span<const DecisionNode*> Graph::mutated(State& state) const {
+    // We will want to eventually replace this implementation with an approach where
+    // decision nodes "eagerly" add themselves to the list of mutated nodes after they
+    // are mutated. This will avoid the need to iterate over all decision nodes every
+    // time this method is called.
     state.mutated_nodes_.clear();
+
     for (const DecisionNode* dec_ptr : decisions()) {
-        if (const ArrayNode* arr_ptr = dynamic_cast<const ArrayNode*>(dec_ptr); arr_ptr) {
+        if (auto* arr_ptr = dynamic_cast<const ArrayNode*>(dec_ptr); arr_ptr) {
             if (not arr_ptr->diff(state).empty()) {
                 state.mutated_nodes_.push_back(dec_ptr);
             }

--- a/dwave/optimization/src/nodes/lambda.cpp
+++ b/dwave/optimization/src/nodes/lambda.cpp
@@ -258,8 +258,7 @@ void AccumulateZipNode::initialize_state(State& state) const {
     ssize_t start_size = this->size(state);
     ssize_t num_args = operands_.size();
     std::vector<double> values;
-    State reg;
-    reg = expression_ptr_->empty_state();
+    State reg = expression_ptr_->empty_state();
 
     std::vector<Array::const_iterator> iterators;
     for (const ArrayNode* array_ptr : operands_) {

--- a/tests/cpp/test_graph.cpp
+++ b/tests/cpp/test_graph.cpp
@@ -235,7 +235,9 @@ TEST_CASE("Graph constructors, assignment operators, and swapping") {
     }
 }
 
-TEST_CASE("Graph::commit(), Graph::descendants(), Graph::propagate(), and Graph::revert") {
+TEST_CASE(
+    "Graph::commit(), Graph::descendants(), Graph::mutated(), Graph::propagate(), and Graph::revert"
+) {
     auto graph = Graph();
     auto* x_ptr = graph.emplace_node<BinaryNode>();
     auto* y_ptr = graph.emplace_node<BinaryNode>();
@@ -248,16 +250,22 @@ TEST_CASE("Graph::commit(), Graph::descendants(), Graph::propagate(), and Graph:
         CHECK_THAT(descendants, RangeEquals(std::vector<Node*>{x_ptr, z_ptr}));
     }
     SECTION("Propagate all") {
+        CHECK_THAT(graph.mutated(state), Catch::Matchers::RangeEquals(std::vector<Node*>{}));
+
         CHECK(x_ptr->view(state).front() == 0);
         CHECK(y_ptr->view(state).front() == 0);
         CHECK(z_ptr->view(state).front() == 0);
 
         x_ptr->flip(state, 0);
+        CHECK_THAT(graph.mutated(state), Catch::Matchers::RangeEquals({x_ptr}));
+
         y_ptr->flip(state, 0);
 
         CHECK(x_ptr->diff(state).size());
         CHECK(y_ptr->diff(state).size());
         CHECK(z_ptr->diff(state).empty());  // not yet propagated to
+
+        CHECK_THAT(graph.mutated(state), Catch::Matchers::RangeEquals({x_ptr, y_ptr}));
 
         graph.propagate(state);
 
@@ -268,6 +276,8 @@ TEST_CASE("Graph::commit(), Graph::descendants(), Graph::propagate(), and Graph:
         CHECK(x_ptr->diff(state).size());
         CHECK(y_ptr->diff(state).size());
         CHECK(z_ptr->diff(state).size());  // now has pending changes
+
+        CHECK_THAT(graph.mutated(state), Catch::Matchers::RangeEquals({x_ptr, y_ptr}));
 
         SECTION("Commit all") {
             graph.commit(state);
@@ -280,6 +290,9 @@ TEST_CASE("Graph::commit(), Graph::descendants(), Graph::propagate(), and Graph:
             CHECK(x_ptr->diff(state).empty());
             CHECK(y_ptr->diff(state).empty());
             CHECK(z_ptr->diff(state).empty());
+
+            // Committing should reset the mutated nodes
+            CHECK_THAT(graph.mutated(state), Catch::Matchers::RangeEquals(std::vector<Node*>{}));
         }
 
         SECTION("Revert all") {
@@ -293,6 +306,9 @@ TEST_CASE("Graph::commit(), Graph::descendants(), Graph::propagate(), and Graph:
             CHECK(x_ptr->diff(state).empty());
             CHECK(y_ptr->diff(state).empty());
             CHECK(z_ptr->diff(state).empty());
+
+            // Reverting should reset the mutated nodes
+            CHECK_THAT(graph.mutated(state), Catch::Matchers::RangeEquals(std::vector<Node*>{}));
         }
     }
 }


### PR DESCRIPTION
#### What does this implement/fix?
This PR adds the `Graph::mutated()` method which returns the list of decision nodes with "pending" changes (see docstring for more details). It also makes `State` a class rather than an alias to a vector of data pointers in order to help implement `Graph::mutated()`.

#### Additional information
For now, I left the implementation of `Graph::mutated()` simple, and it will return only decision nodes, and not specific successors of `DisjointListsNode` and `DisjointBitSetsNode`. However, if we plan to use this directly with `descendants()`/`propagate()` etc., we may need to consider returning specific successors because of the known performance hit on models with large amounts of lists/sets on individual `DisjointListsNode`/`DisjointBitSetsNode`s.

#### AI Generation Disclosure
No AI tools used