### PR TITLE
Replace `deduplicate_diff_view` with `views::deduplicate_diff`

### DIFF
--- a/dwave/optimization/include/dwave-optimization/array.hpp
+++ b/dwave/optimization/include/dwave-optimization/array.hpp
@@ -708,23 +708,25 @@ std::vector<ssize_t> broadcast_shapes(
     std::initializer_list<ssize_t> rhs
 );
 
+/// Sort and deduplicate the given vector of updates in-place.
 void deduplicate_diff(std::vector<Update>& diff);
 
-class deduplicate_diff_view {
- public:
+// dev note: this class isn't private per se, but it's really intended to be used via
+// views::deduplicate_diff
+struct deduplicate_diff_adaptor : std::ranges::range_adaptor_closure<deduplicate_diff_adaptor> {
     template <std::ranges::range R>
-    deduplicate_diff_view(R&& diff) : diff_(std::ranges::begin(diff), std::ranges::end(diff)) {
-        deduplicate_diff(diff_);
+    auto operator()(R&& diff) const {
+        // put them into a vector we can use
+        auto updates = std::ranges::to<std::vector<Update>>(std::forward<R>(diff));
+        deduplicate_diff(updates);
+        return updates;
     }
-
-    auto begin() const { return diff_.begin(); }
-    auto end() const { return diff_.end(); }
-
- private:
-    std::vector<Update> diff_;
 };
-// todo: In C++23 once we have std::ranges::range_adaptor_closure, we should
-// make this work with a range adaptor.
+
+namespace views {
+/// A range adaptor version of deduplicate_diff
+inline constexpr deduplicate_diff_adaptor deduplicate_diff{};
+}  // namespace views
 
 // Determine whether a given shape/strides define a contiguous array or not.
 bool is_contiguous(const ssize_t ndim, const ssize_t* shape, const ssize_t* strides);

--- a/dwave/optimization/src/nodes/binaryop.cpp
+++ b/dwave/optimization/src/nodes/binaryop.cpp
@@ -336,13 +336,10 @@ void BinaryOpNode<BinaryOp>::propagate(State& state) const {
         std::vector<Update> rhs_diff_copy;
         if (lhs_ptr->dynamic()) {
             assert(rhs_ptr->dynamic());
-            // Copy and then deduplicate both diffs
-            lhs_diff_copy.assign(lhs_diff.begin(), lhs_diff.end());
-            rhs_diff_copy.assign(rhs_diff.begin(), rhs_diff.end());
-            deduplicate_diff(lhs_diff_copy);
-            deduplicate_diff(rhs_diff_copy);
-            lhs_diff = std::span<const Update>(lhs_diff_copy.begin(), lhs_diff_copy.end());
-            rhs_diff = std::span<const Update>(rhs_diff_copy.begin(), rhs_diff_copy.end());
+            lhs_diff_copy = lhs_diff | views::deduplicate_diff;
+            rhs_diff_copy = rhs_diff | views::deduplicate_diff;
+            lhs_diff = std::span(lhs_diff_copy);
+            rhs_diff = std::span(rhs_diff_copy);
         }
 
         if (lhs_diff.size() && rhs_diff.size()) {

--- a/dwave/optimization/src/nodes/manipulation.cpp
+++ b/dwave/optimization/src/nodes/manipulation.cpp
@@ -257,7 +257,7 @@ void BroadcastToNode::propagate(State& state) const {
 
     ssize_t size_diff = 0;
     if (this->size() != 0) {
-        for (Update update : deduplicate_diff_view(from_diff)) {
+        for (Update update : from_diff | views::deduplicate_diff) {
             // we need to convert from our predecessor's index to ours
             const ssize_t index = convert_predecessor_index_(update.index);
             assert(
@@ -1401,13 +1401,7 @@ void RollNode::propagate(State& state) const {
             if (array_ptr_->dynamic()) {
                 // One last case we need to worry about. If the array may have grown and then
                 // shrunk, we need to deduplicate the diff.
-                // We'd really like to use some of the nice C++20 range stuff and
-                // deduplicate_diff_view(), but alas some of the old Python images
-                // don't support deduplicate_diff_view with std::ranges::transform.
-                // So we have to do it manually with a copy.
-                std::vector<Update> updates(diff.begin(), diff.end());
-                deduplicate_diff(updates);
-                state_ptr->update(updates | std::views::transform(transform));
+                state_ptr->update(diff | views::deduplicate_diff | std::views::transform(transform));
             } else {
                 // Otherwise we just propagate the diff like normal under the assumption
                 // that our predecessor was efficient (not always true but nice to believe).
@@ -1461,10 +1455,7 @@ void RollNode::propagate(State& state) const {
 
             // Unlike the flat shift case we always deduplicate because each shift
             // operation is relatively expensive.
-            // See note there about the use of deduplicate_diff
-            std::vector<Update> updates(diff.begin(), diff.end());
-            deduplicate_diff(updates);
-            state_ptr->update(updates | std::views::transform(transform));
+            state_ptr->update(diff | views::deduplicate_diff | std::views::transform(transform));
         } else {
             // Either our size or our shifts have changed, so we might as well re-calculate
             // the whole thing.

--- a/dwave/optimization/src/nodes/softmax.cpp
+++ b/dwave/optimization/src/nodes/softmax.cpp
@@ -93,15 +93,15 @@ void SoftMaxNode::propagate(State& state) const {
     if (diff.empty()) return;
 
     // Store updates to predecessor in vector
-    std::vector<Update> arr_updates(diff.begin(), diff.end());
+    // Deduplicate because we only want to compute an exponential once per index
+    std::vector<Update> arr_updates = diff | views::deduplicate_diff;
     assert(not arr_updates.empty());
 
     // To update node, we need to compute the new softmax denominator
     auto node_data = data_ptr_<SoftMaxNodeStateData>(state);
     const double prior_denominator = node_data->denominator;
     double new_denominator = prior_denominator;
-    // We only want to compute an exponential once per index
-    deduplicate_diff(arr_updates);
+
     // Record for which indices we need to recompute the exponential
     node_data->index_changed.resize(arr_ptr_->size(state), false);
 

--- a/releasenotes/notes/views-deduplicate_diff-3d8e78c17ae4a598.yaml
+++ b/releasenotes/notes/views-deduplicate_diff-3d8e78c17ae4a598.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - Add C++ ``views::deduplicate_diff`` range adaptor closure.
+upgrade:
+  - Remove C++ ``deduplicate_diff_view()`` class.

--- a/tests/cpp/test_array.cpp
+++ b/tests/cpp/test_array.cpp
@@ -531,11 +531,6 @@ TEST_CASE("Test broadcast_shapes()") {
 }
 
 TEST_CASE("Test deduplicate_diff") {
-    SECTION("static asserts") {
-        static_assert(std::ranges::sized_range<deduplicate_diff_view>);
-        static_assert(std::ranges::viewable_range<deduplicate_diff_view>);
-    }
-
     GIVEN("An empty vector of updates") {
         std::vector<Update> updates;
 
@@ -545,10 +540,10 @@ TEST_CASE("Test deduplicate_diff") {
         }
 
         THEN("Iteration over it with a view does nothing") {
-            for ([[maybe_unused]] const Update& v : deduplicate_diff_view(updates)) {
+            for ([[maybe_unused]] const Update& v : updates | views::deduplicate_diff) {
                 CHECK(false);  // shouldn't get here
             }
-            for ([[maybe_unused]] const Update& v : deduplicate_diff_view(std::span(updates))) {
+            for ([[maybe_unused]] const Update& v : std::span(updates) | views::deduplicate_diff) {
                 CHECK(false);  // shouldn't get here
             }
         }
@@ -564,7 +559,7 @@ TEST_CASE("Test deduplicate_diff") {
 
         THEN("We can use deduplicate_diff_view in a for-loop") {
             std::vector<Update> deduped;
-            for (const auto& u : deduplicate_diff_view(updates)) {
+            for (const auto& u : updates | views::deduplicate_diff) {
                 deduped.emplace_back(u);
             }
             CHECK_THAT(deduped, RangeEquals({Update(2, 1, 0), Update(3, 0, 1), Update(5, 0, -1)}));
@@ -578,7 +573,7 @@ TEST_CASE("Test deduplicate_diff") {
                 return update;
             };
 
-            for (const auto& u : deduplicate_diff_view(updates) | std::views::transform(shift)) {
+            for (const auto& u : updates | views::deduplicate_diff | std::views::transform(shift)) {
                 deduped_and_shifted.emplace_back(u);
             }
             CHECK_THAT(


### PR DESCRIPTION
Builds off of https://github.com/dwavesystems/dwave-optimization/pull/624 but requires a backwards compatibility break so making it a separate PR.

#### AI Generation Disclosure
Claude was helpful in helping to understand what the difference between a view and a range adaptor closure is.
