### PR TITLE
Add early ``propagate()`` exit to ``Nodes``

### DIFF
--- a/dwave/optimization/include/dwave-optimization/nodes/quadratic_model.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/quadratic_model.hpp
@@ -101,6 +101,10 @@ class QuadraticModelNode : public ScalarOutputMixin<EqualityMixin<ArrayNode>> {
     QuadraticModel* get_quadratic_model();
 
  private:
+    // Redundant, because we could dynamic_cast each time from predecessors(),
+    // but this is more performant
+    const ArrayNode* array_ptr_;
+
     QuadraticModel quadratic_model_;
 };
 

--- a/dwave/optimization/src/nodes/binaryop.cpp
+++ b/dwave/optimization/src/nodes/binaryop.cpp
@@ -187,7 +187,9 @@ bool calculate_integral(const Array* lhs_ptr, const Array* rhs_ptr) {
 
 template <class BinaryOp>
 BinaryOpNode<BinaryOp>::BinaryOpNode(ArrayNode* a_ptr, ArrayNode* b_ptr) :
-    ArrayOutputMixin<EqualityMixin<ArrayNode, BinaryOpNode<BinaryOp>>>(broadcast_shapes(a_ptr->shape(), b_ptr->shape())),
+    ArrayOutputMixin<EqualityMixin<ArrayNode, BinaryOpNode<BinaryOp>>>(
+        broadcast_shapes(a_ptr->shape(), b_ptr->shape())
+    ),
     operands_({a_ptr, b_ptr}),
     values_info_(
         calculate_values_minmax<BinaryOp>(operands_[0], operands_[1]),
@@ -315,16 +317,18 @@ double BinaryOpNode<BinaryOp>::min() const {
 
 template <class BinaryOp>
 void BinaryOpNode<BinaryOp>::propagate(State& state) const {
-    auto ptr = this->template data_ptr_<ArrayNodeStateData>(state);
-
     const Array* lhs_ptr = operands_[0];
     const Array* rhs_ptr = operands_[1];
+    std::span<const Update> lhs_diff = lhs_ptr->diff(state);
+    std::span<const Update> rhs_diff = rhs_ptr->diff(state);
+
+    // If there are no updates, return early.
+    if (lhs_diff.empty() and rhs_diff.empty()) return;
+
+    auto ptr = this->template data_ptr_<ArrayNodeStateData>(state);
 
     if (std::ranges::equal(lhs_ptr->shape(state), rhs_ptr->shape(state))) {
         // The easy case, just go through both predecessors making updates.
-
-        std::span<const Update> lhs_diff = lhs_ptr->diff(state);
-        std::span<const Update> rhs_diff = rhs_ptr->diff(state);
 
         // Handle the dynamic case by copying and deduplicating both diffs,
         // and then get a span pointing to the copies to use instead of
@@ -334,8 +338,8 @@ void BinaryOpNode<BinaryOp>::propagate(State& state) const {
         if (lhs_ptr->dynamic()) {
             assert(rhs_ptr->dynamic());
             // Copy and then deduplicate both diffs
-            lhs_diff_copy.assign(lhs_ptr->diff(state).begin(), lhs_ptr->diff(state).end());
-            rhs_diff_copy.assign(rhs_ptr->diff(state).begin(), rhs_ptr->diff(state).end());
+            lhs_diff_copy.assign(lhs_diff.begin(), lhs_diff.end());
+            rhs_diff_copy.assign(rhs_diff.begin(), rhs_diff.end());
             deduplicate_diff(lhs_diff_copy);
             deduplicate_diff(rhs_diff_copy);
             lhs_diff = std::span<const Update>(lhs_diff_copy.begin(), lhs_diff_copy.end());
@@ -360,11 +364,12 @@ void BinaryOpNode<BinaryOp>::propagate(State& state) const {
                 return !up.removed() && !up.placed();
             };
 
-            ptr->update(lhs_diff | std::views::transform(apply_op));
+            ptr->update(std::move(lhs_diff) | std::views::transform(apply_op));
             // For the RHS, we have already dealt with growing/shrinking the array,
             // so we just ignore all updates that are placements/removals.
             ptr->update(
-                rhs_diff | std::views::filter(is_standard_update) | std::views::transform(apply_op)
+                std::move(rhs_diff) | std::views::filter(is_standard_update) |
+                std::views::transform(apply_op)
             );
         } else if (lhs_diff.size()) {
             // LHS modified, but not RHS
@@ -386,7 +391,7 @@ void BinaryOpNode<BinaryOp>::propagate(State& state) const {
         const double lhs = lhs_ptr->view(state).front();
         auto unary_func = std::bind(op, lhs, std::placeholders::_1);
 
-        if (lhs_ptr->diff(state).size()) {
+        if (lhs_diff.size()) {
             // The lhs has changed, so in this case we're probably changing
             // everything, so just overwrite the state entirely.
             auto rhs_view = rhs_ptr->view(state);
@@ -397,7 +402,7 @@ void BinaryOpNode<BinaryOp>::propagate(State& state) const {
                 if (!update.removed()) update.value = unary_func(update.value);
                 return update;
             };
-            ptr->update(rhs_ptr->diff(state) | std::views::transform(update_func));
+            ptr->update(std::move(rhs_diff) | std::views::transform(update_func));
         }
     } else if (rhs_ptr->size() == 1) {
         // rhs is a single value being broadcast to the lhs array
@@ -406,7 +411,7 @@ void BinaryOpNode<BinaryOp>::propagate(State& state) const {
         const double rhs = rhs_ptr->view(state).front();
         auto unary_func = std::bind(op, std::placeholders::_1, rhs);
 
-        if (rhs_ptr->diff(state).size()) {
+        if (rhs_diff.size()) {
             // The rhs has changed, so in this case we're probably changing
             // everything, so just overwrite the state entirely.
             auto lhs_view = lhs_ptr->view(state);
@@ -417,7 +422,7 @@ void BinaryOpNode<BinaryOp>::propagate(State& state) const {
                 if (!update.removed()) update.value = unary_func(update.value);
                 return update;
             };
-            ptr->update(lhs_ptr->diff(state) | std::views::transform(update_func));
+            ptr->update(std::move(lhs_diff) | std::views::transform(update_func));
         }
     } else {
         // this case is complicated we need to "stretch" dimensions into eachother

--- a/dwave/optimization/src/nodes/creation.cpp
+++ b/dwave/optimization/src/nodes/creation.cpp
@@ -374,6 +374,9 @@ void ARangeNode::propagate(State& state) const {
     const auto [stop_old, stop_new] = std::visit(visitor, stop_);
     const auto [step_old, step_new] = std::visit(visitor, step_);
 
+    // If nothing has changed, return early.
+    if (start_old == start_new and stop_old == stop_new and step_old == step_new) return;
+
     ArrayNodeStateData* ptr = data_ptr_<ArrayNodeStateData>(state);
 
     // If the start or the step has changed, we need to change everything

--- a/dwave/optimization/src/nodes/flow.cpp
+++ b/dwave/optimization/src/nodes/flow.cpp
@@ -99,16 +99,18 @@ double ExtractNode::max() const { return values_info_.max; }
 double ExtractNode::min() const { return values_info_.min; }
 
 void ExtractNode::propagate(State& state) const {
-    auto node_data = data_ptr_<ArrayNodeStateData>(state);
-
+    const auto condition_diff = condition_ptr_->diff(state);
+    const auto array_diff = arr_ptr_->diff(state);
     // Nothing to do in this case
-    if (condition_ptr_->diff(state).empty() && arr_ptr_->diff(state).empty()) return;
+    if (condition_diff.empty() and array_diff.empty()) return;
+
+    auto node_data = data_ptr_<ArrayNodeStateData>(state);
 
     auto get_index = [](const Update& update) { return update.index; };
 
     // Get the minimum changed index
-    auto cond_view = condition_ptr_->diff(state) | std::views::transform(get_index);
-    auto arr_view = arr_ptr_->diff(state) | std::views::transform(get_index);
+    auto cond_view = condition_diff | std::views::transform(get_index);
+    auto arr_view = array_diff | std::views::transform(get_index);
     auto min_cond_it = std::ranges::min_element(cond_view);
     auto min_arr_it = std::ranges::min_element(arr_view);
 
@@ -337,6 +339,12 @@ bool _flipped(std::span<const Update> diff) {
 }
 
 void WhereNode::propagate(State& state) const {
+    auto condition_diff = condition_ptr_->diff(state);
+    auto x_diff = x_ptr_->diff(state);
+    auto y_diff = y_ptr_->diff(state);
+    // If there are no updates, return early.
+    if (condition_diff.empty() and x_diff.empty() and y_diff.empty()) return;
+
     auto node_data = data_ptr_<WhereNodeData>(state);
 
     if (condition_ptr_->size() != 1) {
@@ -344,14 +352,14 @@ void WhereNode::propagate(State& state) const {
 
         node_data->apply_diffs(
             condition_ptr_->view(state),
-            condition_ptr_->diff(state),
+            std::move(condition_diff),
             x_ptr_->view(state),
-            x_ptr_->diff(state),
+            std::move(x_diff),
             y_ptr_->view(state),
-            y_ptr_->diff(state)
+            std::move(y_diff)
         );
 
-    } else if (_flipped(condition_ptr_->diff(state))) {
+    } else if (_flipped(std::move(condition_diff))) {
         // `condition` is a single value and it changed
         // so let's just assume we're updating everything in our buffer
 
@@ -369,10 +377,10 @@ void WhereNode::propagate(State& state) const {
 
         if (condition_ptr_->buff(state)[0]) {
             // we're pointing to x, so update ourselves according to x
-            node_data->update(x_ptr_->diff(state));
+            node_data->update(std::move(x_diff));
         } else {
             // we're pointing to y, so update ourselves according to y
-            node_data->update(y_ptr_->diff(state));
+            node_data->update(std::move(y_diff));
         }
     }
 }

--- a/dwave/optimization/src/nodes/indexing.cpp
+++ b/dwave/optimization/src/nodes/indexing.cpp
@@ -894,6 +894,20 @@ std::pair<ssize_t, ssize_t> get_mapped_index(
 }
 
 void AdvancedIndexingNode::propagate(State& state) const {
+    // Check if there are no updates.
+    if (array_ptr_->diff(state).empty()) {
+        // `array_ptr_` has no updates, suffices to check `indexer` arrays.
+        bool no_updates = true;
+        for (const auto indexer : indices_) {
+            if (!std::holds_alternative<ArrayNode*>(indexer)) continue;
+            if (not std::get<ArrayNode*>(indexer)->diff(state).empty()) {
+                no_updates = false;
+                break;
+            }
+        }
+        if (no_updates) return;  // No updates to process, return early.
+    }
+
     // Pull the data into this namespce
     auto node_data = data_ptr_<AdvancedIndexingNodeData>(state);
     auto& data = node_data->data;
@@ -1622,6 +1636,9 @@ double BasicIndexingNode::min() const { return this->values_info_.min; }
 double BasicIndexingNode::max() const { return this->values_info_.max; }
 
 void BasicIndexingNode::propagate(State& state) const {
+    // If there are no updates, return early.
+    if (array_ptr_->diff(state).empty()) return;
+
     auto node_data = data_ptr_<BasicIndexingNodeData>(state);
     auto& diff = node_data->diff;
     assert(diff.size() == 0 && "calling propagate on an node with pending updates");
@@ -2113,6 +2130,12 @@ void PermutationNode::initialize_state(State& state) const {
 }
 
 void PermutationNode::propagate(State& state) const {
+    assert(array_ptr_->diff(state).empty() and "not implemented yet");  // todo
+
+    const auto order_diff = order_ptr_->diff(state);
+    // If there are no updates, return early.
+    if (order_diff.empty()) return;
+
     auto ptr = data_ptr_<IndexingNodeData>(state);
 
     auto& offsets = ptr->offsets;
@@ -2123,7 +2146,6 @@ void PermutationNode::propagate(State& state) const {
     assert(updates.size() == 0 && "called propagate on a node with pending updates");
 
     // incorporate changes to the order
-    auto order_diff = order_ptr_->diff(state);
     if (order_diff.size()) {
         const ssize_t ndim = this->ndim();
         const ssize_t n = this->shape()[0];
@@ -2158,9 +2180,6 @@ void PermutationNode::propagate(State& state) const {
             step *= n;
         }
     }
-
-    // incorporate changes to the array
-    assert(array_ptr_->diff(state).size() == 0 && "not implemented yet");  // todo
 
     // Only signal successors if we actually have something to propagate
     if (updates.size()) Node::propagate(state);

--- a/dwave/optimization/src/nodes/interpolation.cpp
+++ b/dwave/optimization/src/nodes/interpolation.cpp
@@ -153,10 +153,11 @@ void BSplineNode::initialize_state(State& state) const {
 }
 
 void BSplineNode::propagate(State& state) const {
-    auto node_data_ptr = dynamic_cast<ArrayNode*>(predecessors()[0]);
-    auto diff = node_data_ptr->diff(state);
-    auto state_data = node_data_ptr->view(state);
+    const auto diff = array_ptr_->diff(state);
+    // If there are no updates, return early.
+    if (diff.empty()) return;
 
+    auto state_data = array_ptr_->view(state);
     for (const auto& [index, _, __] : diff) {
         data_ptr_<ArrayNodeStateData>(state)->set(index, compute_value(state_data[index]));
     }

--- a/dwave/optimization/src/nodes/linear_algebra.cpp
+++ b/dwave/optimization/src/nodes/linear_algebra.cpp
@@ -531,7 +531,7 @@ void MatrixMultiplyNode::update_shape_(State& state) const {
 }
 
 void MatrixMultiplyNode::propagate(State& state) const {
-    if (operands_[0]->diff(state).size() == 0 and operands_[1]->diff(state).size() == 0) return;
+    if (operands_[0]->diff(state).empty() and operands_[1]->diff(state).empty()) return;
 
     auto data = data_ptr_<MatrixMultiplyNodeData>(state);
 

--- a/dwave/optimization/src/nodes/manipulation.cpp
+++ b/dwave/optimization/src/nodes/manipulation.cpp
@@ -246,11 +246,10 @@ double BroadcastToNode::max() const { return values_info_.max; }
 ssize_t BroadcastToNode::ndim() const { return ndim_; }
 
 void BroadcastToNode::propagate(State& state) const {
-    BroadcastToNodeData* data_ptr = this->data_ptr_<BroadcastToNodeData>(state);
-
     const auto from_diff = array_ptr_->diff(state);
     if (from_diff.empty()) return;  // exit early if nothing to propagate
 
+    BroadcastToNodeData* data_ptr = this->data_ptr_<BroadcastToNodeData>(state);
     auto& to_diff = data_ptr->diff;
     assert(to_diff.empty());  // should be cleared between propagations
 
@@ -540,6 +539,10 @@ void ConcatenateNode::propagate(State& state) const {
     auto ptr = data_ptr_<ArrayNodeStateData>(state);
 
     for (ssize_t arr_i = 0, stop = array_ptrs_.size(); arr_i < stop; ++arr_i) {
+        const auto diff = array_ptrs_[arr_i]->diff(state);
+        // No updates for given pointer, move to next.
+        if (diff.empty()) continue;
+
         auto view_it = Array::const_iterator(
             ptr->buff() + array_starts_[arr_i],
             this->ndim(),
@@ -547,7 +550,7 @@ void ConcatenateNode::propagate(State& state) const {
             this->strides().data()
         );
 
-        for (auto update : array_ptrs_[arr_i]->diff(state)) {
+        for (const auto update : diff) {
             assert(!update.placed() && !update.removed() && "no dynamic support implemented");
             auto update_it = view_it + update.index;
             ssize_t buffer_index = &*update_it - ptr->buff();
@@ -596,7 +599,11 @@ double CopyNode::min() const { return values_info_.min; }
 double CopyNode::max() const { return values_info_.max; }
 
 void CopyNode::propagate(State& state) const {
-    data_ptr_<ArrayNodeStateData>(state)->update(array_ptr_->diff(state));
+    auto diff = array_ptr_->diff(state);
+    // If there are no updates, return early.
+    if (diff.empty()) return;
+
+    data_ptr_<ArrayNodeStateData>(state)->update(std::move(diff));
 }
 
 void CopyNode::replace_predecessor_(ssize_t index, Node* node_ptr) {
@@ -828,6 +835,12 @@ double PutNode::min() const { return values_info_.min; }
 double PutNode::max() const { return values_info_.max; }
 
 void PutNode::propagate(State& state) const {
+    const auto array_diff = array_ptr_->diff(state);
+    const auto indices_diff = indices_ptr_->diff(state);
+    const auto values_diff = values_ptr_->diff(state);
+    // If there are no updates, return early.
+    if (array_diff.empty() and indices_diff.empty() and values_diff.empty()) return;
+
     auto ptr = data_ptr_<PutNodeState>(state);
 
     // these should always be synced
@@ -840,7 +853,7 @@ void PutNode::propagate(State& state) const {
 
         const ssize_t values_size = values_ptr_->size(state);
 
-        for (const Update& update : indices_ptr_->diff(state)) {
+        for (const Update& update : indices_diff) {
             // if the update is not a placement, that means that we're removing
             // update.old from the list of masked indices and thereby potentially
             // overwriting the value propagated by the PutNode
@@ -881,7 +894,7 @@ void PutNode::propagate(State& state) const {
     {
         auto index_iterator = indices_ptr_->begin(state);
 
-        for (const Update& update : values_ptr_->diff(state)) {
+        for (const Update& update : values_diff) {
             if (update.removed()) continue;  // should have already been handled by the indexer
             assert(is_integer(*(index_iterator + update.index)));
 
@@ -890,7 +903,7 @@ void PutNode::propagate(State& state) const {
     }
 
     // finally incorporate changes from the base array.
-    for (const Update& update : array_ptr_->diff(state)) {
+    for (const Update& update : array_diff) {
         assert(!update.placed() && "base array cannot be dynamic");
         assert(!update.removed() && "base array cannot be dynamic");
         ptr->update_array(update);
@@ -1206,13 +1219,17 @@ double ResizeNode::min() const { return values_info_.min; }
 double ResizeNode::max() const { return values_info_.max; }
 
 void ResizeNode::propagate(State& state) const {
+    const auto diff = array_ptr_->diff(state);
+    // If there are no updates, return early.
+    if (diff.empty()) return;
+
     const ssize_t size = this->size();  // the desired size of our state
     assert(size >= 0);                  // we're never dynamic
 
     auto data_ptr = this->data_ptr_<ArrayNodeStateData>(state);
     assert(data_ptr);  // should never be nullptr
 
-    for (const Update& update : array_ptr_->diff(state)) {
+    for (const Update& update : diff) {
         const auto& [index, _, value] = update;
 
         if (index >= size) continue;  // don't care, it's out of range
@@ -1379,6 +1396,10 @@ void RollNode::propagate(State& state) const {
             // if neither our size nor our shift changed, then we just need to
             // update the individual indices and it is efficient to do so.
 
+            // If there are no updates, return early.
+            auto diff = array_ptr_->diff(state);
+            if (diff.empty()) return;
+
             auto transform = [&shift, &size](Update update) -> Update {
                 update.index = positive_modulus_(update.index + shift, size);
                 return update;
@@ -1391,14 +1412,13 @@ void RollNode::propagate(State& state) const {
                 // deduplicate_diff_view(), but alas some of the old Python images
                 // don't support deduplicate_diff_view with std::ranges::transform.
                 // So we have to do it manually with a copy.
-                auto diff = array_ptr_->diff(state);
                 std::vector<Update> updates(diff.begin(), diff.end());
                 deduplicate_diff(updates);
                 state_ptr->update(updates | std::views::transform(transform));
             } else {
                 // Otherwise we just propagate the diff like normal under the assumption
                 // that our predecessor was efficient (not always true but nice to believe).
-                state_ptr->update(std::ranges::transform_view(array_ptr_->diff(state), transform));
+                state_ptr->update(std::ranges::transform_view(std::move(diff), transform));
             }
         } else {
             // Either our size or our shift has changed, so we might as well re-calculate
@@ -1414,6 +1434,10 @@ void RollNode::propagate(State& state) const {
         const auto [shifts, changed] = shifts_diff_(state);
 
         if (not changed and array_ptr_->size_diff(state) == 0) {
+            // If there are no updates, return early.
+            auto diff = array_ptr_->diff(state);
+            if (diff.empty()) return;
+
             const auto shape = array_ptr_->shape(state);
 
             auto transform = [&shape, &shifts](Update update) -> Update {
@@ -1445,7 +1469,6 @@ void RollNode::propagate(State& state) const {
             // Unlike the flat shift case we always deduplicate because each shift
             // operation is relatively expensive.
             // See note there about the use of deduplicate_diff
-            auto diff = array_ptr_->diff(state);
             std::vector<Update> updates(diff.begin(), diff.end());
             deduplicate_diff(updates);
             state_ptr->update(updates | std::views::transform(transform));
@@ -1616,7 +1639,11 @@ double SizeNode::min() const { return minmax_.first; }
 
 double SizeNode::max() const { return minmax_.second; }
 
-void SizeNode::propagate(State& state) const { set_state(state, array_ptr_->size(state)); }
+void SizeNode::propagate(State& state) const {
+    // If there are no updates, return early.
+    if (array_ptr_->diff(state).empty()) return;
+    set_state(state, array_ptr_->size(state));
+}
 
 void SizeNode::replace_predecessor_(ssize_t index, Node* node_ptr) {
     Node::replace_predecessor_(index, node_ptr);

--- a/dwave/optimization/src/nodes/naryop.cpp
+++ b/dwave/optimization/src/nodes/naryop.cpp
@@ -262,8 +262,6 @@ template <class BinaryOp>
 void NaryOpNode<BinaryOp>::propagate(State& state) const {
     auto node_data = data_ptr_<NaryOpNodeData>(state);
 
-    auto& iterators = node_data->iterators;
-
     std::vector<ssize_t> recompute_indices;
 
     if constexpr (!InverseOp<BinaryOp>().exists()) {
@@ -298,6 +296,7 @@ void NaryOpNode<BinaryOp>::propagate(State& state) const {
 
     // now fully recompute any needed indices
     if (recompute_indices.size()) {
+        auto& iterators = node_data->iterators;
         iterators.clear();
         for (const Array* node_ptr : operands_) {
             iterators.push_back(node_ptr->begin(state));

--- a/dwave/optimization/src/nodes/quadratic_model.cpp
+++ b/dwave/optimization/src/nodes/quadratic_model.cpp
@@ -276,9 +276,9 @@ QuadraticModelNode::QuadraticModelNode(
     ArrayNode* state_node_ptr,
     QuadraticModel&& quadratic_model
 ) :
-    quadratic_model_(quadratic_model) {
+    array_ptr_(state_node_ptr), quadratic_model_(quadratic_model) {
     if (!std::ranges::equal(
-            state_node_ptr->shape(), std::vector<ssize_t>{quadratic_model_.num_variables()}
+            array_ptr_->shape(), std::vector<ssize_t>{quadratic_model_.num_variables()}
         )) {
         throw std::invalid_argument(
             "node array must be one dimensional of length same as QuadraticModelNode.shape[0]"
@@ -306,8 +306,7 @@ void QuadraticModelNode::revert(State& state) const {
 }
 
 void QuadraticModelNode::initialize_state(State& state) const {
-    Array* ptr = dynamic_cast<Array*>(predecessors()[0]);
-    std::vector<double> state_copy(ptr->begin(state), ptr->end(state));
+    std::vector<double> state_copy(array_ptr_->begin(state), array_ptr_->end(state));
     double value = quadratic_model_.compute_value(state_copy);
     emplace_data_ptr_<QuadraticModelNodeData>(
         state, value, std::move(state_copy), quadratic_model_.num_variables()
@@ -315,53 +314,52 @@ void QuadraticModelNode::initialize_state(State& state) const {
 }
 
 void QuadraticModelNode::propagate(State& state) const {
-    auto state_node_ptr = dynamic_cast<Array*>(predecessors()[0]);
-    auto diff = state_node_ptr->diff(state);
-    if (diff.size()) {
-        auto node_data_ptr = data_ptr_<QuadraticModelNodeData>(state);
-        auto& previous_state = node_data_ptr->previous_state_;
-        auto& effective_changes = node_data_ptr->effective_changes_;
-        auto& value = node_data_ptr->value;
+    const auto diff = array_ptr_->diff(state);
+    // If there are not updates, return early.
+    if (diff.empty()) return;
 
-        if (state_node_ptr->contiguous()) {
-            auto current_state =
-                std::span(state_node_ptr->buff(state), state_node_ptr->size(state));
-            for (auto& update : diff) {
-                auto index = update.index;
-                auto neo = current_state[index];
-                auto old = previous_state[index];
+    auto node_data_ptr = data_ptr_<QuadraticModelNodeData>(state);
+    auto& previous_state = node_data_ptr->previous_state_;
+    auto& effective_changes = node_data_ptr->effective_changes_;
+    auto& value = node_data_ptr->value;
 
-                // We do not need to process every update, only if there is a difference between the
-                // evolved state and the evolving state.
-                if (neo != old) {
-                    effective_changes.emplace_back(std::make_pair(index, old));
-                    value += (neo - old) *
-                             (quadratic_model_.get_quadratic(index) * (neo + old) +
-                              quadratic_model_.get_effective_linear_bias(index, previous_state));
-                    previous_state[index] = neo;
-                }
-            }
-        } else {
-            auto current_state = state_node_ptr->view(state);
-            for (auto& update : diff) {
-                auto index = update.index;
-                auto neo = current_state[index];
-                auto old = previous_state[index];
+    if (array_ptr_->contiguous()) {
+        auto current_state = std::span(array_ptr_->buff(state), array_ptr_->size(state));
+        for (auto& update : diff) {
+            auto index = update.index;
+            auto neo = current_state[index];
+            auto old = previous_state[index];
 
-                // We do not need to process every update, only if there is a difference between the
-                // evolved state and the evolving state.
-                if (neo != old) {
-                    effective_changes.emplace_back(std::make_pair(index, old));
-                    value += (neo - old) *
-                             (quadratic_model_.get_quadratic(index) * (neo + old) +
-                              quadratic_model_.get_effective_linear_bias(index, previous_state));
-                    previous_state[index] = neo;
-                }
+            // We do not need to process every update, only if there is a difference between the
+            // evolved state and the evolving state.
+            if (neo != old) {
+                effective_changes.emplace_back(std::make_pair(index, old));
+                value += (neo - old) *
+                         (quadratic_model_.get_quadratic(index) * (neo + old) +
+                          quadratic_model_.get_effective_linear_bias(index, previous_state));
+                previous_state[index] = neo;
             }
         }
+    } else {
+        auto current_state = array_ptr_->view(state);
+        for (auto& update : diff) {
+            auto index = update.index;
+            auto neo = current_state[index];
+            auto old = previous_state[index];
 
-        Node::propagate(state);
+            // We do not need to process every update, only if there is a difference between the
+            // evolved state and the evolving state.
+            if (neo != old) {
+                effective_changes.emplace_back(std::make_pair(index, old));
+                value += (neo - old) *
+                         (quadratic_model_.get_quadratic(index) * (neo + old) +
+                          quadratic_model_.get_effective_linear_bias(index, previous_state));
+                previous_state[index] = neo;
+            }
+        }
     }
+
+    Node::propagate(state);
 }
 
 QuadraticModel* QuadraticModelNode::get_quadratic_model() {

--- a/dwave/optimization/src/nodes/reduce.cpp
+++ b/dwave/optimization/src/nodes/reduce.cpp
@@ -955,11 +955,38 @@ ssize_t ReduceNode<BinaryOp>::convert_predecessor_index_(ssize_t index) const {
 
 template <class BinaryOp>
 void ReduceNode<BinaryOp>::propagate(State& state) const {
+    // Edge case is when our predecessor is a dynamic array with size 0 and
+    // we're also dynamic
+    if (this->dynamic() and array_ptr_->size() == 0) {
+        const ssize_t size = this->size(state);
+        const ssize_t new_size = product(drop_axes(array_ptr_->shape(state), axes_));
+
+        auto* const state_ptr = this->template data_ptr_<ReduceNodeData<BinaryOp>>(state);
+        // add/remove the relevant reductions
+        for (ssize_t i = size; i < new_size; ++i) state_ptr->append_reduction(*initial);
+        for (ssize_t i = size; i > new_size; --i) state_ptr->pop_reduction();
+
+        state_ptr->prepare_diff([&](ssize_t index) {
+            assert(false);  // should never be called because our reduction space is empty
+            return this->reduce_(state, index);
+        });
+        return;
+    }
+
+    const auto diff = array_ptr_->diff(state);
+    const ssize_t size_diff = array_ptr_->size_diff(state);
+    // If there are no updates, return early.*
+    // * Cannot do this earlier because of the above edge case.
+    if (diff.empty() and size_diff == 0) return;
+
     auto* const state_ptr = this->template data_ptr_<ReduceNodeData<BinaryOp>>(state);
 
     // We are reducing over all axes, so this is nice and simple
     if (axes_.empty() or axes_.size() == static_cast<std::size_t>(array_ptr_->ndim())) {
-        for (const Update& update : array_ptr_->diff(state)) {
+        // If there are no updates to handle, return early.
+        if (diff.empty()) return;
+
+        for (const Update& update : diff) {
             if (update.placed()) {
                 state_ptr->add_to_reduction(0, update.value);
             } else if (update.removed()) {
@@ -973,29 +1000,9 @@ void ReduceNode<BinaryOp>::propagate(State& state) const {
         return;
     }
 
-    // Another edge case is when our predecessor is a dynamic array with size 0
-    // and we're also dynamic
-    if (this->dynamic() and array_ptr_->size() == 0) {
-        const ssize_t size = this->size(state);
-        const ssize_t new_size = product(drop_axes(array_ptr_->shape(state), axes_));
-
-        // add/remove the relevant reductions
-        for (ssize_t i = size; i < new_size; ++i) state_ptr->append_reduction(*initial);
-        for (ssize_t i = size; i > new_size; --i) state_ptr->pop_reduction();
-
-        state_ptr->prepare_diff([&](ssize_t index) {
-            assert(false);  // should never be called because our reduction space is empty
-            return this->reduce_(state, index);
-        });
-        return;
-    }
-
     // Alas, we're in the more complex case where we have several axis to reduce over
 
-    if (this->dynamic() and array_ptr_->size_diff(state) > 0 and initial) {
-        // Make sure we're including the initial values
-        const ssize_t size_diff = array_ptr_->size_diff(state);
-
+    if (this->dynamic() and size_diff > 0 and initial) {
         const auto subspace_shape = keep_axes(array_ptr_->shape(state), axes_);
         const ssize_t subspace_size = std::reduce(
             subspace_shape.begin(), subspace_shape.end(), 1, std::multiplies<ssize_t>()
@@ -1005,7 +1012,7 @@ void ReduceNode<BinaryOp>::propagate(State& state) const {
         }
     }
 
-    for (const Update& update : array_ptr_->diff(state)) {
+    for (const Update& update : diff) {
         ssize_t reduction_index = convert_predecessor_index_(update.index);
         assert(
             ravel_multi_index(
@@ -1023,9 +1030,7 @@ void ReduceNode<BinaryOp>::propagate(State& state) const {
         }
     }
 
-    if (this->dynamic() and array_ptr_->size_diff(state) < 0) {
-        const ssize_t size_diff = array_ptr_->size_diff(state);
-
+    if (this->dynamic() and size_diff < 0) {
         const auto subspace_shape = keep_axes(array_ptr_->shape(state), axes_);
         const ssize_t subspace_size = std::reduce(
             subspace_shape.begin(), subspace_shape.end(), 1, std::multiplies<ssize_t>()

--- a/dwave/optimization/src/nodes/set_routines.cpp
+++ b/dwave/optimization/src/nodes/set_routines.cpp
@@ -121,10 +121,10 @@ IsDisjointCoverNode::IsDisjointCoverNode(
         if (not node->integral()) {
             throw std::invalid_argument("Predecessors of DisjointCoverNode must be integral");
         }
-        if (not (node->max() < primary_set_size)) {
+        if (not(node->max() < primary_set_size)) {
             throw std::invalid_argument("Predecessor exceeds primary set size");
         }
-        if (not (node->min() >= 0)) {
+        if (not(node->min() >= 0)) {
             throw std::invalid_argument("Predecessor exceeds primary set size");
         }
         add_predecessor_(node);
@@ -338,9 +338,8 @@ void IsInNode::propagate(State& state) const {
     const std::span<const Update> test_elements_diff = test_elements_ptr_->diff(state);
     const std::span<const Update> element_diff = element_ptr_->diff(state);
 
-    if (test_elements_diff.empty() && element_diff.empty()) {
-        return;  // Nothing to do
-    }
+    // If no updates, return early.
+    if (test_elements_diff.empty() and element_diff.empty()) return;
 
     IsInNodeData* node_data = data_ptr_<IsInNodeData>(state);
 

--- a/dwave/optimization/src/nodes/softmax.cpp
+++ b/dwave/optimization/src/nodes/softmax.cpp
@@ -88,12 +88,13 @@ double SoftMaxNode::min() const { return 0.0; }
 double SoftMaxNode::max() const { return 1.0; }
 
 void SoftMaxNode::propagate(State& state) const {
-    // Store updates to predecessor in vector
-    std::vector<Update> arr_updates(arr_ptr_->diff(state).begin(), arr_ptr_->diff(state).end());
+    const auto diff = arr_ptr_->diff(state);
+    // If there are no updates, return early.
+    if (diff.empty()) return;
 
-    if (arr_updates.empty()) {
-        return;
-    }
+    // Store updates to predecessor in vector
+    std::vector<Update> arr_updates(diff.begin(), diff.end());
+    assert(not arr_updates.empty());
 
     // To update node, we need to compute the new softmax denominator
     auto node_data = data_ptr_<SoftMaxNodeStateData>(state);

--- a/dwave/optimization/src/nodes/sorting.cpp
+++ b/dwave/optimization/src/nodes/sorting.cpp
@@ -84,10 +84,11 @@ double ArgSortNode::min() const { return minmax_.first; }
 double ArgSortNode::max() const { return minmax_.second; }
 
 void ArgSortNode::propagate(State& state) const {
+    const auto pred_diff = arr_ptr_->diff(state);
+    // If there are no updates, return early.
+    if (pred_diff.empty()) return;
+
     auto node_data = data_ptr_<ArgSortNodeData>(state);
-
-    auto pred_diff = arr_ptr_->diff(state);
-
     // Save a copy of the predecessor's updates so we can use them in case we
     // need to revert the changes to the ordering
     node_data->predecessor_updates.assign(pred_diff.begin(), pred_diff.end());

--- a/dwave/optimization/src/nodes/unaryop.cpp
+++ b/dwave/optimization/src/nodes/unaryop.cpp
@@ -226,9 +226,13 @@ double UnaryOpNode<UnaryOp>::max() const {
 
 template <class UnaryOp>
 void UnaryOpNode<UnaryOp>::propagate(State& state) const {
+    const auto diff = array_ptr_->diff(state);
+    // If there are no updates the handle, return early.
+    if (diff.empty()) return;
+
     auto node_data = data_ptr_<ArrayNodeStateData>(state);
 
-    for (const auto& update : array_ptr_->diff(state)) {
+    for (const auto& update : diff) {
         const auto& [idx, _, value] = update;
 
         if (update.placed()) {


### PR DESCRIPTION
#### What does this implement/fix?
Add early `propagate()` exit to `Nodes`.

**Nodes untouched:**
- DisjointListsNode <- Decision,
- ConstantNode <- No propagate,
- InputNode <- No propagate,
- ReshapeNode <- Already implemented,
- TransposeNode <- Already implemented,
- BinaryNode <- Decision,
- IntegerNode <- Decision,
- IsDisjointCoverNode <- Already implemented,
- IsInNode <- Already implemented,
- MeanNode <- Already implemented,
- ArrayValidationNode <- Needed for testing
- AccumulateZipNode <- Did not even know where to start
- All LPNode related nodes <- Unsure if applicable to node 

**Affected nodes:**
- BinaryOpNode
- ARangeNode,
- ExtractNode,
- WhereNode,
- AdvancedIndexingNode,
- BasicIndexingNode,
- PermutationNode,
- BSplineNode,
- MatrixMultiplyNode <- simplified logic,
- BroadcastToNode,
- ConcatenateNode,
- CopyNode,
- PutNode,
- ResizeNode,
- RollNode,
- SizeNode,
- NaryOpNode <- minor modification to pointer look-up order,
- QuadraticModelNode <- Added predecessor pointer to avoid dynamic cast, 
- SoftMaxNode,
- ReduceNode,
- ArgSortNode,
- UnaryOpNode

#### AI Generation Disclosure
No AI tools used
