### PR TITLE
Add const overload for DisjointBitSetsNode::get_containing_set_index()

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/collections.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/collections.hpp
@@ -116,7 +116,6 @@ class DisjointBitSetsNode : public DecisionNode {
 
     void commit(State&) const override;
 
-    ssize_t get_containing_set_index(State& state, ssize_t element_i) const;
     ssize_t get_containing_set_index(const State& state, ssize_t element_i) const;
 
     void initialize_state(State& state) const override;

--- a/dwave/optimization/include/dwave-optimization/nodes/collections.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/collections.hpp
@@ -117,6 +117,7 @@ class DisjointBitSetsNode : public DecisionNode {
     void commit(State&) const override;
 
     ssize_t get_containing_set_index(State& state, ssize_t element_i) const;
+    ssize_t get_containing_set_index(const State& state, ssize_t element_i) const;
 
     void initialize_state(State& state) const override;
 

--- a/dwave/optimization/src/nodes/collections.cpp
+++ b/dwave/optimization/src/nodes/collections.cpp
@@ -621,10 +621,6 @@ void DisjointBitSetsNode::swap_between_sets(
     );
 }
 
-ssize_t DisjointBitSetsNode::get_containing_set_index(State& state, ssize_t element) const {
-    return data_ptr_<DisjointBitSetsNodeData_>(state)->get_containing_set_index(element);
-}
-
 ssize_t DisjointBitSetsNode::get_containing_set_index(const State& state, ssize_t element) const {
     return data_ptr_<DisjointBitSetsNodeData_>(state)->get_containing_set_index(element);
 }

--- a/dwave/optimization/src/nodes/collections.cpp
+++ b/dwave/optimization/src/nodes/collections.cpp
@@ -625,6 +625,10 @@ ssize_t DisjointBitSetsNode::get_containing_set_index(State& state, ssize_t elem
     return data_ptr_<DisjointBitSetsNodeData_>(state)->get_containing_set_index(element);
 }
 
+ssize_t DisjointBitSetsNode::get_containing_set_index(const State& state, ssize_t element) const {
+    return data_ptr_<DisjointBitSetsNodeData_>(state)->get_containing_set_index(element);
+}
+
 DisjointBitSetNode::DisjointBitSetNode(DisjointBitSetsNode* disjoint_bit_sets_node) :
     ArrayOutputMixin(disjoint_bit_sets_node->primary_set_size()),
     disjoint_bit_sets_node_(disjoint_bit_sets_node),

--- a/releasenotes/notes/const-get-containing-set-index-4ff5b13c0bd39bf6.yaml
+++ b/releasenotes/notes/const-get-containing-set-index-4ff5b13c0bd39bf6.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    Add C++ ``DisjointBitSetsNode::get_containing_set_index()`` overload
-    accepting a ``const State&``. This allows the containing set of an element
-    to be queried when only a const state is available.
+    C++ ``DisjointBitSetsNode::get_containing_set_index()`` now accepts a
+    ``const State&``. This allows the containing set of an element to be
+    queried when only a const state is available.

--- a/releasenotes/notes/const-get-containing-set-index-4ff5b13c0bd39bf6.yaml
+++ b/releasenotes/notes/const-get-containing-set-index-4ff5b13c0bd39bf6.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add C++ ``DisjointBitSetsNode::get_containing_set_index()`` overload
+    accepting a ``const State&``. This allows the containing set of an element
+    to be queried when only a const state is available.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR conforms to our contributor guide.
https://github.com/dwavesystems/dwave-optimization/blob/main/CONTRIBUTING.rst
-->

#### Reference issue
N/A
<!--Example: Closes https://github.com/dwavesystems/dwave-optimization/issues/XYZ.-->

#### What does this implement/fix?
Make DisjointBitSetsNode::get_containing_set_index() take const State&

#### Additional information
N/A
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
No AI tools used.
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://github.com/dwavesystems/dwave-ocean-sdk/blob/master/docs/ocean/ai_policy.rst -->
