### PR TITLE
Clean up imports in `states.pyx`/`states.pxd`

### DIFF
--- a/dwave/optimization/states.pxd
+++ b/dwave/optimization/states.pxd
@@ -16,17 +16,14 @@
 
 from libcpp.vector cimport vector
 
-from dwave.optimization.libcpp.state cimport State as cppState
-from dwave.optimization.model cimport _Graph
+from dwave.optimization.libcpp.state cimport State
 
 
 cdef class States:
-    cdef void attach_states(self, vector[cppState]) noexcept
-    cdef vector[cppState] detach_states(self)
+    cdef void attach_states(self, vector[State]) noexcept
+    cdef vector[State] detach_states(self)
     cpdef resolve(self)
     cpdef Py_ssize_t size(self) except -1
-
-    cdef _Graph _model(self)
 
     # In order to not create a circular reference, we only hold a weakref
     # to the model from the states. This introduces some overhead, but it
@@ -34,13 +31,9 @@ cdef class States:
     cdef readonly object _model_ref
 
     # The state(s) of the model kept as a ragged vector-of-vectors (each
-    # cppState is a vector).
+    # State is a vector).
     # Accessors should check the length of the state when accessing!
-    cdef vector[cppState] _states
-
-    # The number of views into the states that exist. The model cannot
-    # be unlocked while there are unsafe views
-    cdef public Py_ssize_t _view_count
+    cdef vector[State] _states
 
     # Object that contains or will contain the information needed to construct states
     cdef readonly object _future

--- a/dwave/optimization/states.pyx
+++ b/dwave/optimization/states.pyx
@@ -17,13 +17,9 @@ import tempfile
 import weakref
 import zipfile
 
-cimport cpython.buffer
-
 from libcpp.utility cimport move
 
-from dwave.optimization.libcpp.array cimport Array as cppArray
-from dwave.optimization.model cimport ArraySymbol, _Graph
-from dwave.optimization.model import Model
+from dwave.optimization.model cimport _Graph
 from dwave.optimization.utilities import _file_object_arg
 
 __all__ = ["States"]
@@ -87,15 +83,13 @@ cdef class States:
         :attr:`~dwave.optimization.model.Model.states`
     """
     def __init__(self, model):
-        if not isinstance(model, Model):
-            raise TypeError("model must be an instance of Model")
         self._model_ref = weakref.ref(model)
 
     def __len__(self):
         """The number of model states."""
         return self.size()
 
-    cdef void attach_states(self, vector[cppState] states) noexcept:
+    cdef void attach_states(self, vector[State] states) noexcept:
         """Attach the given states.
 
         Note:
@@ -135,7 +129,7 @@ cdef class States:
         """
         self.detach_states()
 
-    cdef vector[cppState] detach_states(self):
+    cdef vector[State] detach_states(self):
         """Move the current C++ states into a returned vector.
 
         Leaves the model's states empty.
@@ -149,7 +143,7 @@ cdef class States:
         self.resolve()
         # move should impliclty leave the states in a valid state, but
         # just to be super explicit we swap with an empty vector first
-        cdef vector[cppState] states
+        cdef vector[State] states
         self._states.swap(states)
         return move(states)
 
@@ -459,7 +453,7 @@ cdef class States:
                 version=version,
             )
 
-    cdef _Graph _model(self):
+    def _model(self):
         """Get a ref-counted Model object."""
         cdef _Graph m = self._model_ref()
         if m is None:


### PR DESCRIPTION
There were a bunch of unused imports and we were using the old `cpp*` convention that I'd like to move away from.

#### AI Generation Disclosure
No AI used.