### PR TITLE
Use `PyCapsule` for creating `Symbol`s from `Node*`s

### DIFF
--- a/dwave/optimization/_model.pyx
+++ b/dwave/optimization/_model.pyx
@@ -26,6 +26,7 @@ import zipfile
 import numpy as np
 
 from cpython cimport Py_buffer
+from cpython.pycapsule cimport PyCapsule_GetPointer, PyCapsule_New
 from cpython.ref cimport PyObject
 from cython.operator cimport dereference as deref, preincrement as inc
 from cython.operator cimport typeid
@@ -91,10 +92,14 @@ cdef object symbol_from_ptr(_Graph model, cppNode* node_ptr):
         # IndexError would be returned by .at()
         raise RuntimeError("given pointer cannot be cast to a known node type") from None
 
-    # In order to get nice polymorphism, it's much easier to pass the dispatch
-    # through Python, so we construct a generic Symbol holding the pointer and then
-    # construct the specific symbol from it.
-    return cls._from_symbol(Symbol.from_ptr(model, node_ptr))
+    # We'll use a PyCapsule to pass a node pointer through the Python layer so
+    # that we can let `cls` determine the type.
+
+    # Even though PyCapsule_New returns a PyObject*, Cython automatically makes
+    # it an object (with appropriate refcounting) so that's nice.
+    cap = PyCapsule_New(node_ptr, 'Node*', NULL)
+
+    return cls._from_ptr(model, cap)
 
 
 cdef class _Graph:
@@ -1195,17 +1200,11 @@ cdef class Symbol:
         return obj
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        # Disallow lateral casts or demotions.
-        # This is to prevent, say, an Add to be constructed from a Subtract
-        # There are ways around it, but this method is private anyway so it
-        # should be enough of a discouragement and for safety.
-        if not issubclass(cls, type(symbol)):
-            raise TypeError(f"cannot construct a {cls.__name__} from a {type(symbol).__name__}")
-
-        cdef Symbol obj = cls.__new__(cls)
-        obj.initialize_node(symbol.model, symbol.node_ptr)
-        return obj
+    def _from_ptr(cls, model, capsule):
+        """Create a Symbol from a Python capsule containing a Node pointer."""
+        cdef Symbol sym = cls.__new__(cls)
+        sym.initialize_node(model, <cppNode*>(PyCapsule_GetPointer(capsule, 'Node*')))
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):
@@ -1681,23 +1680,14 @@ cdef class ArraySymbol(Symbol):
         self.initialize_node(model, array_ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        """Construct an ArraySymbol from another Symbol."""
-        # Disallow lateral casts or demotions.
-        # This is to prevent, say, an Add to be constructed from a Subtract
-        # There are ways around it, but this method is private anyway so it
-        # should be enough of a discouragement and for safety.
-        if not issubclass(cls, type(symbol)):
-            raise TypeError(f"cannot construct a {cls.__name__} from a {type(symbol).__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef ArraySymbol sym = super()._from_ptr(model, capsule)
 
-        # Now try to "promote" the type and raise an error if that fails.
-        cdef cppArrayNode* ptr = dynamic_cast_ptr[cppArrayNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+        sym.array_ptr = dynamic_cast_ptr[cppArrayNode](sym.node_ptr)
+        if not sym.array_ptr:
+            raise TypeError(f"given pointer cannot construct an ArrayNode")
 
-        cdef ArraySymbol obj = cls.__new__(cls)
-        obj.initialize_arraynode(symbol.model, ptr)
-        return obj
+        return sym
 
     # Opt ArraySymbol out of default interoperability with NumPy ufuncs. We then
     # add explicit support with our various __<op>__() and __r<op>__ methods.

--- a/dwave/optimization/symbols/accumulate_zip.pyx
+++ b/dwave/optimization/symbols/accumulate_zip.pyx
@@ -157,16 +157,14 @@ cdef class AccumulateZip(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef AccumulateZipNode* ptr = dynamic_cast_ptr[AccumulateZipNode](
-            symbol.node_ptr
-        )
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
-        cdef AccumulateZip x = AccumulateZip.__new__(AccumulateZip)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
+    def _from_ptr(cls, model, capsule):
+        cdef AccumulateZip sym = super()._from_ptr(model, capsule)
+
+        sym.ptr = dynamic_cast_ptr[AccumulateZipNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a AccumulateZip")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):

--- a/dwave/optimization/symbols/collections.pyx
+++ b/dwave/optimization/symbols/collections.pyx
@@ -70,14 +70,14 @@ cdef class DisjointBitSet(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef DisjointBitSetNode* ptr = dynamic_cast_ptr[DisjointBitSetNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
-        cdef DisjointBitSet x = DisjointBitSet.__new__(DisjointBitSet)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
+    def _from_ptr(cls, model, capsule):
+        cdef DisjointBitSet sym = super()._from_ptr(model, capsule)
+
+        sym.ptr = dynamic_cast_ptr[DisjointBitSetNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a DisjointBitSet")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):
@@ -169,15 +169,14 @@ cdef class DisjointBitSets(Symbol):
         self.initialize_node(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef DisjointBitSetsNode* ptr = dynamic_cast_ptr[DisjointBitSetsNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef DisjointBitSets sym = super()._from_ptr(model, capsule)
 
-        cdef DisjointBitSets x = DisjointBitSets.__new__(DisjointBitSets)
-        x.ptr = ptr
-        x.initialize_node(symbol.model, ptr)
-        return x
+        sym.ptr = dynamic_cast_ptr[DisjointBitSetsNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a DisjointBitSets")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):
@@ -375,14 +374,14 @@ cdef class DisjointList(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef DisjointListNode* ptr = dynamic_cast_ptr[DisjointListNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
-        cdef DisjointList x = DisjointList.__new__(DisjointList)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
+    def _from_ptr(cls, model, capsule):
+        cdef DisjointList sym = super()._from_ptr(model, capsule)
+
+        sym.ptr = dynamic_cast_ptr[DisjointListNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a DisjointList")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):
@@ -478,14 +477,14 @@ cdef class DisjointLists(Symbol):
         return DisjointList(self, index)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef DisjointListsNode* ptr = dynamic_cast_ptr[DisjointListsNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
-        cdef DisjointLists x = DisjointLists.__new__(DisjointLists)
-        x.ptr = ptr
-        x.initialize_node(symbol.model, ptr)
-        return x
+    def _from_ptr(cls, model, capsule):
+        cdef DisjointLists sym = super()._from_ptr(model, capsule)
+
+        sym.ptr = dynamic_cast_ptr[DisjointListsNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a DisjointLists")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):
@@ -682,15 +681,14 @@ cdef class ListVariable(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef ListNode* ptr = dynamic_cast_ptr[ListNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef ListVariable sym = super()._from_ptr(model, capsule)
 
-        cdef ListVariable x = ListVariable.__new__(ListVariable)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
+        sym.ptr = dynamic_cast_ptr[ListNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a ListVariable")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):
@@ -781,15 +779,14 @@ cdef class SetVariable(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef SetNode* ptr = dynamic_cast_ptr[SetNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef SetVariable sym = super()._from_ptr(model, capsule)
 
-        cdef SetVariable x = SetVariable.__new__(SetVariable)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
+        sym.ptr = dynamic_cast_ptr[SetNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a SetVariable")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):

--- a/dwave/optimization/symbols/constants.pyx
+++ b/dwave/optimization/symbols/constants.pyx
@@ -169,15 +169,14 @@ cdef class Constant(ArraySymbol):
         return self.ptr.size() == 1 and self.ptr.ndim() == 0
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef ConstantNode* ptr = dynamic_cast_ptr[ConstantNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef Constant sym = super()._from_ptr(model, capsule)
 
-        cdef Constant constant = Constant.__new__(Constant)
-        constant.ptr = ptr
-        constant.initialize_arraynode(symbol.model, ptr)
-        return constant
+        sym.ptr = dynamic_cast_ptr[ConstantNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a Constant")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):

--- a/dwave/optimization/symbols/creation.pyx
+++ b/dwave/optimization/symbols/creation.pyx
@@ -93,13 +93,13 @@ cdef class ARange(ArraySymbol):
             raise RuntimeError  # shouldn't be possible
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef ARangeNode* ptr = dynamic_cast_ptr[ARangeNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
-        cdef ARange sym = cls.__new__(cls)
-        sym.ptr = ptr
-        sym.initialize_arraynode(symbol.model, ptr)
+    def _from_ptr(cls, model, capsule):
+        cdef ARange sym = super()._from_ptr(model, capsule)
+
+        sym.ptr = dynamic_cast_ptr[ARangeNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a ARange")
+
         return sym
 
     @classmethod

--- a/dwave/optimization/symbols/indexing.pyx
+++ b/dwave/optimization/symbols/indexing.pyx
@@ -123,14 +123,13 @@ cdef class AdvancedIndexing(ArraySymbol):
         return super().__getitem__(index)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef AdvancedIndexingNode* ptr = dynamic_cast_ptr[AdvancedIndexingNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef AdvancedIndexing sym = super()._from_ptr(model, capsule)
 
-        cdef AdvancedIndexing sym = AdvancedIndexing.__new__(AdvancedIndexing)
-        sym.ptr = ptr
-        sym.initialize_arraynode(symbol.model, ptr)
+        sym.ptr = dynamic_cast_ptr[AdvancedIndexingNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a AdvancedIndexing")
+
         return sym
 
     @classmethod
@@ -232,14 +231,13 @@ cdef class BasicIndexing(ArraySymbol):
         return Slice(start, stop, step)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef BasicIndexingNode* ptr = dynamic_cast_ptr[BasicIndexingNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef BasicIndexing sym = super()._from_ptr(model, capsule)
 
-        cdef BasicIndexing sym = BasicIndexing.__new__(BasicIndexing)
-        sym.ptr = ptr
-        sym.initialize_arraynode(symbol.model, ptr)
+        sym.ptr = dynamic_cast_ptr[BasicIndexingNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a BasicIndexing")
+
         return sym
 
     @classmethod

--- a/dwave/optimization/symbols/inputs.pyx
+++ b/dwave/optimization/symbols/inputs.pyx
@@ -120,15 +120,14 @@ cdef class Input(ArraySymbol):
         return self.ptr.max()
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef InputNode* ptr = dynamic_cast_ptr[InputNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef Input sym = super()._from_ptr(model, capsule)
 
-        cdef Input inp = Input.__new__(Input)
-        inp.ptr = ptr
-        inp.initialize_arraynode(symbol.model, ptr)
-        return inp
+        sym.ptr = dynamic_cast_ptr[InputNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a Input")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):

--- a/dwave/optimization/symbols/interpolation.pyx
+++ b/dwave/optimization/symbols/interpolation.pyx
@@ -54,14 +54,14 @@ cdef class BSpline(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef BSplineNode * ptr = dynamic_cast_ptr[BSplineNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
-        cdef BSpline m = BSpline.__new__(BSpline)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
+    def _from_ptr(cls, model, capsule):
+        cdef BSpline sym = super()._from_ptr(model, capsule)
+
+        sym.ptr = dynamic_cast_ptr[BSplineNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a BSpline")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):

--- a/dwave/optimization/symbols/lp.pyx
+++ b/dwave/optimization/symbols/lp.pyx
@@ -200,14 +200,14 @@ cdef class LinearProgram(Symbol):
         return x.array_ptr
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef LinearProgramNode* ptr = dynamic_cast_ptr[LinearProgramNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
-        cdef LinearProgram x = LinearProgram.__new__(LinearProgram)
-        x.ptr = ptr
-        x.initialize_node(symbol.model, ptr)
-        return x
+    def _from_ptr(cls, model, capsule):
+        cdef LinearProgram sym = super()._from_ptr(model, capsule)
+
+        sym.ptr = dynamic_cast_ptr[LinearProgramNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a LinearProgram")
+
+        return sym
 
     def feasible(self, Py_ssize_t index = 0):
         """Return True if the indexed state is a feasible solution.

--- a/dwave/optimization/symbols/manipulation.pyx
+++ b/dwave/optimization/symbols/manipulation.pyx
@@ -119,15 +119,14 @@ cdef class Concatenate(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef ConcatenateNode* ptr = dynamic_cast_ptr[ConcatenateNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef Concatenate sym = super()._from_ptr(model, capsule)
 
-        cdef Concatenate m = Concatenate.__new__(Concatenate)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
+        sym.ptr = dynamic_cast_ptr[ConcatenateNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a Concatenate")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):
@@ -228,15 +227,14 @@ cdef class Reshape(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef ReshapeNode* ptr = dynamic_cast_ptr[ReshapeNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef Reshape sym = super()._from_ptr(model, capsule)
 
-        cdef Reshape m = Reshape.__new__(Reshape)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
+        sym.ptr = dynamic_cast_ptr[ReshapeNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a Reshape")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):
@@ -291,15 +289,14 @@ cdef class Resize(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef ResizeNode* ptr = dynamic_cast_ptr[ResizeNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef Resize sym = super()._from_ptr(model, capsule)
 
-        cdef Resize m = Resize.__new__(Resize)
-        m.ptr = ptr
-        m.initialize_arraynode(symbol.model, ptr)
-        return m
+        sym.ptr = dynamic_cast_ptr[ResizeNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a Resize")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):
@@ -382,15 +379,14 @@ cdef class Roll(ArraySymbol):
         self.initialize_arraynode(array.model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef RollNode* ptr = dynamic_cast_ptr[RollNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef Roll sym = super()._from_ptr(model, capsule)
 
-        cdef Roll r = Roll.__new__(Roll)
-        r.ptr = ptr
-        r.initialize_arraynode(symbol.model, ptr)
-        return r
+        sym.ptr = dynamic_cast_ptr[RollNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a Roll")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):

--- a/dwave/optimization/symbols/naryop.pyx
+++ b/dwave/optimization/symbols/naryop.pyx
@@ -56,14 +56,14 @@ cdef class NaryAdd(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef NaryAddNode* ptr = dynamic_cast_ptr[NaryAddNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
-        cdef NaryAdd x = NaryAdd.__new__(NaryAdd)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
+    def _from_ptr(cls, model, capsule):
+        cdef NaryAdd sym = super()._from_ptr(model, capsule)
+
+        sym.ptr = dynamic_cast_ptr[NaryAddNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a NaryAdd")
+
+        return sym
 
     def __iadd__(self, rhs):
         if not self.node_ptr.successors().empty():
@@ -169,14 +169,14 @@ cdef class NaryMultiply(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef NaryMultiplyNode* ptr = dynamic_cast_ptr[NaryMultiplyNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
-        cdef NaryMultiply x = NaryMultiply.__new__(NaryMultiply)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
+    def _from_ptr(cls, model, capsule):
+        cdef NaryMultiply sym = super()._from_ptr(model, capsule)
+
+        sym.ptr = dynamic_cast_ptr[NaryMultiplyNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a NaryMultiply")
+
+        return sym
 
     def __imul__(self, rhs):
         if not self.node_ptr.successors().empty():

--- a/dwave/optimization/symbols/numbers.pyx
+++ b/dwave/optimization/symbols/numbers.pyx
@@ -175,15 +175,14 @@ cdef class BinaryVariable(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef BinaryNode* ptr = dynamic_cast_ptr[BinaryNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef BinaryVariable sym = super()._from_ptr(model, capsule)
 
-        cdef BinaryVariable x = BinaryVariable.__new__(BinaryVariable)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
+        sym.ptr = dynamic_cast_ptr[BinaryNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a BinaryVariable")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):
@@ -403,15 +402,14 @@ cdef class IntegerVariable(ArraySymbol):
         self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef IntegerNode* ptr = dynamic_cast_ptr[IntegerNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef IntegerVariable sym = super()._from_ptr(model, capsule)
 
-        cdef IntegerVariable x = IntegerVariable.__new__(IntegerVariable)
-        x.ptr = ptr
-        x.initialize_arraynode(symbol.model, ptr)
-        return x
+        sym.ptr = dynamic_cast_ptr[IntegerNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a IntegerVariable")
+
+        return sym
 
     @classmethod
     def _from_zipfile(cls, zf, directory, _Graph model, predecessors):

--- a/dwave/optimization/symbols/quadratic_model.pyx
+++ b/dwave/optimization/symbols/quadratic_model.pyx
@@ -160,15 +160,14 @@ cdef class QuadraticModel(ArraySymbol):
         self._init_from_coords(x, (data, coords), ldata)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef QuadraticModelNode* ptr = dynamic_cast_ptr[QuadraticModelNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
+    def _from_ptr(cls, model, capsule):
+        cdef QuadraticModel sym = super()._from_ptr(model, capsule)
 
-        cdef QuadraticModel qm = QuadraticModel.__new__(QuadraticModel)
-        qm.ptr = ptr
-        qm.initialize_arraynode(symbol.model, ptr)
-        return qm
+        sym.ptr = dynamic_cast_ptr[QuadraticModelNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a QuadraticModel")
+
+        return sym
 
     def get_linear(self, Py_ssize_t v):
         """Return the linear bias of a variable.

--- a/dwave/optimization/symbols/set_routines.pyx
+++ b/dwave/optimization/symbols/set_routines.pyx
@@ -52,18 +52,17 @@ cdef class IsDisjointCover(ArraySymbol):
                 raise ValueError("all predecessors must be from the same model")
             cppinputs.push_back((<ArraySymbol?>symbol).array_ptr)
 
-        self.primary_set_size = n
-        cdef IsDisjointCoverNode* ptr = model._graph.emplace_node[IsDisjointCoverNode](cppinputs, n)
-        self.initialize_arraynode(model, ptr)
+        self.ptr = model._graph.emplace_node[IsDisjointCoverNode](cppinputs, n)
+        self.initialize_arraynode(model, self.ptr)
 
     @classmethod
-    def _from_symbol(cls, Symbol symbol):
-        cdef IsDisjointCoverNode* ptr = dynamic_cast_ptr[IsDisjointCoverNode](symbol.node_ptr)
-        if not ptr:
-            raise TypeError(f"given symbol cannot construct a {cls.__name__}")
-        cdef IsDisjointCover sym = cls.__new__(cls)
-        sym.primary_set_size = ptr.primary_set_size()
-        sym.initialize_arraynode(symbol.model, ptr)
+    def _from_ptr(cls, model, capsule):
+        cdef IsDisjointCover sym = super()._from_ptr(model, capsule)
+
+        sym.ptr = dynamic_cast_ptr[IsDisjointCoverNode](sym.node_ptr)
+        if not sym.ptr:
+            raise TypeError(f"given pointer cannot construct a IsDisjointCover")
+
         return sym
 
     @classmethod
@@ -82,7 +81,12 @@ cdef class IsDisjointCover(ArraySymbol):
         args.update(primary_set_size=int(self.primary_set_size))
         zf.writestr(directory + "args.json", encoder.encode(args))
 
-    cdef Py_ssize_t primary_set_size
+    @property
+    def primary_set_size(self):
+        """The size of the set to be covered"""
+        return self.ptr.primary_set_size()
+
+    cdef IsDisjointCoverNode* ptr
 
 _register(IsDisjointCover, typeid(IsDisjointCoverNode))
 


### PR DESCRIPTION
We need a way to smuggle a C++ pointer through Python. Before we used a (malformed) `Symbol` but Python provides [capsules](https://docs.python.org/3/c-api/capsule.html) for this exact purpose. It doesn't really change the amount of code, but IMO this is a nicer mechanism.

Eventually this will help remove a circular dependency between `_Graph` and `Symbol`.

#### AI Generation Disclosure
No AI used.